### PR TITLE
Add translucent block rendering (glass, water, ice)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -37,6 +37,7 @@ fn main() {
         ("chunk_border.frag", shaderc::ShaderKind::Fragment),
         ("item_entity.vert", shaderc::ShaderKind::Vertex),
         ("item_entity.frag", shaderc::ShaderKind::Fragment),
+        ("chunk_translucent.frag", shaderc::ShaderKind::Fragment),
     ];
 
     for (file, kind) in &shaders {

--- a/src/renderer/chunk/buffer.rs
+++ b/src/renderer/chunk/buffer.rs
@@ -10,6 +10,20 @@ use crate::renderer::MAX_FRAMES_IN_FLIGHT;
 use crate::renderer::shader;
 use crate::renderer::util;
 
+fn quad_center(vertices: &[ChunkVertex], indices: &[u32]) -> [f32; 3] {
+    let mut cx = 0.0f32;
+    let mut cy = 0.0f32;
+    let mut cz = 0.0f32;
+    let n = indices.len().min(3) as f32;
+    for &i in indices.iter().take(3) {
+        let p = &vertices[i as usize].position;
+        cx += p[0];
+        cy += p[1];
+        cz += p[2];
+    }
+    [cx / n, cy / n, cz / n]
+}
+
 const BUCKET_VERTICES: u32 = 32768;
 const BUCKET_INDICES: u32 = 49152;
 const VERTEX_SIZE: u64 = std::mem::size_of::<ChunkVertex>() as u64;
@@ -90,6 +104,11 @@ struct ChunkAlloc {
     uploaded_at: std::time::Instant,
 }
 
+struct TranslucentChunkData {
+    vertices: Vec<ChunkVertex>,
+    indices: Vec<u32>,
+}
+
 pub struct ChunkBufferStore {
     total_buckets: u32,
     vertex_buffer: vk::Buffer,
@@ -123,6 +142,16 @@ pub struct ChunkBufferStore {
     frustum_buffers: Vec<vk::Buffer>,
     frustum_allocs: Vec<Allocation>,
     fade_enabled: bool,
+
+    translucent_chunks: HashMap<ChunkPos, TranslucentChunkData>,
+    translucent_vertex_buffer: vk::Buffer,
+    translucent_vertex_alloc: Allocation,
+    translucent_index_buffer: vk::Buffer,
+    translucent_index_alloc: Allocation,
+    translucent_buf_capacity: u64,
+    translucent_index_count: u32,
+    translucent_dirty: bool,
+    last_translucent_sort_pos: [f32; 3],
 }
 
 impl ChunkBufferStore {
@@ -351,6 +380,22 @@ impl ChunkBufferStore {
             unsafe { device.update_descriptor_sets(&writes, &[]) };
         }
 
+        let translucent_buf_capacity = 1024 * 1024; // 1 MB initial
+        let (translucent_vertex_buffer, translucent_vertex_alloc) = util::create_host_buffer(
+            device,
+            allocator,
+            translucent_buf_capacity,
+            vk::BufferUsageFlags::VERTEX_BUFFER,
+            "translucent_vertex",
+        );
+        let (translucent_index_buffer, translucent_index_alloc) = util::create_host_buffer(
+            device,
+            allocator,
+            translucent_buf_capacity,
+            vk::BufferUsageFlags::INDEX_BUFFER,
+            "translucent_index",
+        );
+
         Self {
             total_buckets,
             vertex_buffer,
@@ -381,16 +426,62 @@ impl ChunkBufferStore {
             frustum_buffers,
             frustum_allocs,
             fade_enabled: false,
+            translucent_chunks: HashMap::new(),
+            translucent_vertex_buffer,
+            translucent_vertex_alloc,
+            translucent_index_buffer,
+            translucent_index_alloc,
+            translucent_buf_capacity,
+            translucent_index_count: 0,
+            translucent_dirty: false,
+            last_translucent_sort_pos: [0.0; 3],
         }
     }
 
+    fn translucent_needs_sort(&self, camera_pos: [f32; 3]) -> bool {
+        if self.translucent_chunks.is_empty() {
+            return false;
+        }
+        let dx = camera_pos[0] - self.last_translucent_sort_pos[0];
+        let dy = camera_pos[1] - self.last_translucent_sort_pos[1];
+        let dz = camera_pos[2] - self.last_translucent_sort_pos[2];
+        dx * dx + dy * dy + dz * dz > 1.0
+    }
+
     pub fn upload(&mut self, device: &ash::Device, queue: vk::Queue, mesh: &ChunkMeshData) {
-        if mesh.vertices.is_empty() || mesh.indices.is_empty() {
+        let has_opaque = !mesh.vertices.is_empty() && !mesh.indices.is_empty();
+        let has_translucent =
+            !mesh.translucent_vertices.is_empty() && !mesh.translucent_indices.is_empty();
+
+        if !has_opaque && !has_translucent {
             self.remove(&mesh.pos);
             return;
         }
 
-        self.remove(&mesh.pos);
+        if has_translucent {
+            self.translucent_chunks.insert(
+                mesh.pos,
+                TranslucentChunkData {
+                    vertices: mesh.translucent_vertices.clone(),
+                    indices: mesh.translucent_indices.clone(),
+                },
+            );
+            self.translucent_dirty = true;
+        } else if self.translucent_chunks.remove(&mesh.pos).is_some() {
+            self.translucent_dirty = true;
+        }
+
+        if !has_opaque {
+            if let Some(alloc) = self.chunks.remove(&mesh.pos) {
+                for bucket in alloc.buckets {
+                    self.free_buckets.push_back(bucket);
+                }
+                self.meta_dirty = true;
+            }
+            return;
+        }
+
+        self.remove_opaque(&mesh.pos);
 
         let num_buckets = mesh.vertices.len().div_ceil(BUCKET_VERTICES as usize) as u32;
         if self.free_buckets.len() < num_buckets as usize {
@@ -567,12 +658,19 @@ impl ChunkBufferStore {
         self.meta_dirty = true;
     }
 
-    pub fn remove(&mut self, pos: &ChunkPos) {
+    fn remove_opaque(&mut self, pos: &ChunkPos) {
         if let Some(alloc) = self.chunks.remove(pos) {
             for bucket in alloc.buckets {
                 self.free_buckets.push_back(bucket);
             }
             self.meta_dirty = true;
+        }
+    }
+
+    pub fn remove(&mut self, pos: &ChunkPos) {
+        self.remove_opaque(pos);
+        if self.translucent_chunks.remove(pos).is_some() {
+            self.translucent_dirty = true;
         }
     }
 
@@ -585,6 +683,10 @@ impl ChunkBufferStore {
         self.cached_meta.clear();
         self.meta_dirty = true;
         self.fade_enabled = false;
+        self.translucent_chunks.clear();
+        self.translucent_index_count = 0;
+        self.translucent_dirty = false;
+        self.last_translucent_sort_pos = [0.0; 3];
     }
 
     pub fn chunk_count(&self) -> u32 {
@@ -744,6 +846,147 @@ impl ChunkBufferStore {
         }
     }
 
+    pub fn rebuild_translucent(
+        &mut self,
+        device: &ash::Device,
+        allocator: &Arc<Mutex<Allocator>>,
+        camera_pos: [f32; 3],
+    ) {
+        if !self.translucent_dirty && !self.translucent_needs_sort(camera_pos) {
+            return;
+        }
+        self.translucent_dirty = false;
+        self.last_translucent_sort_pos = camera_pos;
+
+        if self.translucent_chunks.is_empty() {
+            self.translucent_index_count = 0;
+            return;
+        }
+
+        let total_verts: usize = self
+            .translucent_chunks
+            .values()
+            .map(|c| c.vertices.len())
+            .sum();
+        let total_idxs: usize = self
+            .translucent_chunks
+            .values()
+            .map(|c| c.indices.len())
+            .sum();
+
+        if total_verts == 0 || total_idxs == 0 {
+            self.translucent_index_count = 0;
+            return;
+        }
+
+        let needed_v = (total_verts as u64) * VERTEX_SIZE;
+        let needed_i = (total_idxs as u64) * INDEX_SIZE;
+        let needed = needed_v.max(needed_i);
+
+        if needed > self.translucent_buf_capacity {
+            let new_cap = (needed * 2).max(self.translucent_buf_capacity * 2);
+            let mut alloc = allocator.lock().unwrap();
+            unsafe { device.destroy_buffer(self.translucent_vertex_buffer, None) };
+            alloc
+                .free(std::mem::replace(
+                    &mut self.translucent_vertex_alloc,
+                    unsafe { std::mem::zeroed() },
+                ))
+                .ok();
+            unsafe { device.destroy_buffer(self.translucent_index_buffer, None) };
+            alloc
+                .free(std::mem::replace(
+                    &mut self.translucent_index_alloc,
+                    unsafe { std::mem::zeroed() },
+                ))
+                .ok();
+            drop(alloc);
+
+            let (vb, va) = util::create_host_buffer(
+                device,
+                allocator,
+                new_cap,
+                vk::BufferUsageFlags::VERTEX_BUFFER,
+                "translucent_vertex",
+            );
+            let (ib, ia) = util::create_host_buffer(
+                device,
+                allocator,
+                new_cap,
+                vk::BufferUsageFlags::INDEX_BUFFER,
+                "translucent_index",
+            );
+            self.translucent_vertex_buffer = vb;
+            self.translucent_vertex_alloc = va;
+            self.translucent_index_buffer = ib;
+            self.translucent_index_alloc = ia;
+            self.translucent_buf_capacity = new_cap;
+        }
+
+        let mut sorted_keys: Vec<ChunkPos> = self.translucent_chunks.keys().copied().collect();
+        sorted_keys.sort_by(|a, b| {
+            let da = (a.x as f32 * 16.0 + 8.0 - camera_pos[0]).powi(2)
+                + (a.z as f32 * 16.0 + 8.0 - camera_pos[2]).powi(2);
+            let db = (b.x as f32 * 16.0 + 8.0 - camera_pos[0]).powi(2)
+                + (b.z as f32 * 16.0 + 8.0 - camera_pos[2]).powi(2);
+            db.partial_cmp(&da).unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        let v_slice = self.translucent_vertex_alloc.mapped_slice_mut().unwrap();
+        let mut v_offset = 0usize;
+        let mut combined_indices: Vec<u32> = Vec::with_capacity(total_idxs);
+        let mut vertex_base = 0u32;
+
+        for pos in &sorted_keys {
+            let chunk_data = &self.translucent_chunks[pos];
+            let verts_bytes = bytemuck::cast_slice(&chunk_data.vertices);
+            v_slice[v_offset..v_offset + verts_bytes.len()].copy_from_slice(verts_bytes);
+            v_offset += verts_bytes.len();
+
+            let mut quads: Vec<(f32, [u32; 6])> = Vec::new();
+            for quad_indices in chunk_data.indices.chunks_exact(6) {
+                let center = quad_center(&chunk_data.vertices, quad_indices);
+                let dist = (center[0] - camera_pos[0]).powi(2)
+                    + (center[1] - camera_pos[1]).powi(2)
+                    + (center[2] - camera_pos[2]).powi(2);
+                let mut qi = [0u32; 6];
+                qi.copy_from_slice(quad_indices);
+                quads.push((dist, qi));
+            }
+            quads.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+            for (_, qi) in &quads {
+                for &idx in qi {
+                    combined_indices.push(idx + vertex_base);
+                }
+            }
+            vertex_base += chunk_data.vertices.len() as u32;
+        }
+
+        let i_slice = self.translucent_index_alloc.mapped_slice_mut().unwrap();
+        let idx_bytes = bytemuck::cast_slice(&combined_indices);
+        i_slice[..idx_bytes.len()].copy_from_slice(idx_bytes);
+
+        self.translucent_index_count = combined_indices.len() as u32;
+    }
+
+    pub fn draw_translucent(&self, device: &ash::Device, cmd: vk::CommandBuffer) {
+        if self.translucent_index_count == 0 {
+            return;
+        }
+
+        unsafe {
+            device.cmd_bind_vertex_buffers(cmd, 0, &[self.translucent_vertex_buffer], &[0]);
+            device.cmd_bind_index_buffer(
+                cmd,
+                self.translucent_index_buffer,
+                0,
+                vk::IndexType::UINT32,
+            );
+            device.cmd_draw_indexed(cmd, self.translucent_index_count, 1, 0, 0, 0);
+        }
+    }
+
     pub fn destroy(&mut self, device: &ash::Device, allocator: &Arc<Mutex<Allocator>>) {
         let mut alloc = allocator.lock().unwrap();
         unsafe {
@@ -795,6 +1038,22 @@ impl ChunkBufferStore {
                 std::mem::zeroed()
             }))
             .ok();
+
+        unsafe { device.destroy_buffer(self.translucent_vertex_buffer, None) };
+        alloc
+            .free(std::mem::replace(
+                &mut self.translucent_vertex_alloc,
+                unsafe { std::mem::zeroed() },
+            ))
+            .ok();
+        unsafe { device.destroy_buffer(self.translucent_index_buffer, None) };
+        alloc
+            .free(std::mem::replace(
+                &mut self.translucent_index_alloc,
+                unsafe { std::mem::zeroed() },
+            ))
+            .ok();
+
         drop(alloc);
 
         unsafe {

--- a/src/renderer/chunk/mesher.rs
+++ b/src/renderer/chunk/mesher.rs
@@ -835,8 +835,7 @@ fn mesh_chunk_snapshot(
 
                 if lod > 0 {
                     emit_lod_cube(
-                        verts, idxs, block_pos, state, snapshot, registry, uv_map, bx, by, bz,
-                        step,
+                        verts, idxs, block_pos, state, snapshot, registry, uv_map, bx, by, bz, step,
                     );
                 } else if let BlockKind::Water | BlockKind::Lava = kind {
                     let fluid = if matches!(kind, BlockKind::Lava) {
@@ -1013,46 +1012,49 @@ enum BlockKind {
     Solid,
 }
 
-const TRANSLUCENT_BLOCKS: &[&str] = &[
-    "glass",
-    "glass_pane",
-    "white_stained_glass",
-    "orange_stained_glass",
-    "magenta_stained_glass",
-    "light_blue_stained_glass",
-    "yellow_stained_glass",
-    "lime_stained_glass",
-    "pink_stained_glass",
-    "gray_stained_glass",
-    "light_gray_stained_glass",
-    "cyan_stained_glass",
-    "purple_stained_glass",
-    "blue_stained_glass",
-    "brown_stained_glass",
-    "green_stained_glass",
-    "red_stained_glass",
-    "black_stained_glass",
-    "white_stained_glass_pane",
-    "orange_stained_glass_pane",
-    "magenta_stained_glass_pane",
-    "light_blue_stained_glass_pane",
-    "yellow_stained_glass_pane",
-    "lime_stained_glass_pane",
-    "pink_stained_glass_pane",
-    "gray_stained_glass_pane",
-    "light_gray_stained_glass_pane",
-    "cyan_stained_glass_pane",
-    "purple_stained_glass_pane",
-    "blue_stained_glass_pane",
-    "brown_stained_glass_pane",
-    "green_stained_glass_pane",
-    "red_stained_glass_pane",
-    "black_stained_glass_pane",
-    "ice",
-    "slime_block",
-    "honey_block",
-    "tinted_glass",
-];
+fn is_translucent_block(id: &str) -> bool {
+    matches!(
+        id,
+        "glass"
+            | "glass_pane"
+            | "white_stained_glass"
+            | "orange_stained_glass"
+            | "magenta_stained_glass"
+            | "light_blue_stained_glass"
+            | "yellow_stained_glass"
+            | "lime_stained_glass"
+            | "pink_stained_glass"
+            | "gray_stained_glass"
+            | "light_gray_stained_glass"
+            | "cyan_stained_glass"
+            | "purple_stained_glass"
+            | "blue_stained_glass"
+            | "brown_stained_glass"
+            | "green_stained_glass"
+            | "red_stained_glass"
+            | "black_stained_glass"
+            | "white_stained_glass_pane"
+            | "orange_stained_glass_pane"
+            | "magenta_stained_glass_pane"
+            | "light_blue_stained_glass_pane"
+            | "yellow_stained_glass_pane"
+            | "lime_stained_glass_pane"
+            | "pink_stained_glass_pane"
+            | "gray_stained_glass_pane"
+            | "light_gray_stained_glass_pane"
+            | "cyan_stained_glass_pane"
+            | "purple_stained_glass_pane"
+            | "blue_stained_glass_pane"
+            | "brown_stained_glass_pane"
+            | "green_stained_glass_pane"
+            | "red_stained_glass_pane"
+            | "black_stained_glass_pane"
+            | "ice"
+            | "slime_block"
+            | "honey_block"
+            | "tinted_glass"
+    )
+}
 
 fn classify_block(state: azalea_block::BlockState) -> BlockKind {
     if state.is_air() {
@@ -1066,7 +1068,7 @@ fn classify_block(state: azalea_block::BlockState) -> BlockKind {
         }
         "water" | "bubble_column" => BlockKind::Water,
         "lava" => BlockKind::Lava,
-        _ if TRANSLUCENT_BLOCKS.contains(&id) => BlockKind::Translucent,
+        _ if is_translucent_block(id) => BlockKind::Translucent,
         _ => BlockKind::Solid,
     }
 }

--- a/src/renderer/chunk/mesher.rs
+++ b/src/renderer/chunk/mesher.rs
@@ -1050,20 +1050,64 @@ enum BlockKind {
     Air,
     Water,
     Lava,
+    Translucent,
     Solid,
 }
+
+const TRANSLUCENT_BLOCKS: &[&str] = &[
+    "glass",
+    "glass_pane",
+    "white_stained_glass",
+    "orange_stained_glass",
+    "magenta_stained_glass",
+    "light_blue_stained_glass",
+    "yellow_stained_glass",
+    "lime_stained_glass",
+    "pink_stained_glass",
+    "gray_stained_glass",
+    "light_gray_stained_glass",
+    "cyan_stained_glass",
+    "purple_stained_glass",
+    "blue_stained_glass",
+    "brown_stained_glass",
+    "green_stained_glass",
+    "red_stained_glass",
+    "black_stained_glass",
+    "white_stained_glass_pane",
+    "orange_stained_glass_pane",
+    "magenta_stained_glass_pane",
+    "light_blue_stained_glass_pane",
+    "yellow_stained_glass_pane",
+    "lime_stained_glass_pane",
+    "pink_stained_glass_pane",
+    "gray_stained_glass_pane",
+    "light_gray_stained_glass_pane",
+    "cyan_stained_glass_pane",
+    "purple_stained_glass_pane",
+    "blue_stained_glass_pane",
+    "brown_stained_glass_pane",
+    "green_stained_glass_pane",
+    "red_stained_glass_pane",
+    "black_stained_glass_pane",
+    "ice",
+    "slime_block",
+    "honey_block",
+    "tinted_glass",
+];
 
 fn classify_block(state: azalea_block::BlockState) -> BlockKind {
     if state.is_air() {
         return BlockKind::Air;
     }
     let block: Box<dyn azalea_block::BlockTrait> = state.into();
-    match block.id() {
+    let id = block.id();
+    match id {
         "cave_air" | "void_air" | "light" | "barrier" | "structure_void" | "moving_piston" => {
             BlockKind::Air
         }
         "water" | "bubble_column" => BlockKind::Water,
         "lava" => BlockKind::Lava,
+        _ if TRANSLUCENT_BLOCKS.contains(&id) => BlockKind::Translucent,
         _ => BlockKind::Solid,
     }
 }

--- a/src/renderer/chunk/mesher.rs
+++ b/src/renderer/chunk/mesher.rs
@@ -85,6 +85,8 @@ pub struct ChunkMeshData {
     pub pos: ChunkPos,
     pub vertices: Vec<ChunkVertex>,
     pub indices: Vec<u32>,
+    pub translucent_vertices: Vec<ChunkVertex>,
+    pub translucent_indices: Vec<u32>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -762,6 +764,8 @@ fn mesh_chunk_snapshot(
 ) -> ChunkMeshData {
     let mut vertices = Vec::new();
     let mut indices = Vec::new();
+    let mut translucent_vertices = Vec::new();
+    let mut translucent_indices = Vec::new();
     let mut logged_missing: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     let step = 1i32 << lod;
@@ -822,18 +826,16 @@ fn mesh_chunk_snapshot(
 
                 let block_pos = [bx as f32, by as f32, bz as f32];
 
+                let is_translucent = matches!(kind, BlockKind::Translucent | BlockKind::Water);
+                let (verts, idxs) = if is_translucent {
+                    (&mut translucent_vertices, &mut translucent_indices)
+                } else {
+                    (&mut vertices, &mut indices)
+                };
+
                 if lod > 0 {
                     emit_lod_cube(
-                        &mut vertices,
-                        &mut indices,
-                        block_pos,
-                        state,
-                        snapshot,
-                        registry,
-                        uv_map,
-                        bx,
-                        by,
-                        bz,
+                        verts, idxs, block_pos, state, snapshot, registry, uv_map, bx, by, bz,
                         step,
                     );
                 } else if let BlockKind::Water | BlockKind::Lava = kind {
@@ -843,55 +845,19 @@ fn mesh_chunk_snapshot(
                         "water"
                     };
                     emit_fluid(
-                        &mut vertices,
-                        &mut indices,
-                        block_pos,
-                        fluid,
-                        snapshot,
-                        registry,
-                        uv_map,
-                        bx,
-                        by,
-                        bz,
+                        verts, idxs, block_pos, fluid, snapshot, registry, uv_map, bx, by, bz,
                     );
                 } else if let Some(baked) = registry.get_baked_model(state) {
                     emit_baked_model(
-                        &mut vertices,
-                        &mut indices,
-                        block_pos,
-                        baked,
-                        snapshot,
-                        registry,
-                        uv_map,
-                        bx,
-                        by,
-                        bz,
+                        verts, idxs, block_pos, baked, snapshot, registry, uv_map, bx, by, bz,
                     );
                 } else if let Some(quads) = registry.get_multipart_quads(state) {
                     emit_multipart(
-                        &mut vertices,
-                        &mut indices,
-                        block_pos,
-                        &quads,
-                        snapshot,
-                        registry,
-                        uv_map,
-                        bx,
-                        by,
-                        bz,
+                        verts, idxs, block_pos, &quads, snapshot, registry, uv_map, bx, by, bz,
                     );
                 } else if let Some(textures) = registry.get_textures(state) {
                     emit_cube_faces(
-                        &mut vertices,
-                        &mut indices,
-                        block_pos,
-                        textures,
-                        snapshot,
-                        registry,
-                        uv_map,
-                        bx,
-                        by,
-                        bz,
+                        verts, idxs, block_pos, textures, snapshot, registry, uv_map, bx, by, bz,
                     );
                 } else {
                     let block: Box<dyn azalea_block::BlockTrait> = state.into();
@@ -899,16 +865,7 @@ fn mesh_chunk_snapshot(
                     if logged_missing.insert(id.clone()) {
                         tracing::warn!("Missing model: {id}");
                     }
-                    emit_missing_cube(
-                        &mut vertices,
-                        &mut indices,
-                        block_pos,
-                        snapshot,
-                        registry,
-                        bx,
-                        by,
-                        bz,
-                    );
+                    emit_missing_cube(verts, idxs, block_pos, snapshot, registry, bx, by, bz);
                 }
                 by += step;
             }
@@ -921,6 +878,8 @@ fn mesh_chunk_snapshot(
         pos,
         vertices,
         indices,
+        translucent_vertices,
+        translucent_indices,
     }
 }
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -947,12 +947,17 @@ impl Renderer {
             self.ctx.device.begin_command_buffer(cmd, &begin_info)?;
 
             if matches!(&mode, RenderMode::World { .. }) {
-                let frustum = self.camera.frustum_planes();
                 let cam_pos = [
                     self.camera.position.x,
                     self.camera.position.y,
                     self.camera.position.z,
                 ];
+                self.chunk_buffers.rebuild_translucent(
+                    &self.ctx.device,
+                    &self.ctx.allocator,
+                    cam_pos,
+                );
+                let frustum = self.camera.frustum_planes();
                 self.chunk_buffers
                     .dispatch_cull(&self.ctx.device, cmd, frame, &frustum, cam_pos);
             }
@@ -1060,6 +1065,10 @@ impl Renderer {
 
                     self.item_entity_pipeline
                         .draw(&self.ctx.device, cmd, frame, item_entities);
+
+                    self.chunk_pipeline
+                        .bind_translucent(&self.ctx.device, cmd, frame);
+                    self.chunk_buffers.draw_translucent(&self.ctx.device, cmd);
 
                     if *show_chunk_borders {
                         self.chunk_border_pipeline

--- a/src/renderer/pipelines/chunk.rs
+++ b/src/renderer/pipelines/chunk.rs
@@ -207,14 +207,15 @@ impl ChunkPipeline {
     }
 }
 
-fn create_pipeline(
+fn create_chunk_pipeline(
     device: &ash::Device,
     render_pass: vk::RenderPass,
     layout: vk::PipelineLayout,
+    frag_spv: &[u8],
+    depth_write: bool,
+    blend: bool,
 ) -> vk::Pipeline {
     let vert_spv = shader::include_spirv!("chunk.vert.spv");
-    let frag_spv = shader::include_spirv!("chunk.frag.spv");
-
     let vert_module = shader::create_shader_module(device, vert_spv);
     let frag_module = shader::create_shader_module(device, frag_spv);
 
@@ -255,13 +256,26 @@ fn create_pipeline(
 
     let depth_stencil = vk::PipelineDepthStencilStateCreateInfo::default()
         .depth_test_enable(true)
-        .depth_write_enable(true)
+        .depth_write_enable(depth_write)
         .depth_compare_op(vk::CompareOp::LESS_OR_EQUAL);
 
-    let blend_attachment = [vk::PipelineColorBlendAttachmentState {
-        blend_enable: vk::FALSE,
-        color_write_mask: vk::ColorComponentFlags::RGBA,
-        ..Default::default()
+    let blend_attachment = [if blend {
+        vk::PipelineColorBlendAttachmentState {
+            blend_enable: vk::TRUE,
+            src_color_blend_factor: vk::BlendFactor::SRC_ALPHA,
+            dst_color_blend_factor: vk::BlendFactor::ONE_MINUS_SRC_ALPHA,
+            color_blend_op: vk::BlendOp::ADD,
+            src_alpha_blend_factor: vk::BlendFactor::ONE,
+            dst_alpha_blend_factor: vk::BlendFactor::ONE_MINUS_SRC_ALPHA,
+            alpha_blend_op: vk::BlendOp::ADD,
+            color_write_mask: vk::ColorComponentFlags::RGBA,
+        }
+    } else {
+        vk::PipelineColorBlendAttachmentState {
+            blend_enable: vk::FALSE,
+            color_write_mask: vk::ColorComponentFlags::RGBA,
+            ..Default::default()
+        }
     }];
     let color_blending =
         vk::PipelineColorBlendStateCreateInfo::default().attachments(&blend_attachment);
@@ -297,97 +311,32 @@ fn create_pipeline(
     pipeline
 }
 
+fn create_pipeline(
+    device: &ash::Device,
+    render_pass: vk::RenderPass,
+    layout: vk::PipelineLayout,
+) -> vk::Pipeline {
+    create_chunk_pipeline(
+        device,
+        render_pass,
+        layout,
+        shader::include_spirv!("chunk.frag.spv"),
+        true,
+        false,
+    )
+}
+
 fn create_translucent_pipeline(
     device: &ash::Device,
     render_pass: vk::RenderPass,
     layout: vk::PipelineLayout,
 ) -> vk::Pipeline {
-    let vert_spv = shader::include_spirv!("chunk.vert.spv");
-    let frag_spv = shader::include_spirv!("chunk_translucent.frag.spv");
-
-    let vert_module = shader::create_shader_module(device, vert_spv);
-    let frag_module = shader::create_shader_module(device, frag_spv);
-
-    let stages = [
-        vk::PipelineShaderStageCreateInfo::default()
-            .stage(vk::ShaderStageFlags::VERTEX)
-            .module(vert_module)
-            .name(c"main"),
-        vk::PipelineShaderStageCreateInfo::default()
-            .stage(vk::ShaderStageFlags::FRAGMENT)
-            .module(frag_module)
-            .name(c"main"),
-    ];
-
-    use crate::renderer::chunk::mesher::ChunkVertex;
-    let binding_descs = [ChunkVertex::binding_description()];
-    let attr_descs = ChunkVertex::attribute_descriptions();
-
-    let vertex_input = vk::PipelineVertexInputStateCreateInfo::default()
-        .vertex_binding_descriptions(&binding_descs)
-        .vertex_attribute_descriptions(&attr_descs);
-
-    let input_assembly = vk::PipelineInputAssemblyStateCreateInfo::default()
-        .topology(vk::PrimitiveTopology::TRIANGLE_LIST);
-
-    let viewport_state = vk::PipelineViewportStateCreateInfo::default()
-        .viewport_count(1)
-        .scissor_count(1);
-
-    let rasterizer = vk::PipelineRasterizationStateCreateInfo::default()
-        .polygon_mode(vk::PolygonMode::FILL)
-        .cull_mode(vk::CullModeFlags::BACK)
-        .front_face(vk::FrontFace::COUNTER_CLOCKWISE)
-        .line_width(1.0);
-
-    let multisampling = vk::PipelineMultisampleStateCreateInfo::default()
-        .rasterization_samples(vk::SampleCountFlags::TYPE_1);
-
-    let depth_stencil = vk::PipelineDepthStencilStateCreateInfo::default()
-        .depth_test_enable(true)
-        .depth_write_enable(false)
-        .depth_compare_op(vk::CompareOp::LESS_OR_EQUAL);
-
-    let blend_attachment = [vk::PipelineColorBlendAttachmentState {
-        blend_enable: vk::TRUE,
-        src_color_blend_factor: vk::BlendFactor::SRC_ALPHA,
-        dst_color_blend_factor: vk::BlendFactor::ONE_MINUS_SRC_ALPHA,
-        color_blend_op: vk::BlendOp::ADD,
-        src_alpha_blend_factor: vk::BlendFactor::ONE,
-        dst_alpha_blend_factor: vk::BlendFactor::ONE_MINUS_SRC_ALPHA,
-        alpha_blend_op: vk::BlendOp::ADD,
-        color_write_mask: vk::ColorComponentFlags::RGBA,
-    }];
-    let color_blending =
-        vk::PipelineColorBlendStateCreateInfo::default().attachments(&blend_attachment);
-
-    let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
-    let dynamic_state =
-        vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
-
-    let pipeline_info = [vk::GraphicsPipelineCreateInfo::default()
-        .stages(&stages)
-        .vertex_input_state(&vertex_input)
-        .input_assembly_state(&input_assembly)
-        .viewport_state(&viewport_state)
-        .rasterization_state(&rasterizer)
-        .multisample_state(&multisampling)
-        .depth_stencil_state(&depth_stencil)
-        .color_blend_state(&color_blending)
-        .dynamic_state(&dynamic_state)
-        .layout(layout)
-        .render_pass(render_pass)
-        .subpass(0)];
-
-    let pipeline = unsafe {
-        device.create_graphics_pipelines(vk::PipelineCache::null(), &pipeline_info, None)
-    }
-    .expect("failed to create translucent chunk pipeline")[0];
-
-    unsafe {
-        device.destroy_shader_module(vert_module, None);
-        device.destroy_shader_module(frag_module, None);
-    }
-
-    pipeline
+    create_chunk_pipeline(
+        device,
+        render_pass,
+        layout,
+        shader::include_spirv!("chunk_translucent.frag.spv"),
+        false,
+        true,
+    )
 }

--- a/src/renderer/pipelines/chunk.rs
+++ b/src/renderer/pipelines/chunk.rs
@@ -11,6 +11,7 @@ use crate::renderer::util;
 
 pub struct ChunkPipeline {
     pub pipeline: vk::Pipeline,
+    pub translucent_pipeline: vk::Pipeline,
     pub pipeline_layout: vk::PipelineLayout,
     pub descriptor_set_layout_camera: vk::DescriptorSetLayout,
     pub descriptor_set_layout_atlas: vk::DescriptorSetLayout,
@@ -45,6 +46,8 @@ impl ChunkPipeline {
             .expect("failed to create pipeline layout");
 
         let pipeline = create_pipeline(device, render_pass, pipeline_layout);
+        let translucent_pipeline =
+            create_translucent_pipeline(device, render_pass, pipeline_layout);
 
         let pool_sizes = [
             vk::DescriptorPoolSize {
@@ -117,6 +120,7 @@ impl ChunkPipeline {
 
         Self {
             pipeline,
+            translucent_pipeline,
             pipeline_layout,
             descriptor_set_layout_camera: camera_layout,
             descriptor_set_layout_atlas: atlas_layout,
@@ -162,6 +166,24 @@ impl ChunkPipeline {
         }
     }
 
+    pub fn bind_translucent(&self, device: &ash::Device, cmd: vk::CommandBuffer, frame: usize) {
+        unsafe {
+            device.cmd_bind_pipeline(
+                cmd,
+                vk::PipelineBindPoint::GRAPHICS,
+                self.translucent_pipeline,
+            );
+            device.cmd_bind_descriptor_sets(
+                cmd,
+                vk::PipelineBindPoint::GRAPHICS,
+                self.pipeline_layout,
+                0,
+                &[self.camera_sets[frame], self.atlas_set],
+                &[],
+            );
+        }
+    }
+
     pub fn destroy(&mut self, device: &ash::Device, allocator: &Arc<Mutex<Allocator>>) {
         let mut alloc = allocator.lock().unwrap();
         for i in 0..MAX_FRAMES_IN_FLIGHT {
@@ -176,6 +198,7 @@ impl ChunkPipeline {
 
         unsafe {
             device.destroy_pipeline(self.pipeline, None);
+            device.destroy_pipeline(self.translucent_pipeline, None);
             device.destroy_pipeline_layout(self.pipeline_layout, None);
             device.destroy_descriptor_pool(self.descriptor_pool, None);
             device.destroy_descriptor_set_layout(self.descriptor_set_layout_camera, None);
@@ -265,6 +288,101 @@ fn create_pipeline(
         device.create_graphics_pipelines(vk::PipelineCache::null(), &pipeline_info, None)
     }
     .expect("failed to create chunk pipeline")[0];
+
+    unsafe {
+        device.destroy_shader_module(vert_module, None);
+        device.destroy_shader_module(frag_module, None);
+    }
+
+    pipeline
+}
+
+fn create_translucent_pipeline(
+    device: &ash::Device,
+    render_pass: vk::RenderPass,
+    layout: vk::PipelineLayout,
+) -> vk::Pipeline {
+    let vert_spv = shader::include_spirv!("chunk.vert.spv");
+    let frag_spv = shader::include_spirv!("chunk_translucent.frag.spv");
+
+    let vert_module = shader::create_shader_module(device, vert_spv);
+    let frag_module = shader::create_shader_module(device, frag_spv);
+
+    let stages = [
+        vk::PipelineShaderStageCreateInfo::default()
+            .stage(vk::ShaderStageFlags::VERTEX)
+            .module(vert_module)
+            .name(c"main"),
+        vk::PipelineShaderStageCreateInfo::default()
+            .stage(vk::ShaderStageFlags::FRAGMENT)
+            .module(frag_module)
+            .name(c"main"),
+    ];
+
+    use crate::renderer::chunk::mesher::ChunkVertex;
+    let binding_descs = [ChunkVertex::binding_description()];
+    let attr_descs = ChunkVertex::attribute_descriptions();
+
+    let vertex_input = vk::PipelineVertexInputStateCreateInfo::default()
+        .vertex_binding_descriptions(&binding_descs)
+        .vertex_attribute_descriptions(&attr_descs);
+
+    let input_assembly = vk::PipelineInputAssemblyStateCreateInfo::default()
+        .topology(vk::PrimitiveTopology::TRIANGLE_LIST);
+
+    let viewport_state = vk::PipelineViewportStateCreateInfo::default()
+        .viewport_count(1)
+        .scissor_count(1);
+
+    let rasterizer = vk::PipelineRasterizationStateCreateInfo::default()
+        .polygon_mode(vk::PolygonMode::FILL)
+        .cull_mode(vk::CullModeFlags::BACK)
+        .front_face(vk::FrontFace::COUNTER_CLOCKWISE)
+        .line_width(1.0);
+
+    let multisampling = vk::PipelineMultisampleStateCreateInfo::default()
+        .rasterization_samples(vk::SampleCountFlags::TYPE_1);
+
+    let depth_stencil = vk::PipelineDepthStencilStateCreateInfo::default()
+        .depth_test_enable(true)
+        .depth_write_enable(false)
+        .depth_compare_op(vk::CompareOp::LESS_OR_EQUAL);
+
+    let blend_attachment = [vk::PipelineColorBlendAttachmentState {
+        blend_enable: vk::TRUE,
+        src_color_blend_factor: vk::BlendFactor::SRC_ALPHA,
+        dst_color_blend_factor: vk::BlendFactor::ONE_MINUS_SRC_ALPHA,
+        color_blend_op: vk::BlendOp::ADD,
+        src_alpha_blend_factor: vk::BlendFactor::ONE,
+        dst_alpha_blend_factor: vk::BlendFactor::ONE_MINUS_SRC_ALPHA,
+        alpha_blend_op: vk::BlendOp::ADD,
+        color_write_mask: vk::ColorComponentFlags::RGBA,
+    }];
+    let color_blending =
+        vk::PipelineColorBlendStateCreateInfo::default().attachments(&blend_attachment);
+
+    let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
+    let dynamic_state =
+        vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
+
+    let pipeline_info = [vk::GraphicsPipelineCreateInfo::default()
+        .stages(&stages)
+        .vertex_input_state(&vertex_input)
+        .input_assembly_state(&input_assembly)
+        .viewport_state(&viewport_state)
+        .rasterization_state(&rasterizer)
+        .multisample_state(&multisampling)
+        .depth_stencil_state(&depth_stencil)
+        .color_blend_state(&color_blending)
+        .dynamic_state(&dynamic_state)
+        .layout(layout)
+        .render_pass(render_pass)
+        .subpass(0)];
+
+    let pipeline = unsafe {
+        device.create_graphics_pipelines(vk::PipelineCache::null(), &pipeline_info, None)
+    }
+    .expect("failed to create translucent chunk pipeline")[0];
 
     unsafe {
         device.destroy_shader_module(vert_module, None);

--- a/src/renderer/shaders/chunk_translucent.frag
+++ b/src/renderer/shaders/chunk_translucent.frag
@@ -1,0 +1,25 @@
+#version 450
+
+layout(set = 1, binding = 0) uniform sampler2D atlas_texture;
+
+layout(location = 0) in vec2 v_tex_coords;
+layout(location = 1) in float v_light;
+layout(location = 2) in vec3 v_tint;
+layout(location = 3) flat in float v_visibility;
+layout(location = 4) in vec3 v_fog_color;
+
+layout(location = 0) out vec4 out_color;
+
+void main() {
+    vec4 color = texture(atlas_texture, v_tex_coords);
+    if (color.a < 0.01) discard;
+    vec3 linear_tint = pow(v_tint, vec3(2.2));
+    float linear_light = pow(v_light, 2.2);
+    vec3 tinted = color.rgb * linear_tint * linear_light;
+
+    if (v_visibility < 1.0) {
+        tinted = mix(v_fog_color, tinted, v_visibility);
+    }
+
+    out_color = vec4(tinted, color.a);
+}

--- a/src/world/block/model.rs
+++ b/src/world/block/model.rs
@@ -66,10 +66,34 @@ struct ModelRef {
 #[derive(Deserialize, Default, Clone)]
 struct ModelFile {
     parent: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_texture_map")]
     textures: HashMap<String, String>,
     #[serde(default)]
     elements: Vec<ElementDef>,
+}
+
+fn deserialize_texture_map<'de, D>(deserializer: D) -> Result<HashMap<String, String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Deserialize;
+    let raw: HashMap<String, serde_json::Value> = HashMap::deserialize(deserializer)?;
+    let mut result = HashMap::new();
+    for (key, value) in raw {
+        let tex = match &value {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Object(obj) => obj
+                .get("sprite")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            _ => continue,
+        };
+        if !tex.is_empty() {
+            result.insert(key, tex);
+        }
+    }
+    Ok(result)
 }
 
 #[derive(Deserialize, Clone)]


### PR DESCRIPTION
## Summary
- Parse 26.1.1 texture format and classify translucent blocks (glass, stained glass, water, ice)
- Add separate translucent rendering pass with its own pipeline and fragment shader
- Extend chunk buffer/mesher to handle translucent geometry alongside opaque

## Test plan
- [ ] Glass and stained glass render with transparency
- [ ] Water and ice render correctly
- [ ] Opaque blocks unaffected
- [ ] No perf regression on chunk meshing