### PR TITLE
docs: add NixOS/Nix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ pnpm install
 just launcher-build --release
 ```
 
+### NixOS / Nix
+Pomme is packaged in [nixpkgs](https://github.com/NixOS/nixpkgs) (Maintained by [DerGrumpf](github.com/DerGrumpf)) as `pomme-client` and `pomme-launcher`.
+
+Try it without installing:
+```bash
+nix run nixpkgs#pomme-launcher
+```
+
+Or add `pomme-launcher` to your NixOS `environment.systemPackages`.
+
 ## Running
 
 ### Via the launcher (recommended)


### PR DESCRIPTION
Adds a NixOS/Nix section to the README.

Draft until NixOS/nixpkgs#554124 is merged, since that PR adds the \`pomme-client\`/\`pomme-launcher\` packages to nixpkgs referenced here.