### PR TITLE
add server hud and connection support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
+ "wl-clipboard-rs",
  "x11rb",
 ]
 
@@ -4942,6 +4943,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7992,6 +8004,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9237,6 +9260,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 1.1.4",
+ "thiserror 2.0.20",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]

--- a/pomme-client/Cargo.toml
+++ b/pomme-client/Cargo.toml
@@ -55,7 +55,7 @@ image = "0.25"
 fontdue = "0.9.3"
 simdnbt = "0.10"
 discord-rich-presence = "1.1"
-arboard = "3"
+arboard = { version = "3", features = ["wayland-data-control"] }
 scopeguard = "1.2"
 rodio = "0.22"
 fastrand = "2"

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -352,6 +352,13 @@ impl AppCore {
         renderer.remove_player_entity_skin(uuid);
     }
 
+    fn clear_server_ui(&mut self, game: &mut GameState, renderer: &mut Renderer) {
+        game.tab_list.clear();
+        game.scoreboard.clear();
+        self.requested_player_skins.clear();
+        renderer.clear_player_entity_skins();
+    }
+
     pub fn drain_network_events(
         &mut self,
         connection: &ConnectionHandle,
@@ -729,8 +736,12 @@ impl AppCore {
                 NetworkEvent::ActionBar { spans } => {
                     game.action_bar = Some((spans, game.tick_count));
                 }
-                NetworkEvent::ScoreboardObjective { name, display } => {
-                    game.scoreboard.set_objective(name, display);
+                NetworkEvent::ScoreboardObjective {
+                    name,
+                    display,
+                    number_format,
+                } => {
+                    game.scoreboard.set_objective(name, display, number_format);
                 }
                 NetworkEvent::ScoreboardDisplay { name } => {
                     game.scoreboard.set_display(name);
@@ -740,8 +751,10 @@ impl AppCore {
                     objective,
                     score,
                     display,
+                    number_format,
                 } => {
-                    game.scoreboard.set_score(owner, objective, score, display);
+                    game.scoreboard
+                        .set_score(owner, objective, score, display, number_format);
                 }
                 NetworkEvent::ScoreboardReset { owner, objective } => {
                     game.scoreboard.reset_score(&owner, objective.as_deref());
@@ -1264,13 +1277,18 @@ impl AppCore {
                     self.menu.active_packs = self.resource_packs.active_pack_info();
                     self.menu.reload_assets = true;
                 }
+                NetworkEvent::Reconfiguring => {
+                    tracing::info!("Server re-entered configuration");
+                    game.entity_store = crate::entity::EntityStore::new();
+                    game.item_entity_store = crate::entity::ItemEntityStore::new();
+                    game.action_bar = None;
+                    game.waypoints = crate::world::waypoints::WaypointMap::default();
+                    self.clear_server_ui(game, renderer);
+                }
                 NetworkEvent::Disconnected { reason } => {
                     tracing::warn!("Disconnected: {reason}");
                     disconnect_reason = Some(reason);
-                    game.tab_list.clear();
-                    game.scoreboard.clear();
-                    self.requested_player_skins.clear();
-                    renderer.clear_player_entity_skins();
+                    self.clear_server_ui(game, renderer);
                 }
                 NetworkEvent::PlayerInfoUpdate { actions, entries } => {
                     if actions.add_player {

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -729,6 +729,43 @@ impl AppCore {
                 NetworkEvent::ActionBar { spans } => {
                     game.action_bar = Some((spans, game.tick_count));
                 }
+                NetworkEvent::ScoreboardObjective { name, display } => {
+                    game.scoreboard.set_objective(name, display);
+                }
+                NetworkEvent::ScoreboardDisplay { name } => {
+                    game.scoreboard.set_display(name);
+                }
+                NetworkEvent::ScoreboardScore {
+                    owner,
+                    objective,
+                    score,
+                    display,
+                } => {
+                    game.scoreboard.set_score(owner, objective, score, display);
+                }
+                NetworkEvent::ScoreboardReset { owner, objective } => {
+                    game.scoreboard.reset_score(&owner, objective.as_deref());
+                }
+                NetworkEvent::ScoreboardTeam {
+                    name,
+                    prefix,
+                    suffix,
+                    color,
+                    members,
+                } => {
+                    game.scoreboard
+                        .set_team(name, prefix, suffix, color, members);
+                }
+                NetworkEvent::ScoreboardTeamMembers {
+                    name,
+                    members,
+                    join,
+                } => {
+                    game.scoreboard.update_team_members(&name, members, join);
+                }
+                NetworkEvent::ScoreboardTeamRemoved { name } => {
+                    game.scoreboard.remove_team(&name);
+                }
                 NetworkEvent::CommandTree { tree } => {
                     game.command_tree = Some(tree);
                 }
@@ -1231,6 +1268,7 @@ impl AppCore {
                     tracing::warn!("Disconnected: {reason}");
                     disconnect_reason = Some(reason);
                     game.tab_list.clear();
+                    game.scoreboard.clear();
                     self.requested_player_skins.clear();
                     renderer.clear_player_entity_skins();
                 }

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -726,6 +726,9 @@ impl AppCore {
                 NetworkEvent::ChatMessage { spans } => {
                     game.chat.push_message(spans);
                 }
+                NetworkEvent::ActionBar { spans } => {
+                    game.action_bar = Some((spans, game.tick_count));
+                }
                 NetworkEvent::CommandTree { tree } => {
                     game.command_tree = Some(tree);
                 }

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -148,6 +148,7 @@ pub struct GameState {
     pub waypoints: crate::world::waypoints::WaypointMap,
     pub held_item_slot: u8,
     pub held_item_tooltip_tick: Option<u64>,
+    pub action_bar: Option<(Vec<crate::ui::text::TextSpan>, u64)>,
     /// Client tick counter (vanilla `player.tickCount`).
     pub tick_count: u64,
     /// Tick of the last XP progress change; the XP bar outprioritizes the
@@ -327,6 +328,7 @@ impl GameState {
             waypoints: crate::world::waypoints::WaypointMap::default(),
             held_item_slot: 0,
             held_item_tooltip_tick: None,
+            action_bar: None,
             tick_count: 0,
             xp_display_start_tick: i64::MIN,
             interaction: InteractionState::new(),
@@ -1675,6 +1677,9 @@ pub fn update_game(
             game.player.inventory.hotbar_slots(),
             game.held_item_tooltip_tick
                 .map(|tick| game.tick_count.saturating_sub(tick)),
+            game.action_bar
+                .as_ref()
+                .map(|(spans, tick)| (spans.as_slice(), game.tick_count.wrapping_sub(*tick))),
             gfx.renderer.is_first_person(),
             debug.as_ref(),
             core.menu.gui_scale_setting,

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -146,8 +146,10 @@ pub struct GameState {
     pub tab_list: TabList,
     /// Locator bar waypoints tracked by the server.
     pub waypoints: crate::world::waypoints::WaypointMap,
-    pub held_item_slot: u8,
-    pub held_item_tooltip_tick: Option<u64>,
+    /// Vanilla `Hud.toolHighlightTimer` / `lastToolHighlight` (see
+    /// `tick_tool_highlight`).
+    pub tool_highlight_timer: u32,
+    pub last_tool_highlight: azalea_inventory::ItemStack,
     pub action_bar: Option<(Vec<crate::ui::text::TextSpan>, u64)>,
     pub scoreboard: crate::ui::hud::Scoreboard,
     /// Client tick counter (vanilla `player.tickCount`).
@@ -327,8 +329,8 @@ impl GameState {
             command_tree: None,
             tab_list: TabList::new(),
             waypoints: crate::world::waypoints::WaypointMap::default(),
-            held_item_slot: 0,
-            held_item_tooltip_tick: None,
+            tool_highlight_timer: 0,
+            last_tool_highlight: azalea_inventory::ItemStack::Empty,
             action_bar: None,
             scoreboard: crate::ui::hud::Scoreboard::default(),
             tick_count: 0,
@@ -1243,6 +1245,32 @@ fn send_container_clicks(
     }
 }
 
+/// Vanilla `Hud.tick`: the held-item tooltip timer resets to 40 when the
+/// selected item's type or hover name changes, clears when the slot empties,
+/// and otherwise counts down.
+fn tick_tool_highlight(core: &AppCore, game: &mut GameState) {
+    use azalea_inventory::ItemStack;
+    let selected = game
+        .player
+        .inventory
+        .hotbar_slots()
+        .get(core.input.selected_slot() as usize)
+        .cloned()
+        .unwrap_or(ItemStack::Empty);
+    match (&selected, &game.last_tool_highlight) {
+        (ItemStack::Empty, _) => game.tool_highlight_timer = 0,
+        (ItemStack::Present(new), ItemStack::Present(old))
+            if new.kind == old.kind
+                && crate::ui::common::item_display_name(new)
+                    == crate::ui::common::item_display_name(old) =>
+        {
+            game.tool_highlight_timer = game.tool_highlight_timer.saturating_sub(1);
+        }
+        _ => game.tool_highlight_timer = 40,
+    }
+    game.last_tool_highlight = selected;
+}
+
 pub fn update_game(
     core: &mut AppCore,
     dt: f32,
@@ -1350,6 +1378,7 @@ pub fn update_game(
         game.item_entity_store.tick(&game.chunk_store);
         game.particle_store.tick(&game.chunk_store);
         game.block_entity_anim.tick();
+        tick_tool_highlight(core, game);
         if let Some(c) = &mut game.open_container
             && let Some(state) = &mut c.enchant
         {
@@ -1656,16 +1685,11 @@ pub fn update_game(
         } else {
             hud::ContextualBarKind::Empty
         };
-        let selected_slot = core.input.selected_slot();
-        if selected_slot != game.held_item_slot {
-            game.held_item_slot = selected_slot;
-            game.held_item_tooltip_tick = Some(game.tick_count);
-        }
         hud::build_hud(
             &mut elements,
             sw,
             sh,
-            selected_slot,
+            core.input.selected_slot(),
             game.player.health,
             game.player.food,
             game.player.armor,
@@ -1677,8 +1701,7 @@ pub fn update_game(
             bar,
             game.player.game_mode,
             game.player.inventory.hotbar_slots(),
-            game.held_item_tooltip_tick
-                .map(|tick| game.tick_count.saturating_sub(tick)),
+            game.tool_highlight_timer,
             game.action_bar
                 .as_ref()
                 .map(|(spans, tick)| (spans.as_slice(), game.tick_count.wrapping_sub(*tick))),

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -149,6 +149,7 @@ pub struct GameState {
     pub held_item_slot: u8,
     pub held_item_tooltip_tick: Option<u64>,
     pub action_bar: Option<(Vec<crate::ui::text::TextSpan>, u64)>,
+    pub scoreboard: crate::ui::hud::Scoreboard,
     /// Client tick counter (vanilla `player.tickCount`).
     pub tick_count: u64,
     /// Tick of the last XP progress change; the XP bar outprioritizes the
@@ -329,6 +330,7 @@ impl GameState {
             held_item_slot: 0,
             held_item_tooltip_tick: None,
             action_bar: None,
+            scoreboard: crate::ui::hud::Scoreboard::default(),
             tick_count: 0,
             xp_display_start_tick: i64::MIN,
             interaction: InteractionState::new(),
@@ -1680,6 +1682,7 @@ pub fn update_game(
             game.action_bar
                 .as_ref()
                 .map(|(spans, tick)| (spans.as_slice(), game.tick_count.wrapping_sub(*tick))),
+            &game.scoreboard,
             gfx.renderer.is_first_person(),
             debug.as_ref(),
             core.menu.gui_scale_setting,
@@ -1699,8 +1702,24 @@ pub fn update_game(
             &mut elements,
             sw,
             &game.tab_list,
+            &game.scoreboard,
             gs,
             &|t, s| r.menu_text_width(t, s),
+        );
+    }
+
+    if !benchmark_running && !game.hide_gui {
+        let renderer = &gfx.renderer;
+        crate::ui::player_tab::build_player_nameplates(
+            &mut elements,
+            &game.entity_store,
+            &game.tab_list,
+            &game.scoreboard,
+            core.user.uuid,
+            partial_tick,
+            gs,
+            renderer.camera_render_position(),
+            &|position| renderer.project_world_to_screen(position),
         );
     }
 

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -1705,6 +1705,7 @@ pub fn update_game(
             game.action_bar
                 .as_ref()
                 .map(|(spans, tick)| (spans.as_slice(), game.tick_count.wrapping_sub(*tick))),
+            &|spans, s| gfx.renderer.menu_spans_width(spans, s),
             &game.scoreboard,
             gfx.renderer.is_first_person(),
             debug.as_ref(),
@@ -1728,6 +1729,7 @@ pub fn update_game(
             &game.scoreboard,
             gs,
             &|t, s| r.menu_text_width(t, s),
+            &|spans, s| r.menu_spans_width(spans, s),
         );
     }
 

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -1712,14 +1712,16 @@ pub fn update_game(
         let renderer = &gfx.renderer;
         crate::ui::player_tab::build_player_nameplates(
             &mut elements,
-            &game.entity_store,
-            &game.tab_list,
-            &game.scoreboard,
-            core.user.uuid,
-            partial_tick,
-            gs,
-            renderer.camera_render_position(),
-            &|position| renderer.project_world_to_screen(position),
+            crate::ui::player_tab::PlayerNameplates {
+                entity_store: &game.entity_store,
+                tab_list: &game.tab_list,
+                scoreboard: &game.scoreboard,
+                local_uuid: core.user.uuid,
+                partial_tick,
+                gs,
+                camera_pos: renderer.camera_render_position(),
+                project: &|position| renderer.project_world_to_screen(position),
+            },
         );
     }
 

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -146,6 +146,8 @@ pub struct GameState {
     pub tab_list: TabList,
     /// Locator bar waypoints tracked by the server.
     pub waypoints: crate::world::waypoints::WaypointMap,
+    pub held_item_slot: u8,
+    pub held_item_tooltip_tick: Option<u64>,
     /// Client tick counter (vanilla `player.tickCount`).
     pub tick_count: u64,
     /// Tick of the last XP progress change; the XP bar outprioritizes the
@@ -323,6 +325,8 @@ impl GameState {
             command_tree: None,
             tab_list: TabList::new(),
             waypoints: crate::world::waypoints::WaypointMap::default(),
+            held_item_slot: 0,
+            held_item_tooltip_tick: None,
             tick_count: 0,
             xp_display_start_tick: i64::MIN,
             interaction: InteractionState::new(),
@@ -1648,11 +1652,16 @@ pub fn update_game(
         } else {
             hud::ContextualBarKind::Empty
         };
+        let selected_slot = core.input.selected_slot();
+        if selected_slot != game.held_item_slot {
+            game.held_item_slot = selected_slot;
+            game.held_item_tooltip_tick = Some(game.tick_count);
+        }
         hud::build_hud(
             &mut elements,
             sw,
             sh,
-            core.input.selected_slot(),
+            selected_slot,
             game.player.health,
             game.player.food,
             game.player.armor,
@@ -1664,6 +1673,8 @@ pub fn update_game(
             bar,
             game.player.game_mode,
             game.player.inventory.hotbar_slots(),
+            game.held_item_tooltip_tick
+                .map(|tick| game.tick_count.saturating_sub(tick)),
             gfx.renderer.is_first_person(),
             debug.as_ref(),
             core.menu.gui_scale_setting,

--- a/pomme-client/src/net/azalea_compat.rs
+++ b/pomme-client/src/net/azalea_compat.rs
@@ -403,6 +403,57 @@ fn translate_entity_data_774() {
     ));
 }
 
+#[test]
+fn translate_entity_profile_774() {
+    use azalea_buf::AzBuf;
+    use azalea_inventory::components::Profile;
+
+    let mut old = Vec::new();
+    wire::write_varint(
+        &mut old,
+        old_id(774, Direction::Clientbound, "set_entity_data"),
+    );
+    wire::write_varint(&mut old, 9);
+    old.extend_from_slice(&[0, 37]);
+    Profile::default().azalea_write(&mut old).unwrap();
+    old.extend_from_slice(&[1, 38, 1, 0xFF]);
+
+    let ClientboundGamePacket::SetEntityData(p) = translate_and_decode(774, old) else {
+        panic!("wrong packet");
+    };
+    assert!(matches!(
+        p.packed_items.0[0].value,
+        azalea_entity::EntityDataValue::ResolvableProfile(_)
+    ));
+    assert!(matches!(
+        p.packed_items.0[1].value,
+        azalea_entity::EntityDataValue::HumanoidArm(_)
+    ));
+}
+
+#[test]
+fn translate_empty_entity_particles_774() {
+    let mut old = Vec::new();
+    wire::write_varint(
+        &mut old,
+        old_id(774, Direction::Clientbound, "set_entity_data"),
+    );
+    wire::write_varint(&mut old, 9);
+    old.extend_from_slice(&[10, 17, 0, 11, 8, 1, 0xFF]);
+
+    let ClientboundGamePacket::SetEntityData(p) = translate_and_decode(774, old) else {
+        panic!("wrong packet");
+    };
+    assert!(matches!(
+        p.packed_items.0[0].value,
+        azalea_entity::EntityDataValue::Particles(_)
+    ));
+    assert!(matches!(
+        p.packed_items.0[1].value,
+        azalea_entity::EntityDataValue::Boolean(true)
+    ));
+}
+
 /// The per-section `fluidCount` insertion (see `translate_chunk`).
 #[test]
 fn translate_chunk_774() {

--- a/pomme-client/src/net/azalea_compat.rs
+++ b/pomme-client/src/net/azalea_compat.rs
@@ -170,6 +170,15 @@ fn translate_game_login_26_1() {
     assert_eq!(&translated[..], &frame[..]);
 }
 
+/// 26.1's team `Parameters` order is `displayName, options, visibility,
+/// collision, color, prefix, suffix` with color as a `ChatFormatting`
+/// ordinal; 26.2 reordered to `displayName, prefix, suffix, visibility,
+/// collision, color, options` (`ClientboundSetPlayerTeamPacket.Parameters`
+/// in both references). Vanilla 26.2 also changed color to
+/// `Optional<TeamColor>`, but azalea (ffedf17) still decodes a plain
+/// `ChatFormatting` ordinal, so these frames target azalea's layout — the
+/// ordinal is copied through unchanged. Teams on native 26.2 servers
+/// misdecode until azalea catches up.
 #[test]
 fn translate_set_player_team_26_1() {
     let team_id = table_id(Direction::Clientbound, "set_player_team");
@@ -208,6 +217,9 @@ fn translate_set_player_team_26_1() {
     assert_eq!(&translated[..], &expected[..]);
 }
 
+/// RESET (ChatFormatting ordinal 21) passes through as-is — azalea's enum
+/// has all 22 formatting variants; the method-0 player list is copied
+/// verbatim.
 #[test]
 fn translate_set_player_team_26_1_reset_color() {
     let team_id = table_id(Direction::Clientbound, "set_player_team");
@@ -445,6 +457,52 @@ fn translate_empty_entity_particles_774() {
         p.packed_items.0[1].value,
         azalea_entity::EntityDataValue::Boolean(true)
     ));
+}
+
+/// A stack component the walker doesn't know falls back to the verbatim-tail
+/// copy instead of dropping the packet. `damage` (id 3 in both 774 and the
+/// latest registry, varint payload) keeps the verbatim bytes decodable.
+#[test]
+fn translate_entity_item_stack_fallback_774() {
+    let mut old = Vec::new();
+    wire::write_varint(
+        &mut old,
+        old_id(774, Direction::Clientbound, "set_entity_data"),
+    );
+    wire::write_varint(&mut old, 9);
+    // index 5, serializer 7 (item stack): count 1, item 1, 1 added
+    // component, 0 removed, component 3 (damage) = 7.
+    old.extend_from_slice(&[5, 7, 1, 1, 1, 0, 3, 7, 0xFF]);
+
+    let ClientboundGamePacket::SetEntityData(p) = translate_and_decode(774, old) else {
+        panic!("wrong packet");
+    };
+    assert!(matches!(
+        p.packed_items.0[0].value,
+        azalea_entity::EntityDataValue::ItemStack(_)
+    ));
+}
+
+/// `translate_item_stack`'s component ids against the latest registry table.
+#[test]
+fn component_id_anchors() {
+    use pomme_protocol::{ClientRegistry, RegistryTable};
+
+    let table = RegistryTable::latest();
+    assert_eq!(
+        table.name_of(
+            ClientRegistry::DataComponentType,
+            super::translate::COMPONENT_MAP_ID
+        ),
+        Some("map_id")
+    );
+    assert_eq!(
+        table.name_of(
+            ClientRegistry::DataComponentType,
+            super::translate::COMPONENT_PROFILE
+        ),
+        Some("profile")
+    );
 }
 
 /// The per-section `fluidCount` insertion (see `translate_chunk`).

--- a/pomme-client/src/net/azalea_compat.rs
+++ b/pomme-client/src/net/azalea_compat.rs
@@ -170,11 +170,6 @@ fn translate_game_login_26_1() {
     assert_eq!(&translated[..], &frame[..]);
 }
 
-/// 26.1's team `Parameters` order is `displayName, options, visibility,
-/// collision, color, prefix, suffix` with color as a `ChatFormatting`
-/// ordinal; 26.2 reordered to `displayName, prefix, suffix, visibility,
-/// collision, color, options` with color as `Optional<TeamColor>`
-/// (`ClientboundSetPlayerTeamPacket.Parameters` in both references).
 #[test]
 fn translate_set_player_team_26_1() {
     let team_id = table_id(Direction::Clientbound, "set_player_team");
@@ -208,13 +203,11 @@ fn translate_set_player_team_26_1() {
     expected.extend_from_slice(suffix);
     expected.push(0); // visibility
     expected.push(1); // collision
-    expected.extend_from_slice(&[1, 5]); // color: Some(TeamColor 5)
+    expected.push(5);
     expected.push(3); // options
     assert_eq!(&translated[..], &expected[..]);
 }
 
-/// RESET (ChatFormatting ordinal 21) has no TeamColor equivalent and maps to
-/// an empty optional; the method-0 player list is copied verbatim.
 #[test]
 fn translate_set_player_team_26_1_reset_color() {
     let team_id = table_id(Direction::Clientbound, "set_player_team");
@@ -246,7 +239,7 @@ fn translate_set_player_team_26_1_reset_color() {
     expected.extend_from_slice(component);
     expected.push(0); // visibility
     expected.push(0); // collision
-    expected.push(0); // color: None
+    expected.push(21);
     expected.push(0); // options
     expected.extend_from_slice(&[1, 3, b'b', b'o', b'b']);
     assert_eq!(&translated[..], &expected[..]);

--- a/pomme-client/src/net/connection.rs
+++ b/pomme-client/src/net/connection.rs
@@ -1,5 +1,5 @@
 use azalea_protocol::address::ServerAddr;
-use azalea_protocol::connect::Connection;
+use azalea_protocol::connect::{Connection, WriteConnection};
 use azalea_protocol::packets::ClientIntention;
 use azalea_protocol::packets::config::{ClientboundConfigPacket, ServerboundConfigPacket};
 use azalea_protocol::packets::game::{ClientboundGamePacket, ServerboundGamePacket};
@@ -352,8 +352,10 @@ async fn config_sequence(
     loop {
         let packet = tokio::select! {
             packet = conn.read() => packet?,
-            outbound = outbound_rx.recv() => {
-                if let Some(Outbound::Packet(packet)) = outbound
+            // `Some(..)` disables the branch when the channel closes instead
+            // of busy-looping on a closed receiver.
+            Some(outbound) = outbound_rx.recv() => {
+                if let Outbound::Packet(packet) = outbound
                     && let ServerboundGamePacket::ResourcePack(p) = *packet
                 {
                     use azalea_protocol::packets::config::s_resource_pack as config_pack;
@@ -610,19 +612,11 @@ async fn game_loop(
                         if let Some(t) = translation {
                             t.remap_outbound(&mut packet);
                         }
-                        azalea_protocol::write::serialize_packet(&*packet)
-                            .map(Vec::from)
-                            .map_err(|e| ConnectionError::Write(std::io::Error::other(e)))?
+                        serialize_game_packet(&packet)?
                     }
                     Outbound::Raw(bytes) => bytes,
                 };
-                let frames = match translation {
-                    Some(t) if t.translates_outbound() => t.translate_outbound_game_frame(frame),
-                    _ => vec![frame],
-                };
-                for frame in frames {
-                    conn.writer.raw.write(&frame).await?;
-                }
+                write_game_frame(&mut conn.writer, translation, frame).await?;
                 continue;
             }
             raw = conn.reader.raw.read() => raw,
@@ -647,21 +641,15 @@ async fn game_loop(
         match deserialize_packet::<ClientboundGamePacket>(&mut std::io::Cursor::new(&raw)) {
             Ok(mut packet) => {
                 if matches!(packet, ClientboundGamePacket::StartConfiguration(_)) {
+                    // Vanilla clears the client level before acknowledging
+                    // (ClientPacketListener.handleConfigurationStart); chat
+                    // survives the transition.
+                    let _ = event_tx.try_send(NetworkEvent::Reconfiguring);
                     let ack = ServerboundGamePacket::ConfigurationAcknowledged(
                         azalea_protocol::packets::game::s_configuration_acknowledged::ServerboundConfigurationAcknowledged,
                     );
-                    let frame = azalea_protocol::write::serialize_packet(&ack)
-                        .map(Vec::from)
-                        .map_err(|e| ConnectionError::Write(std::io::Error::other(e)))?;
-                    let frames = match translation {
-                        Some(t) if t.translates_outbound() => {
-                            t.translate_outbound_game_frame(frame)
-                        }
-                        _ => vec![frame],
-                    };
-                    for frame in frames {
-                        conn.writer.raw.write(&frame).await?;
-                    }
+                    write_game_frame(&mut conn.writer, translation, serialize_game_packet(&ack)?)
+                        .await?;
                     let mut config = conn.config();
                     let holder =
                         config_sequence(&mut config, view_distance, event_tx, &mut outbound_rx)
@@ -681,6 +669,28 @@ async fn game_loop(
             Err(e) => skip_malformed_packet(e)?,
         }
     }
+}
+
+fn serialize_game_packet(packet: &ServerboundGamePacket) -> Result<Vec<u8>, ConnectionError> {
+    azalea_protocol::write::serialize_packet(packet)
+        .map(Vec::from)
+        .map_err(|e| ConnectionError::Write(std::io::Error::other(e)))
+}
+
+/// Writes one latest-layout frame, translating it for older wire versions.
+async fn write_game_frame(
+    writer: &mut WriteConnection<ServerboundGamePacket>,
+    translation: Option<&super::translate::Translation>,
+    frame: Vec<u8>,
+) -> Result<(), ConnectionError> {
+    let frames = match translation {
+        Some(t) if t.translates_outbound() => t.translate_outbound_game_frame(frame),
+        _ => vec![frame],
+    };
+    for frame in frames {
+        writer.raw.write(&frame).await?;
+    }
+    Ok(())
 }
 
 /// Recoverable decode errors skip the packet; anything else tears down the

--- a/pomme-client/src/net/connection.rs
+++ b/pomme-client/src/net/connection.rs
@@ -145,6 +145,7 @@ pub async fn connect_to_server(
         args.view_distance,
         &event_tx,
         &mut game_packet_rx,
+        None,
     )
     .await?;
 
@@ -302,7 +303,11 @@ async fn config_sequence(
     view_distance: u8,
     event_tx: &Sender<NetworkEvent>,
     outbound_rx: &mut mpsc::UnboundedReceiver<Outbound>,
-) -> Result<azalea_core::registry_holder::RegistryHolder, ConnectionError> {
+    // `Some` on a mid-session reconfiguration: the previous registries,
+    // kept when the server re-sends nothing (vanilla's RegistryDataCollector
+    // returns the original registries unchanged in that case).
+    previous_registries: Option<&std::sync::Arc<azalea_core::registry_holder::RegistryHolder>>,
+) -> Result<std::sync::Arc<azalea_core::registry_holder::RegistryHolder>, ConnectionError> {
     use azalea_core::delta::AzBuf;
     use azalea_core::registry_holder::RegistryHolder;
     use azalea_entity::HumanoidArm;
@@ -310,44 +315,49 @@ async fn config_sequence(
     use azalea_protocol::packets::config::*;
 
     let mut registry_holder = RegistryHolder::default();
+    let mut received_registry_data = false;
 
-    // Vanilla announces its brand in the config phase; some servers key off it.
-    let mut brand_payload = Vec::new();
-    String::from("pomme")
-        .azalea_write(&mut brand_payload)
-        .unwrap();
-    conn.write(ServerboundConfigPacket::CustomPayload(
-        s_custom_payload::ServerboundCustomPayload {
-            identifier: "minecraft:brand".into(),
-            data: brand_payload.into(),
-        },
-    ))
-    .await?;
-
-    conn.write(ServerboundConfigPacket::ClientInformation(
-        s_client_information::ServerboundClientInformation {
-            information: ClientInformation {
-                language: "en_us".into(),
-                view_distance,
-                chat_visibility: ChatVisibility::Full,
-                chat_colors: true,
-                model_customization: ModelCustomization {
-                    cape: true,
-                    jacket: true,
-                    left_sleeve: true,
-                    right_sleeve: true,
-                    left_pants: true,
-                    right_pants: true,
-                    hat: true,
-                },
-                main_hand: HumanoidArm::Right,
-                text_filtering_enabled: false,
-                allows_listing: true,
-                particle_status: ParticleStatus::All,
+    // Vanilla sends brand and client information once, from the login
+    // listener; a reconfiguration sends neither.
+    if previous_registries.is_none() {
+        // Some servers key off the brand.
+        let mut brand_payload = Vec::new();
+        String::from("pomme")
+            .azalea_write(&mut brand_payload)
+            .unwrap();
+        conn.write(ServerboundConfigPacket::CustomPayload(
+            s_custom_payload::ServerboundCustomPayload {
+                identifier: "minecraft:brand".into(),
+                data: brand_payload.into(),
             },
-        },
-    ))
-    .await?;
+        ))
+        .await?;
+
+        conn.write(ServerboundConfigPacket::ClientInformation(
+            s_client_information::ServerboundClientInformation {
+                information: ClientInformation {
+                    language: "en_us".into(),
+                    view_distance,
+                    chat_visibility: ChatVisibility::Full,
+                    chat_colors: true,
+                    model_customization: ModelCustomization {
+                        cape: true,
+                        jacket: true,
+                        left_sleeve: true,
+                        right_sleeve: true,
+                        left_pants: true,
+                        right_pants: true,
+                        hat: true,
+                    },
+                    main_hand: HumanoidArm::Right,
+                    text_filtering_enabled: false,
+                    allows_listing: true,
+                    particle_status: ParticleStatus::All,
+                },
+            },
+        ))
+        .await?;
+    }
 
     loop {
         let packet = tokio::select! {
@@ -373,11 +383,15 @@ async fn config_sequence(
                         config_pack::ServerboundResourcePack { id: p.id, action },
                     )).await?;
                 }
+                // Anything else is discarded: vanilla defers its outbound
+                // queue, but pomme's game keeps ticking through a
+                // reconfiguration, so stale movement/actions are best dropped.
                 continue;
             }
         };
         match packet {
             ClientboundConfigPacket::RegistryData(p) => {
+                received_registry_data = true;
                 registry_holder.append(p.registry_id, p.entries);
             }
             ClientboundConfigPacket::UpdateTags(_) => {
@@ -405,7 +419,10 @@ async fn config_sequence(
                     s_finish_configuration::ServerboundFinishConfiguration {},
                 ))
                 .await?;
-                return Ok(registry_holder);
+                return Ok(match previous_registries {
+                    Some(previous) if !received_registry_data => previous.clone(),
+                    _ => std::sync::Arc::new(registry_holder),
+                });
             }
             ClientboundConfigPacket::Disconnect(p) => {
                 return Err(ConnectionError::Disconnected(format!("{}", p.reason)));
@@ -539,7 +556,7 @@ async fn game_loop(
     chat_rx: crossbeam_channel::Receiver<String>,
     outbound_tx: mpsc::UnboundedSender<Outbound>,
     mut outbound_rx: mpsc::UnboundedReceiver<Outbound>,
-    registry_holder: azalea_core::registry_holder::RegistryHolder,
+    mut registry_holder: std::sync::Arc<azalea_core::registry_holder::RegistryHolder>,
     view_distance: u8,
 ) -> Result<(), ConnectionError> {
     let sender = PacketSender::new(outbound_tx.clone());
@@ -600,7 +617,6 @@ async fn game_loop(
 
     // Share the registries with the game loop for hashing predicted container
     // clicks.
-    let mut registry_holder = std::sync::Arc::new(registry_holder);
     let _ = event_tx.try_send(NetworkEvent::Registries(registry_holder.clone()));
 
     let translation = super::translate::active();
@@ -651,12 +667,23 @@ async fn game_loop(
                     write_game_frame(&mut conn.writer, translation, serialize_game_packet(&ack)?)
                         .await?;
                     let mut config = conn.config();
-                    let holder =
-                        config_sequence(&mut config, view_distance, event_tx, &mut outbound_rx)
-                            .await?;
+                    let holder = config_sequence(
+                        &mut config,
+                        view_distance,
+                        event_tx,
+                        &mut outbound_rx,
+                        Some(&registry_holder),
+                    )
+                    .await?;
                     conn = config.game();
-                    registry_holder = std::sync::Arc::new(holder);
-                    let _ = event_tx.try_send(NetworkEvent::Registries(registry_holder.clone()));
+                    if !std::sync::Arc::ptr_eq(&holder, &registry_holder) {
+                        registry_holder = holder;
+                        let _ =
+                            event_tx.try_send(NetworkEvent::Registries(registry_holder.clone()));
+                        let _ = event_tx.try_send(NetworkEvent::BiomeColors {
+                            colors: extract_biome_climate(&registry_holder),
+                        });
+                    }
                     continue;
                 }
                 if let Some(t) = translation

--- a/pomme-client/src/net/connection.rs
+++ b/pomme-client/src/net/connection.rs
@@ -1,5 +1,5 @@
 use azalea_protocol::address::ServerAddr;
-use azalea_protocol::connect::{Connection, ReadConnection, WriteConnection};
+use azalea_protocol::connect::Connection;
 use azalea_protocol::packets::ClientIntention;
 use azalea_protocol::packets::config::{ClientboundConfigPacket, ServerboundConfigPacket};
 use azalea_protocol::packets::game::{ClientboundGamePacket, ServerboundGamePacket};
@@ -108,7 +108,7 @@ pub async fn connect_to_server(
     event_tx: Sender<NetworkEvent>,
     chat_rx: crossbeam_channel::Receiver<String>,
     game_packet_tx: mpsc::UnboundedSender<Outbound>,
-    game_packet_rx: mpsc::UnboundedReceiver<Outbound>,
+    mut game_packet_rx: mpsc::UnboundedReceiver<Outbound>,
 ) -> Result<(), ConnectionError> {
     let server_addr: ServerAddr = args
         .server
@@ -140,7 +140,13 @@ pub async fn connect_to_server(
     let mut conn = conn.config();
 
     tracing::info!("Entering configuration phase");
-    let registry_holder = config_sequence(&mut conn, args.view_distance, &event_tx).await?;
+    let registry_holder = config_sequence(
+        &mut conn,
+        args.view_distance,
+        &event_tx,
+        &mut game_packet_rx,
+    )
+    .await?;
 
     let conn = conn.game();
     tracing::info!("Entering game state");
@@ -157,6 +163,7 @@ pub async fn connect_to_server(
         game_packet_tx,
         game_packet_rx,
         registry_holder,
+        args.view_distance,
     )
     .await
 }
@@ -294,6 +301,7 @@ async fn config_sequence(
     conn: &mut Connection<ClientboundConfigPacket, ServerboundConfigPacket>,
     view_distance: u8,
     event_tx: &Sender<NetworkEvent>,
+    outbound_rx: &mut mpsc::UnboundedReceiver<Outbound>,
 ) -> Result<azalea_core::registry_holder::RegistryHolder, ConnectionError> {
     use azalea_core::delta::AzBuf;
     use azalea_core::registry_holder::RegistryHolder;
@@ -342,7 +350,30 @@ async fn config_sequence(
     .await?;
 
     loop {
-        let packet: ClientboundConfigPacket = conn.read().await?;
+        let packet = tokio::select! {
+            packet = conn.read() => packet?,
+            outbound = outbound_rx.recv() => {
+                if let Some(Outbound::Packet(packet)) = outbound
+                    && let ServerboundGamePacket::ResourcePack(p) = *packet
+                {
+                    use azalea_protocol::packets::config::s_resource_pack as config_pack;
+                    use azalea_protocol::packets::game::s_resource_pack as game_pack;
+                    let action = match p.action {
+                        game_pack::Action::SuccessfullyLoaded => config_pack::Action::SuccessfullyLoaded,
+                        game_pack::Action::Declined => config_pack::Action::Declined,
+                        game_pack::Action::FailedDownload => config_pack::Action::FailedDownload,
+                        game_pack::Action::Accepted => config_pack::Action::Accepted,
+                        game_pack::Action::InvalidUrl => config_pack::Action::InvalidUrl,
+                        game_pack::Action::FailedReload => config_pack::Action::FailedReload,
+                        game_pack::Action::Discarded => config_pack::Action::Discarded,
+                    };
+                    conn.write(ServerboundConfigPacket::ResourcePack(
+                        config_pack::ServerboundResourcePack { id: p.id, action },
+                    )).await?;
+                }
+                continue;
+            }
+        };
         match packet {
             ClientboundConfigPacket::RegistryData(p) => {
                 registry_holder.append(p.registry_id, p.entries);
@@ -501,56 +532,18 @@ fn nbt_string_from_compound(compound: &simdnbt::owned::NbtCompound, key: &str) -
 }
 
 async fn game_loop(
-    conn: Connection<ClientboundGamePacket, ServerboundGamePacket>,
+    mut conn: Connection<ClientboundGamePacket, ServerboundGamePacket>,
     event_tx: &Sender<NetworkEvent>,
     chat_rx: crossbeam_channel::Receiver<String>,
     outbound_tx: mpsc::UnboundedSender<Outbound>,
     mut outbound_rx: mpsc::UnboundedReceiver<Outbound>,
     registry_holder: azalea_core::registry_holder::RegistryHolder,
+    view_distance: u8,
 ) -> Result<(), ConnectionError> {
-    let (mut reader, mut writer): (
-        ReadConnection<ClientboundGamePacket>,
-        WriteConnection<ServerboundGamePacket>,
-    ) = conn.into_split();
-
     let sender = PacketSender::new(outbound_tx.clone());
 
     let shared_tree: crate::net::commands::SharedCommandTree =
         std::sync::Arc::new(parking_lot::Mutex::new(None));
-
-    tokio::spawn(async move {
-        let translation = super::translate::active();
-        'writer: while let Some(out) = outbound_rx.recv().await {
-            // Frames are in the latest layout (azalea's serializer and
-            // `wire`'s encoders both emit it); older wire versions get them
-            // translated before framing.
-            let frame = match out {
-                Outbound::Packet(mut packet) => {
-                    if let Some(t) = translation {
-                        t.remap_outbound(&mut packet);
-                    }
-                    match azalea_protocol::write::serialize_packet(&*packet) {
-                        Ok(frame) => Vec::from(frame),
-                        Err(e) => {
-                            tracing::error!("Failed to serialize packet: {e}");
-                            break;
-                        }
-                    }
-                }
-                Outbound::Raw(bytes) => bytes,
-            };
-            let frames = match translation {
-                Some(t) if t.translates_outbound() => t.translate_outbound_game_frame(frame),
-                _ => vec![frame],
-            };
-            for frame in frames {
-                if let Err(e) = writer.raw.write(&frame).await {
-                    tracing::error!("Failed to write packet: {e}");
-                    break 'writer;
-                }
-            }
-        }
-    });
 
     let chat_outbound_tx = outbound_tx;
     let chat_tree = shared_tree.clone();
@@ -605,12 +598,36 @@ async fn game_loop(
 
     // Share the registries with the game loop for hashing predicted container
     // clicks.
-    let registry_holder = std::sync::Arc::new(registry_holder);
+    let mut registry_holder = std::sync::Arc::new(registry_holder);
     let _ = event_tx.try_send(NetworkEvent::Registries(registry_holder.clone()));
 
     let translation = super::translate::active();
     loop {
-        let raw = match reader.raw.read().await {
+        let raw = tokio::select! {
+            Some(out) = outbound_rx.recv() => {
+                let frame = match out {
+                    Outbound::Packet(mut packet) => {
+                        if let Some(t) = translation {
+                            t.remap_outbound(&mut packet);
+                        }
+                        azalea_protocol::write::serialize_packet(&*packet)
+                            .map(Vec::from)
+                            .map_err(|e| ConnectionError::Write(std::io::Error::other(e)))?
+                    }
+                    Outbound::Raw(bytes) => bytes,
+                };
+                let frames = match translation {
+                    Some(t) if t.translates_outbound() => t.translate_outbound_game_frame(frame),
+                    _ => vec![frame],
+                };
+                for frame in frames {
+                    conn.writer.raw.write(&frame).await?;
+                }
+                continue;
+            }
+            raw = conn.reader.raw.read() => raw,
+        };
+        let raw = match raw {
             Ok(raw) => raw,
             Err(e) => {
                 skip_malformed_packet(e)?;
@@ -629,6 +646,31 @@ async fn game_loop(
         }
         match deserialize_packet::<ClientboundGamePacket>(&mut std::io::Cursor::new(&raw)) {
             Ok(mut packet) => {
+                if matches!(packet, ClientboundGamePacket::StartConfiguration(_)) {
+                    let ack = ServerboundGamePacket::ConfigurationAcknowledged(
+                        azalea_protocol::packets::game::s_configuration_acknowledged::ServerboundConfigurationAcknowledged,
+                    );
+                    let frame = azalea_protocol::write::serialize_packet(&ack)
+                        .map(Vec::from)
+                        .map_err(|e| ConnectionError::Write(std::io::Error::other(e)))?;
+                    let frames = match translation {
+                        Some(t) if t.translates_outbound() => {
+                            t.translate_outbound_game_frame(frame)
+                        }
+                        _ => vec![frame],
+                    };
+                    for frame in frames {
+                        conn.writer.raw.write(&frame).await?;
+                    }
+                    let mut config = conn.config();
+                    let holder =
+                        config_sequence(&mut config, view_distance, event_tx, &mut outbound_rx)
+                            .await?;
+                    conn = config.game();
+                    registry_holder = std::sync::Arc::new(holder);
+                    let _ = event_tx.try_send(NetworkEvent::Registries(registry_holder.clone()));
+                    continue;
+                }
                 if let Some(t) = translation
                     && !t.remap_inbound(&mut packet)
                 {

--- a/pomme-client/src/net/handler.rs
+++ b/pomme-client/src/net/handler.rs
@@ -302,6 +302,9 @@ pub fn handle_game_packet(
                 number_format,
             });
         }
+        // TODO: track the other display slots too — vanilla prefers the
+        // local team's `sidebar.team.<color>` slot over SIDEBAR, and LIST
+        // drives the tab-overlay score column.
         ClientboundGamePacket::SetDisplayObjective(p)
             if matches!(
                 p.slot,

--- a/pomme-client/src/net/handler.rs
+++ b/pomme-client/src/net/handler.rs
@@ -278,6 +278,69 @@ pub fn handle_game_packet(
         ClientboundGamePacket::SetActionBarText(p) => {
             send_action_bar(event_tx, &p.text);
         }
+        ClientboundGamePacket::SetObjective(p) => {
+            use azalea_protocol::packets::game::c_set_objective::Method;
+            let display = match &p.method {
+                Method::Add { display_name, .. } | Method::Change { display_name, .. } => {
+                    Some(format_text_spans(display_name, [1.0; 4]))
+                }
+                Method::Remove => None,
+            };
+            let _ = event_tx.try_send(NetworkEvent::ScoreboardObjective {
+                name: p.objective_name.clone(),
+                display,
+            });
+        }
+        ClientboundGamePacket::SetDisplayObjective(p)
+            if matches!(
+                p.slot,
+                azalea_protocol::packets::game::c_set_display_objective::DisplaySlot::Sidebar
+            ) =>
+        {
+            let _ = event_tx.try_send(NetworkEvent::ScoreboardDisplay {
+                name: (!p.objective_name.is_empty()).then(|| p.objective_name.clone()),
+            });
+        }
+        ClientboundGamePacket::SetScore(p) => {
+            let _ = event_tx.try_send(NetworkEvent::ScoreboardScore {
+                owner: p.owner.clone(),
+                objective: p.objective_name.clone(),
+                score: p.score,
+                display: p
+                    .display
+                    .as_ref()
+                    .map(|text| format_text_spans(text, [1.0; 4])),
+            });
+        }
+        ClientboundGamePacket::ResetScore(p) => {
+            let _ = event_tx.try_send(NetworkEvent::ScoreboardReset {
+                owner: p.owner.clone(),
+                objective: p.objective_name.clone(),
+            });
+        }
+        ClientboundGamePacket::SetPlayerTeam(p) => {
+            use azalea_protocol::packets::game::c_set_player_team::Method;
+            match &p.method {
+                Method::Add((parameters, members)) => {
+                    send_scoreboard_team(event_tx, &p.name, parameters, Some(members.clone()))
+                }
+                Method::Change(parameters) => {
+                    send_scoreboard_team(event_tx, &p.name, parameters, None)
+                }
+                Method::Join(members) | Method::Leave(members) => {
+                    let _ = event_tx.try_send(NetworkEvent::ScoreboardTeamMembers {
+                        name: p.name.clone(),
+                        members: members.clone(),
+                        join: matches!(p.method, Method::Join(_)),
+                    });
+                }
+                Method::Remove => {
+                    let _ = event_tx.try_send(NetworkEvent::ScoreboardTeamRemoved {
+                        name: p.name.clone(),
+                    });
+                }
+            }
+        }
         ClientboundGamePacket::PlayerChat(p) => {
             send_chat(event_tx, &p.message());
         }
@@ -688,7 +751,10 @@ pub fn handle_game_packet(
                     game_mode: e.game_mode.to_id(),
                     listed: e.listed,
                     latency: e.latency,
-                    display_name: e.display_name.as_ref().map(|c| c.to_string()),
+                    display_name: e
+                        .display_name
+                        .as_ref()
+                        .map(|c| crate::ui::text::format_text_spans(c, [1.0, 1.0, 1.0, 1.0])),
                     list_order: e.list_order,
                 })
                 .collect();
@@ -701,8 +767,8 @@ pub fn handle_game_packet(
         }
         ClientboundGamePacket::TabList(p) => {
             let _ = event_tx.try_send(NetworkEvent::TabListHeaderFooter {
-                header: p.header.to_string(),
-                footer: p.footer.to_string(),
+                header: crate::ui::text::format_text_spans(&p.header, [1.0, 1.0, 1.0, 1.0]),
+                footer: crate::ui::text::format_text_spans(&p.footer, [1.0, 1.0, 1.0, 1.0]),
             });
         }
         ClientboundGamePacket::Commands(p) => {
@@ -743,6 +809,33 @@ fn send_chat(event_tx: &Sender<NetworkEvent>, message: &azalea_chat::FormattedTe
 fn send_action_bar(event_tx: &Sender<NetworkEvent>, message: &azalea_chat::FormattedText) {
     let spans = format_text_spans(message, [1.0; 4]);
     let _ = event_tx.try_send(NetworkEvent::ActionBar { spans });
+}
+
+fn send_scoreboard_team(
+    event_tx: &Sender<NetworkEvent>,
+    name: &str,
+    parameters: &azalea_protocol::packets::game::c_set_player_team::Parameters,
+    members: Option<Vec<String>>,
+) {
+    let color = team_color(parameters.color);
+    let _ = event_tx.try_send(NetworkEvent::ScoreboardTeam {
+        name: name.into(),
+        prefix: format_text_spans(&parameters.player_prefix, color),
+        suffix: format_text_spans(&parameters.player_suffix, color),
+        color,
+        members,
+    });
+}
+
+fn team_color(color: azalea_chat::style::ChatFormatting) -> [f32; 4] {
+    let hex = [
+        0x000000, 0x0000aa, 0x00aa00, 0x00aaaa, 0xaa0000, 0xaa00aa, 0xffaa00, 0xaaaaaa, 0x555555,
+        0x5555ff, 0x55ff55, 0x55ffff, 0xff5555, 0xff55ff, 0xffff55, 0xffffff,
+    ]
+    .get(color as usize)
+    .copied()
+    .unwrap_or(0xffffff);
+    crate::ui::common::rgb(hex)
 }
 
 /// Resolves a variant registry holder id to the mob's renderer pool slot.

--- a/pomme-client/src/net/handler.rs
+++ b/pomme-client/src/net/handler.rs
@@ -280,15 +280,26 @@ pub fn handle_game_packet(
         }
         ClientboundGamePacket::SetObjective(p) => {
             use azalea_protocol::packets::game::c_set_objective::Method;
-            let display = match &p.method {
-                Method::Add { display_name, .. } | Method::Change { display_name, .. } => {
-                    Some(format_text_spans(display_name, [1.0; 4]))
+            let (display, number_format) = match &p.method {
+                Method::Add {
+                    display_name,
+                    number_format,
+                    ..
                 }
-                Method::Remove => None,
+                | Method::Change {
+                    display_name,
+                    number_format,
+                    ..
+                } => (
+                    Some(format_text_spans(display_name, [1.0; 4])),
+                    objective_number_format(number_format),
+                ),
+                Method::Remove => (None, None),
             };
             let _ = event_tx.try_send(NetworkEvent::ScoreboardObjective {
                 name: p.objective_name.clone(),
                 display,
+                number_format,
             });
         }
         ClientboundGamePacket::SetDisplayObjective(p)
@@ -305,11 +316,14 @@ pub fn handle_game_packet(
             let _ = event_tx.try_send(NetworkEvent::ScoreboardScore {
                 owner: p.owner.clone(),
                 objective: p.objective_name.clone(),
-                score: p.score,
+                // Wire scores are signed varints; azalea models the field
+                // unsigned.
+                score: p.score as i32,
                 display: p
                     .display
                     .as_ref()
                     .map(|text| format_text_spans(text, [1.0; 4])),
+                number_format: p.number_format.as_ref().map(score_number_format),
             });
         }
         ClientboundGamePacket::ResetScore(p) => {
@@ -827,15 +841,49 @@ fn send_scoreboard_team(
     });
 }
 
+fn score_number_format(
+    format: &azalea_chat::numbers::NumberFormat,
+) -> crate::ui::hud::ScoreNumberFormat {
+    use azalea_chat::numbers::NumberFormat;
+
+    use crate::ui::hud::ScoreNumberFormat as F;
+    match format {
+        NumberFormat::Blank => F::Blank,
+        // Vanilla applies the style to the plain number; only the color
+        // matters for rendering, an unstyled number stays white.
+        NumberFormat::Styled { style } => F::Styled(styled_color(style).unwrap_or([1.0; 4])),
+        NumberFormat::Fixed { value } => F::Fixed(format_text_spans(value, [1.0; 4])),
+    }
+}
+
+/// azalea's `SetObjective` reads the number format without vanilla's
+/// `Optional` bool, so the decode lands shifted: vanilla `None` (the common
+/// case) arrives as `Blank`, vanilla `Blank` arrives as `Styled` with empty
+/// NBT, and real styled/fixed formats fail to decode the whole packet. Undo
+/// the shift for the two recoverable cases.
+fn objective_number_format(
+    format: &azalea_chat::numbers::NumberFormat,
+) -> Option<crate::ui::hud::ScoreNumberFormat> {
+    use azalea_chat::numbers::NumberFormat;
+    match format {
+        NumberFormat::Blank => None,
+        NumberFormat::Styled { style } if style.is_none() => {
+            Some(crate::ui::hud::ScoreNumberFormat::Blank)
+        }
+        other => Some(score_number_format(other)),
+    }
+}
+
+fn styled_color(style: &simdnbt::owned::Nbt) -> Option<[f32; 4]> {
+    let color = style
+        .iter()
+        .find_map(|(key, value)| (key.to_str() == "color").then(|| value.string()).flatten())?;
+    let value = azalea_chat::style::TextColor::parse(&color.to_str())?.value;
+    Some(crate::ui::common::rgb(value))
+}
+
 fn team_color(color: azalea_chat::style::ChatFormatting) -> [f32; 4] {
-    let hex = [
-        0x000000, 0x0000aa, 0x00aa00, 0x00aaaa, 0xaa0000, 0xaa00aa, 0xffaa00, 0xaaaaaa, 0x555555,
-        0x5555ff, 0x55ff55, 0x55ffff, 0xff5555, 0xff55ff, 0xffff55, 0xffffff,
-    ]
-    .get(color as usize)
-    .copied()
-    .unwrap_or(0xffffff);
-    crate::ui::common::rgb(hex)
+    crate::ui::common::rgb(color.color().unwrap_or(0xffffff))
 }
 
 /// Resolves a variant registry holder id to the mob's renderer pool slot.

--- a/pomme-client/src/net/handler.rs
+++ b/pomme-client/src/net/handler.rs
@@ -268,8 +268,15 @@ pub fn handle_game_packet(
                 walking_speed: p.walking_speed,
             });
         }
-        ClientboundGamePacket::SystemChat(p) if !p.overlay => {
-            send_chat(event_tx, &p.content);
+        ClientboundGamePacket::SystemChat(p) => {
+            if p.overlay {
+                send_action_bar(event_tx, &p.content);
+            } else {
+                send_chat(event_tx, &p.content);
+            }
+        }
+        ClientboundGamePacket::SetActionBarText(p) => {
+            send_action_bar(event_tx, &p.text);
         }
         ClientboundGamePacket::PlayerChat(p) => {
             send_chat(event_tx, &p.message());
@@ -731,6 +738,11 @@ fn send_chat(event_tx: &Sender<NetworkEvent>, message: &azalea_chat::FormattedTe
     let text: String = spans.iter().map(|s| s.text.as_str()).collect();
     tracing::info!("Chat: {text}");
     let _ = event_tx.try_send(NetworkEvent::ChatMessage { spans });
+}
+
+fn send_action_bar(event_tx: &Sender<NetworkEvent>, message: &azalea_chat::FormattedText) {
+    let spans = format_text_spans(message, [1.0; 4]);
+    let _ = event_tx.try_send(NetworkEvent::ActionBar { spans });
 }
 
 /// Resolves a variant registry holder id to the mob's renderer pool slot.

--- a/pomme-client/src/net/mod.rs
+++ b/pomme-client/src/net/mod.rs
@@ -133,6 +133,38 @@ pub enum NetworkEvent {
     ActionBar {
         spans: Vec<crate::ui::text::TextSpan>,
     },
+    ScoreboardObjective {
+        name: String,
+        display: Option<Vec<crate::ui::text::TextSpan>>,
+    },
+    ScoreboardDisplay {
+        name: Option<String>,
+    },
+    ScoreboardScore {
+        owner: String,
+        objective: String,
+        score: u32,
+        display: Option<Vec<crate::ui::text::TextSpan>>,
+    },
+    ScoreboardReset {
+        owner: String,
+        objective: Option<String>,
+    },
+    ScoreboardTeam {
+        name: String,
+        prefix: Vec<crate::ui::text::TextSpan>,
+        suffix: Vec<crate::ui::text::TextSpan>,
+        color: [f32; 4],
+        members: Option<Vec<String>>,
+    },
+    ScoreboardTeamMembers {
+        name: String,
+        members: Vec<String>,
+        join: bool,
+    },
+    ScoreboardTeamRemoved {
+        name: String,
+    },
     CommandTree {
         tree: Arc<crate::net::commands::CommandTree>,
     },
@@ -387,7 +419,7 @@ pub enum NetworkEvent {
         uuids: Vec<uuid::Uuid>,
     },
     TabListHeaderFooter {
-        header: String,
-        footer: String,
+        header: Vec<crate::ui::text::TextSpan>,
+        footer: Vec<crate::ui::text::TextSpan>,
     },
 }

--- a/pomme-client/src/net/mod.rs
+++ b/pomme-client/src/net/mod.rs
@@ -130,6 +130,9 @@ pub enum NetworkEvent {
     ChatMessage {
         spans: Vec<crate::ui::text::TextSpan>,
     },
+    ActionBar {
+        spans: Vec<crate::ui::text::TextSpan>,
+    },
     CommandTree {
         tree: Arc<crate::net::commands::CommandTree>,
     },

--- a/pomme-client/src/net/mod.rs
+++ b/pomme-client/src/net/mod.rs
@@ -136,6 +136,7 @@ pub enum NetworkEvent {
     ScoreboardObjective {
         name: String,
         display: Option<Vec<crate::ui::text::TextSpan>>,
+        number_format: Option<crate::ui::hud::ScoreNumberFormat>,
     },
     ScoreboardDisplay {
         name: Option<String>,
@@ -143,8 +144,9 @@ pub enum NetworkEvent {
     ScoreboardScore {
         owner: String,
         objective: String,
-        score: u32,
+        score: i32,
         display: Option<Vec<crate::ui::text::TextSpan>>,
+        number_format: Option<crate::ui::hud::ScoreNumberFormat>,
     },
     ScoreboardReset {
         owner: String,
@@ -408,6 +410,9 @@ pub enum NetworkEvent {
     ResourcePackPop {
         id: Option<uuid::Uuid>,
     },
+    /// The server re-entered the configuration phase (a proxy transfer);
+    /// world-scoped state resets like vanilla's `clearClientLevel`.
+    Reconfiguring,
     Disconnected {
         reason: String,
     },

--- a/pomme-client/src/net/translate.rs
+++ b/pomme-client/src/net/translate.rs
@@ -576,10 +576,17 @@ fn translate_entity_data(
         wire::write_varint(&mut out, new);
         let value_at = cur.position() as usize;
         if new == 7 {
-            translate_item_stack(&mut cur, &mut out, remaps)?;
-            continue;
+            let mut stack = Vec::new();
+            if translate_item_stack(&mut cur, &mut stack, remaps).is_some() {
+                out.extend_from_slice(&stack);
+                continue;
+            }
+            tracing::debug!("Copying entity data tail verbatim past an item stack");
+            out.extend_from_slice(&payload[value_at..]);
+            return Some(out);
         }
         if !skip_metadata_value(&mut cur, new)? {
+            tracing::debug!("Copying entity data tail verbatim past serializer {old}");
             out.extend_from_slice(&payload[value_at..]);
             return Some(out);
         }
@@ -589,6 +596,17 @@ fn translate_entity_data(
     Some(out)
 }
 
+/// Latest-registry component ids whose payloads the stack walker can advance
+/// past (26.2 `DataComponents` registration order; anchored in
+/// `component_id_anchors` in `azalea_compat`). Matching happens after the
+/// remap, so one set of ids serves every wire version.
+pub(crate) const COMPONENT_MAP_ID: u32 = 46;
+pub(crate) const COMPONENT_PROFILE: u32 = 70;
+
+/// Remaps one entity-data item stack (count, item id, component patch) into
+/// the latest registry space. `None` means a component payload the walker
+/// doesn't know (or a malformed stack); the caller falls back to the
+/// verbatim-tail copy.
 fn translate_item_stack(
     cur: &mut Cursor<&[u8]>,
     out: &mut Vec<u8>,
@@ -610,16 +628,14 @@ fn translate_item_stack(
     out.extend_from_slice(&cur.get_ref()[removed_at..cur.position() as usize]);
     for _ in 0..added {
         let component = u32::azalea_read_var(cur).ok()?;
-        wire::write_varint(
-            out,
-            remaps.remap(ClientRegistry::DataComponentType, component)?,
-        );
+        let latest = remaps.remap(ClientRegistry::DataComponentType, component)?;
+        wire::write_varint(out, latest);
         let value_at = cur.position() as usize;
-        match component {
-            44 => {
+        match latest {
+            COMPONENT_MAP_ID => {
                 varint_span(cur)?;
             }
-            68 => {
+            COMPONENT_PROFILE => {
                 Profile::azalea_read(cur).ok()?;
             }
             _ => return None,
@@ -890,6 +906,11 @@ fn translate_team(id: u32, payload: &[u8]) -> Option<Vec<u8>> {
         out.extend_from_slice(&payload[suffix]);
         out.extend_from_slice(&payload[visibility]);
         out.extend_from_slice(&payload[collision]);
+        // Vanilla 26.2 changed color from a ChatFormatting ordinal to
+        // Optional<TeamColor>, but azalea still decodes the plain ordinal,
+        // and these frames feed azalea — copy it through unchanged (all
+        // ordinals fit one varint byte). See the team tests in
+        // azalea_compat.
         out.push(color as u8);
         out.push(options);
     }

--- a/pomme-client/src/net/translate.rs
+++ b/pomme-client/src/net/translate.rs
@@ -54,8 +54,9 @@
 use std::io::Cursor;
 use std::sync::Mutex;
 
-use azalea_buf::AzBufVar;
+use azalea_buf::{AzBuf, AzBufVar};
 use azalea_core::sound::CustomSound;
+use azalea_inventory::components::Profile;
 use azalea_inventory::{ItemStack, ItemStackData};
 use azalea_protocol::packets::game::s_container_click::HashedStack;
 use azalea_protocol::packets::game::{ClientboundGamePacket, ServerboundGamePacket};
@@ -198,7 +199,7 @@ impl Translation {
             translate_team(id, payload)
         } else if let Some(ids) = &self.game_ids {
             if id == ids.set_entity_data_id {
-                translate_entity_data(id, payload, ids.serializer_map)
+                translate_entity_data(id, payload, ids.serializer_map, self.to_latest)
             } else if id == ids.level_chunk_id {
                 translate_chunk(id, payload)
             } else if id == ids.set_time_id {
@@ -556,6 +557,7 @@ fn translate_entity_data(
     id: u32,
     payload: &[u8],
     serializer_map: fn(u32) -> Option<u32>,
+    remaps: &RegistryRemaps,
 ) -> Option<Vec<u8>> {
     let mut cur = Cursor::new(payload);
     varint_span(&mut cur)?; // entity id
@@ -573,8 +575,11 @@ fn translate_entity_data(
         let new = serializer_map(old)?;
         wire::write_varint(&mut out, new);
         let value_at = cur.position() as usize;
+        if new == 7 {
+            translate_item_stack(&mut cur, &mut out, remaps)?;
+            continue;
+        }
         if !skip_metadata_value(&mut cur, new)? {
-            tracing::debug!("Copying entity data tail verbatim past serializer {old}");
             out.extend_from_slice(&payload[value_at..]);
             return Some(out);
         }
@@ -582,6 +587,53 @@ fn translate_entity_data(
     }
     out.extend_from_slice(&payload[cur.position() as usize..]);
     Some(out)
+}
+
+fn translate_item_stack(
+    cur: &mut Cursor<&[u8]>,
+    out: &mut Vec<u8>,
+    remaps: &RegistryRemaps,
+) -> Option<()> {
+    let count_at = cur.position() as usize;
+    let count = i32::azalea_read_var(cur).ok()?;
+    out.extend_from_slice(&cur.get_ref()[count_at..cur.position() as usize]);
+    if count <= 0 {
+        return Some(());
+    }
+    let item = u32::azalea_read_var(cur).ok()?;
+    wire::write_varint(out, remaps.remap(ClientRegistry::Item, item)?);
+    let added_at = cur.position() as usize;
+    let added = u32::azalea_read_var(cur).ok()?;
+    out.extend_from_slice(&cur.get_ref()[added_at..cur.position() as usize]);
+    let removed_at = cur.position() as usize;
+    let removed = u32::azalea_read_var(cur).ok()?;
+    out.extend_from_slice(&cur.get_ref()[removed_at..cur.position() as usize]);
+    for _ in 0..added {
+        let component = u32::azalea_read_var(cur).ok()?;
+        wire::write_varint(
+            out,
+            remaps.remap(ClientRegistry::DataComponentType, component)?,
+        );
+        let value_at = cur.position() as usize;
+        match component {
+            44 => {
+                varint_span(cur)?;
+            }
+            68 => {
+                Profile::azalea_read(cur).ok()?;
+            }
+            _ => return None,
+        }
+        out.extend_from_slice(&cur.get_ref()[value_at..cur.position() as usize]);
+    }
+    for _ in 0..removed {
+        let component = u32::azalea_read_var(cur).ok()?;
+        wire::write_varint(
+            out,
+            remaps.remap(ClientRegistry::DataComponentType, component)?,
+        );
+    }
+    Some(())
 }
 
 /// Advances past one entity-data value of the given latest-version
@@ -596,6 +648,14 @@ fn skip_metadata_value(cur: &mut Cursor<&[u8]>, serializer: u32) -> Option<bool>
         10 => advance(cur, 8)?,    // block_pos
         39 => advance(cur, 12)?,   // vector3
         40 => advance(cur, 16)?,   // quaternion
+        41 => {
+            Profile::azalea_read(cur).ok()?;
+        }
+        17 => {
+            if u32::azalea_read_var(cur).ok()? != 0 {
+                return Some(false);
+            }
+        }
         // varint-shaped: int, enums, registry/holder ids, optional ints
         1 | 12 | 14 | 15 | 19 | 20 | 21 | 22..=32 | 35..=38 | 42 => {
             varint_span(cur)?;
@@ -830,14 +890,7 @@ fn translate_team(id: u32, payload: &[u8]) -> Option<Vec<u8>> {
         out.extend_from_slice(&payload[suffix]);
         out.extend_from_slice(&payload[visibility]);
         out.extend_from_slice(&payload[collision]);
-        // ChatFormatting ordinals 0..=15 are the colors, in TeamColor id
-        // order; formats (16..=20) and RESET (21) have no team color.
-        if color <= 15 {
-            out.push(1);
-            out.push(color as u8);
-        } else {
-            out.push(0);
-        }
+        out.push(color as u8);
         out.push(options);
     }
 

--- a/pomme-client/src/player/tab_list.rs
+++ b/pomme-client/src/player/tab_list.rs
@@ -2,6 +2,9 @@ use std::collections::HashMap;
 
 use uuid::Uuid;
 
+use crate::ui::hud::Scoreboard;
+use crate::ui::text::TextSpan;
+
 #[derive(Clone, Debug)]
 pub struct PlayerInfoEntry {
     pub uuid: Uuid,
@@ -11,7 +14,7 @@ pub struct PlayerInfoEntry {
     pub game_mode: u8,
     pub listed: bool,
     pub latency: i32,
-    pub display_name: Option<String>,
+    pub display_name: Option<Vec<TextSpan>>,
     pub list_order: i32,
 }
 
@@ -31,7 +34,7 @@ pub struct TabListPlayer {
     pub uuid: Uuid,
     pub name: String,
     pub textures: Option<String>,
-    pub display_name: Option<String>,
+    pub display_name: Option<Vec<TextSpan>>,
     pub game_mode: u8,
     pub latency: i32,
     pub listed: bool,
@@ -41,8 +44,8 @@ pub struct TabListPlayer {
 #[derive(Default)]
 pub struct TabList {
     pub players: HashMap<Uuid, TabListPlayer>,
-    pub header: Option<String>,
-    pub footer: Option<String>,
+    pub header: Option<Vec<TextSpan>>,
+    pub footer: Option<Vec<TextSpan>>,
 }
 
 impl TabList {
@@ -101,19 +104,24 @@ impl TabList {
         }
     }
 
-    pub fn set_header_footer(&mut self, header: String, footer: String) {
+    pub fn set_header_footer(&mut self, header: Vec<TextSpan>, footer: Vec<TextSpan>) {
         self.header = (!header.is_empty()).then_some(header);
         self.footer = (!footer.is_empty()).then_some(footer);
     }
 
     /// Vanilla PlayerTabOverlay PLAYER_COMPARATOR (PlayerTabOverlay.java:63).
     /// Teams aren't tracked, so the team-name tiebreaker is skipped.
-    pub fn sorted_listed(&self) -> Vec<&TabListPlayer> {
+    pub fn sorted_listed(&self, scoreboard: &Scoreboard) -> Vec<&TabListPlayer> {
         let mut out: Vec<&TabListPlayer> = self.players.values().filter(|p| p.listed).collect();
         out.sort_by(|a, b| {
             a.list_order
                 .cmp(&b.list_order)
                 .then_with(|| (a.game_mode == 3).cmp(&(b.game_mode == 3)))
+                .then_with(|| {
+                    scoreboard
+                        .team_name(&a.name)
+                        .cmp(scoreboard.team_name(&b.name))
+                })
                 .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
         });
         out.truncate(80);

--- a/pomme-client/src/player/tab_list.rs
+++ b/pomme-client/src/player/tab_list.rs
@@ -110,7 +110,6 @@ impl TabList {
     }
 
     /// Vanilla PlayerTabOverlay PLAYER_COMPARATOR (PlayerTabOverlay.java:63).
-    /// Teams aren't tracked, so the team-name tiebreaker is skipped.
     pub fn sorted_listed(&self, scoreboard: &Scoreboard) -> Vec<&TabListPlayer> {
         let mut out: Vec<&TabListPlayer> = self.players.values().filter(|p| p.listed).collect();
         out.sort_by(|a, b| {

--- a/pomme-client/src/player/tab_list.rs
+++ b/pomme-client/src/player/tab_list.rs
@@ -113,8 +113,9 @@ impl TabList {
     pub fn sorted_listed(&self, scoreboard: &Scoreboard) -> Vec<&TabListPlayer> {
         let mut out: Vec<&TabListPlayer> = self.players.values().filter(|p| p.listed).collect();
         out.sort_by(|a, b| {
-            a.list_order
-                .cmp(&b.list_order)
+            // `comparingInt(p -> -p.getTabListOrder())`: higher order first.
+            b.list_order
+                .cmp(&a.list_order)
                 .then_with(|| (a.game_mode == 3).cmp(&(b.game_mode == 3)))
                 .then_with(|| {
                     scoreboard

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -889,6 +889,21 @@ impl Renderer {
         self.camera.anchor()
     }
 
+    pub fn project_world_to_screen(&self, position: glam::DVec3) -> Option<(f32, f32)> {
+        let clip = self.camera.view_rotation_projection()
+            * (position - self.camera_render_position())
+                .as_vec3()
+                .extend(1.0);
+        if clip.w <= 0.0 {
+            return None;
+        }
+        let ndc = clip.truncate() / clip.w;
+        (ndc.x.abs() <= 1.0 && ndc.y.abs() <= 1.0 && ndc.z.abs() <= 1.0).then_some((
+            (ndc.x + 1.0) * self.width as f32 * 0.5,
+            (1.0 - ndc.y) * self.height as f32 * 0.5,
+        ))
+    }
+
     /// Six normalized frustum planes (camera-relative, same convention as the
     /// GPU cull), for CPU-side visibility classification of
     /// mesh-scheduling.

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -1275,6 +1275,10 @@ impl Renderer {
         self.menu_pipeline.mc_text_width_sga(text, scale)
     }
 
+    pub fn menu_spans_width(&self, spans: &[crate::ui::text::TextSpan], scale: f32) -> f32 {
+        self.menu_pipeline.spans_width(spans, scale)
+    }
+
     /// Builds the item mesh if needed; returns whether it has a 3D model
     /// (vs a flat sprite), used to pick the first-person transform.
     pub fn ensure_item_mesh(&mut self, name: &str) -> pipelines::item_entity::ItemMeshInfo {

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -733,13 +733,12 @@ impl MenuOverlayPipeline {
                     scale,
                     centered,
                 } => {
+                    let start_x = if *centered {
+                        *x - self.spans_width(spans, *scale) / 2.0
+                    } else {
+                        *x
+                    };
                     if let Some(ref gm) = self.mc_glyph_map {
-                        let text: String = spans.iter().map(|span| span.text.as_str()).collect();
-                        let start_x = if *centered {
-                            *x - self.mc_text_width(&text, *scale) / 2.0
-                        } else {
-                            *x
-                        };
                         push_mc_text(&mut vertices, gm, start_x, *y, spans, *scale, true);
                     }
                 }
@@ -1338,15 +1337,21 @@ impl MenuOverlayPipeline {
         raw.ceil()
     }
 
-    /// Width of a multi-span line, honoring each span's font.
-    fn spans_width(&self, spans: &[TextSpan], scale: f32) -> f32 {
+    /// Width of a multi-span line, honoring each span's font and the extra
+    /// per-glyph advance of bold text.
+    pub fn spans_width(&self, spans: &[TextSpan], scale: f32) -> f32 {
         let Some(ref gm) = self.mc_glyph_map else {
             return 0.0;
         };
         let px_scale = scale / gm.cell_h as f32;
         let raw: f32 = spans
             .iter()
-            .flat_map(|s| s.text.chars().map(|ch| glyph_advance(gm, ch, s.sga)))
+            .flat_map(|s| {
+                let bold = if s.bold { 1.0 } else { 0.0 };
+                s.text
+                    .chars()
+                    .map(move |ch| glyph_advance(gm, ch, s.sga) + bold)
+            })
             .sum::<f32>()
             * px_scale;
         raw.ceil()

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -726,6 +726,23 @@ impl MenuOverlayPipeline {
                         push_mc_text(&mut vertices, gm, *x, *y, &[span], *scale, false);
                     }
                 }
+                MenuElement::TextSpans {
+                    x,
+                    y,
+                    spans,
+                    scale,
+                    centered,
+                } => {
+                    if let Some(ref gm) = self.mc_glyph_map {
+                        let text: String = spans.iter().map(|span| span.text.as_str()).collect();
+                        let start_x = if *centered {
+                            *x - self.mc_text_width(&text, *scale) / 2.0
+                        } else {
+                            *x
+                        };
+                        push_mc_text(&mut vertices, gm, start_x, *y, spans, *scale, true);
+                    }
+                }
                 MenuElement::Icon {
                     x,
                     y,
@@ -1458,6 +1475,13 @@ pub enum MenuElement {
         text: String,
         scale: f32,
         color: [f32; 4],
+        centered: bool,
+    },
+    TextSpans {
+        x: f32,
+        y: f32,
+        spans: Vec<crate::ui::text::TextSpan>,
+        scale: f32,
         centered: bool,
     },
     TextFlat {

--- a/pomme-client/src/ui/anvil.rs
+++ b/pomme-client/src/ui/anvil.rs
@@ -47,8 +47,6 @@ impl AnvilState {
     }
 }
 
-/// The item's hover name: custom name, else item-name component, else the
-/// translated kind name.
 /// Applies this frame's typing to the rename field, mirroring vanilla
 /// `AnvilScreen.slotChanged` + `onNameChanged`: reset the text when input
 /// slot 0 changes, edit it while the slot is filled, normalize an unchanged

--- a/pomme-client/src/ui/anvil.rs
+++ b/pomme-client/src/ui/anvil.rs
@@ -4,8 +4,7 @@
 
 use std::time::Instant;
 
-use azalea_inventory::components::{CustomName, ItemName};
-use azalea_inventory::{ItemStack, ItemStackData};
+use azalea_inventory::ItemStack;
 
 use super::common::{FONT_SIZE, WHITE, push_field_text};
 use super::container::{
@@ -50,16 +49,6 @@ impl AnvilState {
 
 /// The item's hover name: custom name, else item-name component, else the
 /// translated kind name.
-fn hover_name(data: &ItemStackData) -> String {
-    if let Some(c) = data.get_component::<CustomName>() {
-        return c.name.to_string();
-    }
-    if let Some(c) = data.get_component::<ItemName>() {
-        return c.name.to_string();
-    }
-    crate::lang::item_display_name(data.kind)
-}
-
 /// Applies this frame's typing to the rename field, mirroring vanilla
 /// `AnvilScreen.slotChanged` + `onNameChanged`: reset the text when input
 /// slot 0 changes, edit it while the slot is filled, normalize an unchanged
@@ -73,7 +62,10 @@ pub fn update_rename(
 ) -> Option<String> {
     let input = slots.first().cloned().unwrap_or(ItemStack::Empty);
     if input != state.last_input {
-        let name = input.as_present().map(hover_name).unwrap_or_default();
+        let name = input
+            .as_present()
+            .map(super::common::item_display_name)
+            .unwrap_or_default();
         state.field.set_value(&name, FIELD_INNER_W, width_fn);
         state.last_input = input.clone();
     }
@@ -89,7 +81,11 @@ pub fn update_rename(
     }
 
     let mut name = state.field.value().to_string();
-    if data.get_component::<CustomName>().is_none() && name == hover_name(data) {
+    if data
+        .get_component::<azalea_inventory::components::CustomName>()
+        .is_none()
+        && name == super::common::item_display_name(data)
+    {
         name = String::new();
     }
     if name != state.sent {

--- a/pomme-client/src/ui/common.rs
+++ b/pomme-client/src/ui/common.rs
@@ -1,3 +1,4 @@
+use azalea_inventory::components::{CustomName, ItemName};
 use azalea_inventory::{ItemStack, ItemStackData};
 
 use crate::benchmark::UploadStatus;
@@ -13,6 +14,16 @@ pub const SLOT_SIZE: f32 = 16.0;
 pub const SLOT_STRIDE: f32 = 18.0;
 pub const SLOT_LABEL_COLOR: [f32; 4] = [0.25, 0.25, 0.25, 1.0];
 const BTN_BORDER: f32 = 3.0;
+
+pub fn item_display_name(data: &ItemStackData) -> String {
+    if let Some(name) = data.get_component::<CustomName>() {
+        return name.name.to_string();
+    }
+    if let Some(name) = data.get_component::<ItemName>() {
+        return name.name.to_string();
+    }
+    crate::lang::item_display_name(data.kind)
+}
 
 pub const fn rgb(hex: u32) -> [f32; 4] {
     [

--- a/pomme-client/src/ui/common.rs
+++ b/pomme-client/src/ui/common.rs
@@ -15,14 +15,37 @@ pub const SLOT_STRIDE: f32 = 18.0;
 pub const SLOT_LABEL_COLOR: [f32; 4] = [0.25, 0.25, 0.25, 1.0];
 const BTN_BORDER: f32 = 3.0;
 
-pub fn item_display_name(data: &ItemStackData) -> String {
+pub type SpansWidthFn<'a> = &'a dyn Fn(&[crate::ui::text::TextSpan], f32) -> f32;
+
+/// The hover-name component: custom name, else item-name component.
+fn item_hover_component(data: &ItemStackData) -> Option<azalea_chat::FormattedText> {
     if let Some(name) = data.get_component::<CustomName>() {
-        return name.name.to_string();
+        return Some(name.name.clone());
     }
-    if let Some(name) = data.get_component::<ItemName>() {
-        return name.name.to_string();
-    }
-    crate::lang::item_display_name(data.kind)
+    data.get_component::<ItemName>()
+        .map(|name| name.name.clone())
+}
+
+pub fn item_display_name(data: &ItemStackData) -> String {
+    item_hover_component(data)
+        .map(|name| name.to_string())
+        .unwrap_or_else(|| crate::lang::item_display_name(data.kind))
+}
+
+/// The hover name as styled spans; `base_color` fills wherever the name
+/// component carries no explicit color (vanilla's parent style).
+pub fn item_display_spans(
+    data: &ItemStackData,
+    base_color: [f32; 4],
+) -> Vec<crate::ui::text::TextSpan> {
+    item_hover_component(data)
+        .map(|name| crate::ui::text::format_text_spans(&name, base_color))
+        .unwrap_or_else(|| {
+            vec![crate::ui::text::TextSpan::new(
+                crate::lang::item_display_name(data.kind),
+                base_color,
+            )]
+        })
 }
 
 pub const fn rgb(hex: u32) -> [f32; 4] {

--- a/pomme-client/src/ui/font.rs
+++ b/pomme-client/src/ui/font.rs
@@ -137,6 +137,51 @@ impl GlyphMap {
             pixels.extend_from_slice(sga.as_raw());
         }
 
+        let nonlatin_path = resolve_asset_path(
+            jar_assets_dir,
+            asset_index,
+            "minecraft/textures/font/nonlatin_european.png",
+        );
+        if let Ok(image) = load_image(&nonlatin_path) {
+            let nonlatin = image.to_rgba8();
+            if nonlatin.width() == tex_w && nonlatin.width() % GRID_COLS == 0 {
+                let nonlatin_cell_w = nonlatin.width() / GRID_COLS;
+                let base_row = tex_h / cell_h;
+                let cyrillic_rows = [
+                    "ЅІЈЉЊЋАБВГДЕЖЗИК",
+                    "ЛМНОПРСТУФХЦЧШЩЪ",
+                    "ЫЬЭЮЯабвгдежзикл",
+                    "мнопрстуфхцчшщъы",
+                    "ьэюяєѕіјљњ–—‘’“”",
+                ];
+                for (source_row, chars) in cyrillic_rows.iter().enumerate() {
+                    for (col, ch) in chars.chars().enumerate() {
+                        let Some((width, y_offset, height)) = detect_glyph_bounds(
+                            &nonlatin,
+                            col as u32 * nonlatin_cell_w,
+                            (source_row as u32 + 4) * nonlatin_cell_w,
+                            nonlatin_cell_w,
+                            nonlatin_cell_w,
+                        ) else {
+                            continue;
+                        };
+                        glyphs.insert(
+                            ch,
+                            GlyphInfo {
+                                col: col as u32,
+                                row: base_row + source_row as u32 + 4,
+                                width,
+                                y_offset,
+                                height,
+                            },
+                        );
+                    }
+                }
+                pixels.extend_from_slice(nonlatin.as_raw());
+                tex_h += nonlatin.height();
+            }
+        }
+
         Some(Self {
             glyphs,
             sga_glyphs,

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet};
+
 use azalea_core::position::BlockPos;
 use azalea_inventory::ItemStack;
 use glam::DVec3;
@@ -26,6 +28,141 @@ pub struct FrameTimings {
     pub cull_ms: f32,
     pub draw_ms: f32,
     pub present_ms: f32,
+}
+
+#[derive(Default)]
+pub struct Scoreboard {
+    sidebar: Option<String>,
+    objectives: HashMap<String, Vec<TextSpan>>,
+    scores: HashMap<(String, String), (u32, Option<Vec<TextSpan>>)>,
+    teams: HashMap<String, ScoreboardTeam>,
+}
+
+struct ScoreboardTeam {
+    prefix: Vec<TextSpan>,
+    suffix: Vec<TextSpan>,
+    color: [f32; 4],
+    members: HashSet<String>,
+}
+
+impl Scoreboard {
+    pub fn clear(&mut self) {
+        self.sidebar = None;
+        self.objectives.clear();
+        self.scores.clear();
+        self.teams.clear();
+    }
+
+    pub fn set_objective(&mut self, name: String, display: Option<Vec<TextSpan>>) {
+        if let Some(display) = display {
+            self.objectives.insert(name, display);
+        } else {
+            self.objectives.remove(&name);
+            self.scores.retain(|(objective, _), _| objective != &name);
+            if self.sidebar.as_deref() == Some(&name) {
+                self.sidebar = None;
+            }
+        }
+    }
+
+    pub fn set_display(&mut self, name: Option<String>) {
+        self.sidebar = name;
+    }
+
+    pub fn set_score(
+        &mut self,
+        owner: String,
+        objective: String,
+        score: u32,
+        display: Option<Vec<TextSpan>>,
+    ) {
+        self.scores.insert((objective, owner), (score, display));
+    }
+
+    pub fn reset_score(&mut self, owner: &str, objective: Option<&str>) {
+        self.scores.retain(|(entry_objective, entry_owner), _| {
+            entry_owner != owner || objective.is_some_and(|objective| entry_objective != objective)
+        });
+    }
+
+    pub fn set_team(
+        &mut self,
+        name: String,
+        prefix: Vec<TextSpan>,
+        suffix: Vec<TextSpan>,
+        color: [f32; 4],
+        members: Option<Vec<String>>,
+    ) {
+        if let Some(members) = &members {
+            for team in self.teams.values_mut() {
+                team.members.retain(|member| !members.contains(member));
+            }
+        }
+        let team = self.teams.entry(name).or_insert_with(|| ScoreboardTeam {
+            prefix: Vec::new(),
+            suffix: Vec::new(),
+            color,
+            members: HashSet::new(),
+        });
+        team.prefix = prefix;
+        team.suffix = suffix;
+        team.color = color;
+        if let Some(members) = members {
+            team.members = members.into_iter().collect();
+        }
+    }
+
+    pub fn update_team_members(&mut self, name: &str, members: Vec<String>, join: bool) {
+        if join {
+            for team in self.teams.values_mut() {
+                team.members.retain(|member| !members.contains(member));
+            }
+        }
+        if let Some(team) = self.teams.get_mut(name) {
+            for member in members {
+                if join {
+                    team.members.insert(member);
+                } else {
+                    team.members.remove(&member);
+                }
+            }
+        }
+    }
+
+    pub fn remove_team(&mut self, name: &str) {
+        self.teams.remove(name);
+    }
+
+    pub fn player_name(&self, name: &str, display: Option<&[TextSpan]>) -> Vec<TextSpan> {
+        display
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| self.line(name, None))
+    }
+
+    pub fn team_name(&self, member: &str) -> &str {
+        self.teams
+            .iter()
+            .find(|(_, team)| team.members.contains(member))
+            .map_or("", |(name, _)| name)
+    }
+
+    fn line(&self, owner: &str, display: Option<&[TextSpan]>) -> Vec<TextSpan> {
+        let team = self
+            .teams
+            .values()
+            .find(|team| team.members.contains(owner));
+        let mut line = team.map_or_else(Vec::new, |team| team.prefix.clone());
+        line.extend(display.map(ToOwned::to_owned).unwrap_or_else(|| {
+            vec![TextSpan::new(
+                owner.into(),
+                team.map_or(WHITE, |team| team.color),
+            )]
+        }));
+        if let Some(team) = team {
+            line.extend(team.suffix.clone());
+        }
+        line
+    }
 }
 
 pub struct DebugInfo<'a> {
@@ -103,6 +240,7 @@ pub fn build_hud(
     hotbar: &[ItemStack],
     held_item_tooltip_ticks: Option<u64>,
     action_bar: Option<(&[TextSpan], u64)>,
+    scoreboard: &Scoreboard,
     first_person: bool,
     debug: Option<&DebugInfo<'_>>,
     gui_scale_setting: u32,
@@ -199,6 +337,8 @@ pub fn build_hud(
             shadow: true,
         });
     }
+
+    build_scoreboard(elements, screen_w, screen_h, gs, scoreboard, text_width_fn);
 
     let status_bar_y = (hotbar_y - (XP_BAR_H + 1.0 + 2.0) * gs).round();
     let is_survival = crate::player::is_survival(game_mode);
@@ -352,6 +492,91 @@ pub fn build_hud(
             });
         }
     }
+}
+
+fn build_scoreboard(
+    elements: &mut Vec<MenuElement>,
+    screen_w: f32,
+    screen_h: f32,
+    gs: f32,
+    scoreboard: &Scoreboard,
+    text_width_fn: TextWidthFn,
+) {
+    let Some(objective) = scoreboard.sidebar.as_ref() else {
+        return;
+    };
+    let Some(title) = scoreboard.objectives.get(objective) else {
+        return;
+    };
+    let mut entries: Vec<_> = scoreboard
+        .scores
+        .iter()
+        .filter_map(|((entry_objective, owner), (score, display))| {
+            (entry_objective == objective)
+                .then(|| (*score, owner, scoreboard.line(owner, display.as_deref())))
+        })
+        .collect();
+    entries.sort_by(|(a_score, a, _), (b_score, b, _)| b_score.cmp(a_score).then_with(|| a.cmp(b)));
+    entries.truncate(15);
+    if entries.is_empty() {
+        return;
+    }
+
+    let fs = FONT_SIZE * gs;
+    let right = screen_w - 4.0 * gs;
+    let title_w = spans_width(title, fs, text_width_fn);
+    let width = entries.iter().fold(title_w, |width, (score, _, spans)| {
+        width.max(
+            spans_width(spans, fs, text_width_fn)
+                + text_width_fn(&score.to_string(), fs)
+                + 5.0 * gs,
+        )
+    });
+    let x = right - width - 2.0 * gs;
+    let line_h = 9.0 * gs;
+    let y = (screen_h - (entries.len() as f32 + 1.0) * line_h) / 2.0;
+    elements.push(MenuElement::Rect {
+        x,
+        y,
+        w: width + 4.0 * gs,
+        h: (entries.len() as f32 + 1.0) * line_h,
+        corner_radius: 0.0,
+        color: [0.0, 0.0, 0.0, 0.5],
+    });
+    elements.push(MenuElement::McText {
+        x: right - width / 2.0,
+        y,
+        spans: title.clone(),
+        scale: fs,
+        centered: true,
+        shadow: true,
+    });
+    for (index, (score, _, spans)) in entries.iter().enumerate() {
+        let row_y = y + (index as f32 + 1.0) * line_h;
+        elements.push(MenuElement::McText {
+            x: x + 2.0 * gs,
+            y: row_y,
+            spans: spans.clone(),
+            scale: fs,
+            centered: false,
+            shadow: true,
+        });
+        elements.push(MenuElement::Text {
+            x: right - text_width_fn(&score.to_string(), fs),
+            y: row_y,
+            text: score.to_string(),
+            scale: fs,
+            color: [1.0, 0.33, 0.33, 1.0],
+            centered: false,
+        });
+    }
+}
+
+fn spans_width(spans: &[TextSpan], scale: f32, text_width_fn: TextWidthFn) -> f32 {
+    spans
+        .iter()
+        .map(|span| text_width_fn(&span.text, scale))
+        .sum()
 }
 
 /// Right-aligned status icon x, matching vanilla `xRight - i * 8 - 9`.

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -100,6 +100,7 @@ pub fn build_hud(
     bar: ContextualBarKind<'_>,
     game_mode: u8,
     hotbar: &[ItemStack],
+    held_item_tooltip_ticks: Option<u64>,
     first_person: bool,
     debug: Option<&DebugInfo<'_>>,
     gui_scale_setting: u32,
@@ -160,6 +161,22 @@ pub fn build_hud(
             if data.count > 1 {
                 push_item_count(elements, ix, iy, item_size, gs, data.count);
             }
+        }
+    }
+
+    if let Some(ticks) = held_item_tooltip_ticks
+        && let Some(ItemStack::Present(data)) = hotbar.get(selected_slot as usize)
+    {
+        let alpha = ((60_u64.saturating_sub(ticks)).min(10) as f32) / 10.0;
+        if alpha > 0.0 {
+            elements.push(MenuElement::Text {
+                x: cx,
+                y: hotbar_y - 24.0 * gs,
+                text: super::common::item_display_name(data),
+                scale: FONT_SIZE * gs,
+                color: [1.0, 1.0, 1.0, alpha],
+                centered: true,
+            });
         }
     }
 

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -100,7 +100,9 @@ impl Scoreboard {
     }
 
     pub fn set_display(&mut self, name: Option<String>) {
-        self.sidebar = name;
+        // Vanilla resolves the objective at packet time; an unknown name
+        // leaves the slot empty even if the objective arrives later.
+        self.sidebar = name.filter(|name| self.objectives.contains_key(name));
     }
 
     pub fn set_score(
@@ -111,6 +113,10 @@ impl Scoreboard {
         display: Option<Vec<TextSpan>>,
         number_format: Option<ScoreNumberFormat>,
     ) {
+        // Vanilla drops scores for objectives it doesn't know.
+        if !self.objectives.contains_key(&objective) {
+            return;
+        }
         self.scores.insert(
             (objective, owner),
             ScoreEntry {
@@ -135,10 +141,13 @@ impl Scoreboard {
         color: [f32; 4],
         members: Option<Vec<String>>,
     ) {
+        // Vanilla ignores a parameter change for a team it doesn't know;
+        // only method ADD creates one.
+        if members.is_none() && !self.teams.contains_key(&name) {
+            return;
+        }
         if let Some(members) = &members {
-            for team in self.teams.values_mut() {
-                team.members.retain(|member| !members.contains(member));
-            }
+            self.strip_members(members);
         }
         let team = self.teams.entry(name).or_insert_with(|| ScoreboardTeam {
             prefix: Vec::new(),
@@ -149,16 +158,21 @@ impl Scoreboard {
         team.prefix = prefix;
         team.suffix = suffix;
         team.color = color;
+        // ADD unions its player list onto an existing team, like vanilla's
+        // addPlayerTeam + per-player addPlayerToTeam.
         if let Some(members) = members {
-            team.members = members.into_iter().collect();
+            team.members.extend(members);
         }
     }
 
     pub fn update_team_members(&mut self, name: &str, members: Vec<String>, join: bool) {
+        // Vanilla ignores joins/leaves for unknown teams without touching
+        // other teams' rosters.
+        if !self.teams.contains_key(name) {
+            return;
+        }
         if join {
-            for team in self.teams.values_mut() {
-                team.members.retain(|member| !members.contains(member));
-            }
+            self.strip_members(&members);
         }
         if let Some(team) = self.teams.get_mut(name) {
             for member in members {
@@ -173,6 +187,13 @@ impl Scoreboard {
 
     pub fn remove_team(&mut self, name: &str) {
         self.teams.remove(name);
+    }
+
+    /// Team membership is exclusive: joining players leave their old team.
+    fn strip_members(&mut self, members: &[String]) {
+        for team in self.teams.values_mut() {
+            team.members.retain(|member| !members.contains(member));
+        }
     }
 
     pub fn player_name(&self, name: &str, display: Option<&[TextSpan]>) -> Vec<TextSpan> {
@@ -194,12 +215,29 @@ impl Scoreboard {
             .values()
             .find(|team| team.members.contains(owner));
         let mut line = team.map_or_else(Vec::new, |team| team.prefix.clone());
-        line.extend(display.map(ToOwned::to_owned).unwrap_or_else(|| {
-            vec![TextSpan::new(
-                owner.into(),
-                team.map_or(WHITE, |team| team.color),
-            )]
-        }));
+        line.extend(display.map_or_else(
+            || {
+                vec![TextSpan::new(
+                    owner.into(),
+                    team.map_or(WHITE, |team| team.color),
+                )]
+            },
+            |display| {
+                let mut display = display.to_owned();
+                // Vanilla's team color is the root style over the display
+                // component too; spans were formatted with a white base, so
+                // recolor the base-white ones (an explicitly white-styled
+                // span is indistinguishable and rare).
+                if let Some(team) = team {
+                    for span in &mut display {
+                        if span.color == WHITE {
+                            span.color = team.color;
+                        }
+                    }
+                }
+                display
+            },
+        ));
         if let Some(team) = team {
             line.extend(team.suffix.clone());
         }
@@ -282,6 +320,7 @@ pub fn build_hud(
     hotbar: &[ItemStack],
     tool_highlight_timer: u32,
     action_bar: Option<(&[TextSpan], u64)>,
+    spans_width_fn: super::common::SpansWidthFn<'_>,
     scoreboard: &Scoreboard,
     first_person: bool,
     debug: Option<&DebugInfo<'_>>,
@@ -356,15 +395,20 @@ pub fn build_hud(
         use azalea_inventory::components::{CustomName, Rarity};
         let alpha = (tool_highlight_timer as f32 * 256.0 / 10.0 / 255.0).min(1.0);
         // Default-component rarities aren't synced; absent means common.
-        let mut color = match data.get_component::<Rarity>().as_deref() {
+        let color = match data.get_component::<Rarity>().as_deref() {
             Some(Rarity::Uncommon) => super::common::rgb(0xffff55),
             Some(Rarity::Rare) => super::common::rgb(0x55ffff),
             Some(Rarity::Epic) => super::common::rgb(0xff55ff),
             _ => WHITE,
         };
-        color[3] = alpha;
-        let mut span = TextSpan::new(super::common::item_display_name(data), color);
-        span.italic = data.get_component::<CustomName>().is_some();
+        // The rarity color and custom-name italic are vanilla's parent
+        // style: the name's own styling wins where it sets one.
+        let italic = data.get_component::<CustomName>().is_some();
+        let mut spans = super::common::item_display_spans(data, color);
+        for span in &mut spans {
+            span.color[3] *= alpha;
+            span.italic |= italic;
+        }
         let mut y = screen_h - 59.0 * gs;
         if game_mode == 1 {
             y += 14.0 * gs;
@@ -372,7 +416,7 @@ pub fn build_hud(
         elements.push(MenuElement::McText {
             x: cx,
             y,
-            spans: vec![span],
+            spans,
             scale: FONT_SIZE * gs,
             centered: true,
             shadow: true,
@@ -398,7 +442,15 @@ pub fn build_hud(
         });
     }
 
-    build_scoreboard(elements, screen_w, screen_h, gs, scoreboard, text_width_fn);
+    build_scoreboard(
+        elements,
+        screen_w,
+        screen_h,
+        gs,
+        scoreboard,
+        text_width_fn,
+        spans_width_fn,
+    );
 
     let status_bar_y = (hotbar_y - (XP_BAR_H + 1.0 + 2.0) * gs).round();
     let is_survival = crate::player::is_survival(game_mode);
@@ -566,6 +618,7 @@ fn build_scoreboard(
     gs: f32,
     scoreboard: &Scoreboard,
     text_width_fn: TextWidthFn,
+    spans_width_fn: super::common::SpansWidthFn<'_>,
 ) {
     let Some(objective) = scoreboard.sidebar.as_ref() else {
         return;
@@ -588,9 +641,6 @@ fn build_scoreboard(
             .then_with(|| a.to_lowercase().cmp(&b.to_lowercase()))
     });
     entries.truncate(15);
-    if entries.is_empty() {
-        return;
-    }
     let rows: Vec<(Vec<TextSpan>, Vec<TextSpan>, f32)> = entries
         .iter()
         .map(|((_, owner), entry)| {
@@ -608,13 +658,13 @@ fn build_scoreboard(
                 }
                 ScoreNumberFormat::Fixed(spans) => spans,
             };
-            let number_w = spans_width(&number, fs, text_width_fn);
+            let number_w = spans_width_fn(&number, fs);
             (name, number, number_w)
         })
         .collect();
 
     let title = &obj.display;
-    let title_w = spans_width(title, fs, text_width_fn);
+    let title_w = spans_width_fn(title, fs);
     let spacer_w = text_width_fn(": ", fs);
     let width = rows.iter().fold(title_w, |width, (name, _, number_w)| {
         let extra = if *number_w > 0.0 {
@@ -622,7 +672,7 @@ fn build_scoreboard(
         } else {
             0.0
         };
-        width.max(spans_width(name, fs, text_width_fn) + extra)
+        width.max(spans_width_fn(name, fs) + extra)
     });
 
     let line_h = 9.0 * gs;
@@ -677,13 +727,6 @@ fn build_scoreboard(
             });
         }
     }
-}
-
-fn spans_width(spans: &[TextSpan], scale: f32, text_width_fn: TextWidthFn) -> f32 {
-    spans
-        .iter()
-        .map(|span| text_width_fn(&span.text, scale))
-        .sum()
 }
 
 /// Right-aligned status icon x, matching vanilla `xRight - i * 8 - 9`.

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -30,11 +30,14 @@ pub struct FrameTimings {
     pub present_ms: f32,
 }
 
+type ScoreKey = (String, String);
+type ScoreEntry = (u32, Option<Vec<TextSpan>>);
+
 #[derive(Default)]
 pub struct Scoreboard {
     sidebar: Option<String>,
     objectives: HashMap<String, Vec<TextSpan>>,
-    scores: HashMap<(String, String), (u32, Option<Vec<TextSpan>>)>,
+    scores: HashMap<ScoreKey, ScoreEntry>,
     teams: HashMap<String, ScoreboardTeam>,
 }
 
@@ -511,9 +514,9 @@ fn build_scoreboard(
     let mut entries: Vec<_> = scoreboard
         .scores
         .iter()
-        .filter_map(|((entry_objective, owner), (score, display))| {
-            (entry_objective == objective)
-                .then(|| (*score, owner, scoreboard.line(owner, display.as_deref())))
+        .filter(|((entry_objective, _), _)| entry_objective == objective)
+        .map(|((_, owner), (score, display))| {
+            (*score, owner, scoreboard.line(owner, display.as_deref()))
         })
         .collect();
     entries.sort_by(|(a_score, a, _), (b_score, b, _)| b_score.cmp(a_score).then_with(|| a.cmp(b)));

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -5,6 +5,7 @@ use glam::DVec3;
 use super::common::{FONT_SIZE, TextWidthFn, WHITE, push_item_count};
 use crate::player::inventory::item_resource_name;
 use crate::renderer::pipelines::menu_overlay::{MenuElement, SpriteId};
+use crate::ui::text::TextSpan;
 use crate::world::waypoints::{LocatorDot, PitchDirection, WaypointStyleId};
 
 /// Which bar occupies the slot above the hotbar (vanilla `ContextualInfo`).
@@ -101,6 +102,7 @@ pub fn build_hud(
     game_mode: u8,
     hotbar: &[ItemStack],
     held_item_tooltip_ticks: Option<u64>,
+    action_bar: Option<(&[TextSpan], u64)>,
     first_person: bool,
     debug: Option<&DebugInfo<'_>>,
     gui_scale_setting: u32,
@@ -178,6 +180,24 @@ pub fn build_hud(
                 centered: true,
             });
         }
+    }
+
+    if let Some((spans, ticks)) = action_bar
+        && ticks < 60
+    {
+        let alpha = ((60 - ticks).min(20) as f32) / 20.0;
+        let mut spans = spans.to_vec();
+        for span in &mut spans {
+            span.color[3] *= alpha;
+        }
+        elements.push(MenuElement::McText {
+            x: cx,
+            y: screen_h - 68.0 * gs,
+            spans,
+            scale: FONT_SIZE * gs,
+            centered: true,
+            shadow: true,
+        });
     }
 
     let status_bar_y = (hotbar_y - (XP_BAR_H + 1.0 + 2.0) * gs).round();

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -31,12 +31,32 @@ pub struct FrameTimings {
 }
 
 type ScoreKey = (String, String);
-type ScoreEntry = (u32, Option<Vec<TextSpan>>);
+
+/// Vanilla `NumberFormat`: how a score's value renders in the sidebar.
+/// Styled keeps only the resolved color; a per-score format overrides the
+/// objective's, and no format at all means the styled-red default.
+#[derive(Clone)]
+pub enum ScoreNumberFormat {
+    Blank,
+    Styled([f32; 4]),
+    Fixed(Vec<TextSpan>),
+}
+
+struct ScoreEntry {
+    score: i32,
+    display: Option<Vec<TextSpan>>,
+    number_format: Option<ScoreNumberFormat>,
+}
+
+struct Objective {
+    display: Vec<TextSpan>,
+    number_format: Option<ScoreNumberFormat>,
+}
 
 #[derive(Default)]
 pub struct Scoreboard {
     sidebar: Option<String>,
-    objectives: HashMap<String, Vec<TextSpan>>,
+    objectives: HashMap<String, Objective>,
     scores: HashMap<ScoreKey, ScoreEntry>,
     teams: HashMap<String, ScoreboardTeam>,
 }
@@ -56,9 +76,20 @@ impl Scoreboard {
         self.teams.clear();
     }
 
-    pub fn set_objective(&mut self, name: String, display: Option<Vec<TextSpan>>) {
+    pub fn set_objective(
+        &mut self,
+        name: String,
+        display: Option<Vec<TextSpan>>,
+        number_format: Option<ScoreNumberFormat>,
+    ) {
         if let Some(display) = display {
-            self.objectives.insert(name, display);
+            self.objectives.insert(
+                name,
+                Objective {
+                    display,
+                    number_format,
+                },
+            );
         } else {
             self.objectives.remove(&name);
             self.scores.retain(|(objective, _), _| objective != &name);
@@ -76,10 +107,18 @@ impl Scoreboard {
         &mut self,
         owner: String,
         objective: String,
-        score: u32,
+        score: i32,
         display: Option<Vec<TextSpan>>,
+        number_format: Option<ScoreNumberFormat>,
     ) {
-        self.scores.insert((objective, owner), (score, display));
+        self.scores.insert(
+            (objective, owner),
+            ScoreEntry {
+                score,
+                display,
+                number_format,
+            },
+        );
     }
 
     pub fn reset_score(&mut self, owner: &str, objective: Option<&str>) {
@@ -241,7 +280,7 @@ pub fn build_hud(
     bar: ContextualBarKind<'_>,
     game_mode: u8,
     hotbar: &[ItemStack],
-    held_item_tooltip_ticks: Option<u64>,
+    tool_highlight_timer: u32,
     action_bar: Option<(&[TextSpan], u64)>,
     scoreboard: &Scoreboard,
     first_person: bool,
@@ -307,20 +346,37 @@ pub fn build_hud(
         }
     }
 
-    if let Some(ticks) = held_item_tooltip_ticks
+    // Vanilla `Hud.extractSelectedItemName`: rarity-colored, italic for
+    // custom names, alpha `timer * 256 / 10` (10-tick fade), y = height - 59
+    // (+14 when the player can't be hurt). Spectators get none.
+    if tool_highlight_timer > 0
+        && game_mode != 3
         && let Some(ItemStack::Present(data)) = hotbar.get(selected_slot as usize)
     {
-        let alpha = ((60_u64.saturating_sub(ticks)).min(10) as f32) / 10.0;
-        if alpha > 0.0 {
-            elements.push(MenuElement::Text {
-                x: cx,
-                y: hotbar_y - 24.0 * gs,
-                text: super::common::item_display_name(data),
-                scale: FONT_SIZE * gs,
-                color: [1.0, 1.0, 1.0, alpha],
-                centered: true,
-            });
+        use azalea_inventory::components::{CustomName, Rarity};
+        let alpha = (tool_highlight_timer as f32 * 256.0 / 10.0 / 255.0).min(1.0);
+        // Default-component rarities aren't synced; absent means common.
+        let mut color = match data.get_component::<Rarity>().as_deref() {
+            Some(Rarity::Uncommon) => super::common::rgb(0xffff55),
+            Some(Rarity::Rare) => super::common::rgb(0x55ffff),
+            Some(Rarity::Epic) => super::common::rgb(0xff55ff),
+            _ => WHITE,
+        };
+        color[3] = alpha;
+        let mut span = TextSpan::new(super::common::item_display_name(data), color);
+        span.italic = data.get_component::<CustomName>().is_some();
+        let mut y = screen_h - 59.0 * gs;
+        if game_mode == 1 {
+            y += 14.0 * gs;
         }
+        elements.push(MenuElement::McText {
+            x: cx,
+            y,
+            spans: vec![span],
+            scale: FONT_SIZE * gs,
+            centered: true,
+            shadow: true,
+        });
     }
 
     if let Some((spans, ticks)) = action_bar
@@ -333,7 +389,8 @@ pub fn build_hud(
         }
         elements.push(MenuElement::McText {
             x: cx,
-            y: screen_h - 68.0 * gs,
+            // Vanilla translates to height - 68 and draws at local y -4.
+            y: screen_h - 72.0 * gs,
             spans,
             scale: FONT_SIZE * gs,
             centered: true,
@@ -497,6 +554,11 @@ pub fn build_hud(
     }
 }
 
+/// Vanilla `Hud.displayScoreboardSidebar`: entries sorted by score
+/// descending then owner case-insensitive, `#`-prefixed owners hidden, at
+/// most 15 rows, number format per score falling back to the objective's and
+/// then to styled red, block anchored at `height/2 + rowsHeight/3`, title
+/// background 0.4 over rows 0.3, no text shadow.
 fn build_scoreboard(
     elements: &mut Vec<MenuElement>,
     screen_w: f32,
@@ -508,70 +570,112 @@ fn build_scoreboard(
     let Some(objective) = scoreboard.sidebar.as_ref() else {
         return;
     };
-    let Some(title) = scoreboard.objectives.get(objective) else {
+    let Some(obj) = scoreboard.objectives.get(objective) else {
         return;
     };
+    let fs = FONT_SIZE * gs;
     let mut entries: Vec<_> = scoreboard
         .scores
         .iter()
-        .filter(|((entry_objective, _), _)| entry_objective == objective)
-        .map(|((_, owner), (score, display))| {
-            (*score, owner, scoreboard.line(owner, display.as_deref()))
+        .filter(|((entry_objective, owner), _)| {
+            entry_objective == objective && !owner.starts_with('#')
         })
         .collect();
-    entries.sort_by(|(a_score, a, _), (b_score, b, _)| b_score.cmp(a_score).then_with(|| a.cmp(b)));
+    entries.sort_by(|((_, a), a_entry), ((_, b), b_entry)| {
+        b_entry
+            .score
+            .cmp(&a_entry.score)
+            .then_with(|| a.to_lowercase().cmp(&b.to_lowercase()))
+    });
     entries.truncate(15);
     if entries.is_empty() {
         return;
     }
+    let rows: Vec<(Vec<TextSpan>, Vec<TextSpan>, f32)> = entries
+        .iter()
+        .map(|((_, owner), entry)| {
+            let name = scoreboard.line(owner, entry.display.as_deref());
+            let number = match entry
+                .number_format
+                .as_ref()
+                .or(obj.number_format.as_ref())
+                .cloned()
+                .unwrap_or(ScoreNumberFormat::Styled(super::common::rgb(0xff5555)))
+            {
+                ScoreNumberFormat::Blank => Vec::new(),
+                ScoreNumberFormat::Styled(color) => {
+                    vec![TextSpan::new(entry.score.to_string(), color)]
+                }
+                ScoreNumberFormat::Fixed(spans) => spans,
+            };
+            let number_w = spans_width(&number, fs, text_width_fn);
+            (name, number, number_w)
+        })
+        .collect();
 
-    let fs = FONT_SIZE * gs;
-    let right = screen_w - 4.0 * gs;
+    let title = &obj.display;
     let title_w = spans_width(title, fs, text_width_fn);
-    let width = entries.iter().fold(title_w, |width, (score, _, spans)| {
-        width.max(
-            spans_width(spans, fs, text_width_fn)
-                + text_width_fn(&score.to_string(), fs)
-                + 5.0 * gs,
-        )
+    let spacer_w = text_width_fn(": ", fs);
+    let width = rows.iter().fold(title_w, |width, (name, _, number_w)| {
+        let extra = if *number_w > 0.0 {
+            spacer_w + number_w
+        } else {
+            0.0
+        };
+        width.max(spans_width(name, fs, text_width_fn) + extra)
     });
-    let x = right - width - 2.0 * gs;
+
     let line_h = 9.0 * gs;
-    let y = (screen_h - (entries.len() as f32 + 1.0) * line_h) / 2.0;
+    let height = rows.len() as f32 * line_h;
+    let bottom = screen_h / 2.0 + height / 3.0;
+    let header_y = bottom - height;
+    let left = screen_w - width - 3.0 * gs;
+    let right = screen_w - 1.0 * gs;
+    let bg_x = left - 2.0 * gs;
     elements.push(MenuElement::Rect {
-        x,
-        y,
-        w: width + 4.0 * gs,
-        h: (entries.len() as f32 + 1.0) * line_h,
+        x: bg_x,
+        y: header_y - line_h - gs,
+        w: right - bg_x,
+        h: line_h,
         corner_radius: 0.0,
-        color: [0.0, 0.0, 0.0, 0.5],
+        color: [0.0, 0.0, 0.0, 0.4],
+    });
+    elements.push(MenuElement::Rect {
+        x: bg_x,
+        y: header_y - gs,
+        w: right - bg_x,
+        h: bottom - (header_y - gs),
+        corner_radius: 0.0,
+        color: [0.0, 0.0, 0.0, 0.3],
     });
     elements.push(MenuElement::McText {
-        x: right - width / 2.0,
-        y,
+        x: left + width / 2.0 - title_w / 2.0,
+        y: header_y - line_h,
         spans: title.clone(),
         scale: fs,
-        centered: true,
-        shadow: true,
+        centered: false,
+        shadow: false,
     });
-    for (index, (score, _, spans)) in entries.iter().enumerate() {
-        let row_y = y + (index as f32 + 1.0) * line_h;
+    for (index, (name, number, number_w)) in rows.iter().enumerate() {
+        let row_y = bottom - (rows.len() - index) as f32 * line_h;
         elements.push(MenuElement::McText {
-            x: x + 2.0 * gs,
+            x: left,
             y: row_y,
-            spans: spans.clone(),
+            spans: name.clone(),
             scale: fs,
             centered: false,
-            shadow: true,
+            shadow: false,
         });
-        elements.push(MenuElement::Text {
-            x: right - text_width_fn(&score.to_string(), fs),
-            y: row_y,
-            text: score.to_string(),
-            scale: fs,
-            color: [1.0, 0.33, 0.33, 1.0],
-            centered: false,
-        });
+        if *number_w > 0.0 {
+            elements.push(MenuElement::McText {
+                x: right - number_w,
+                y: row_y,
+                spans: number.clone(),
+                scale: fs,
+                centered: false,
+                shadow: false,
+            });
+        }
     }
 }
 

--- a/pomme-client/src/ui/player_tab.rs
+++ b/pomme-client/src/ui/player_tab.rs
@@ -1,9 +1,12 @@
 //! Ported 1:1 from vanilla `PlayerTabOverlay.extractRenderState`
 //! (reference/26.1/decompiled/.../PlayerTabOverlay.java:103-204).
 
+use crate::entity::EntityStore;
 use crate::player::tab_list::{TabList, TabListPlayer};
 use crate::renderer::pipelines::menu_overlay::{MenuElement, SpriteId};
 use crate::ui::common::FONT_SIZE;
+use crate::ui::hud::Scoreboard;
+use crate::ui::text::TextSpan;
 
 const MAX_ROWS_PER_COL: usize = 20;
 const HEAD_COL_W: i32 = 9;
@@ -21,10 +24,11 @@ pub fn build_player_tab_overlay(
     elements: &mut Vec<MenuElement>,
     screen_w: f32,
     tab_list: &TabList,
+    scoreboard: &Scoreboard,
     gs: f32,
     text_width: &dyn Fn(&str, f32) -> f32,
 ) {
-    let players = tab_list.sorted_listed();
+    let players = tab_list.sorted_listed(scoreboard);
     if players.is_empty() {
         return;
     }
@@ -32,10 +36,13 @@ pub fn build_player_tab_overlay(
     let gw = (screen_w / gs).floor();
     let font_w = |s: &str| text_width(s, FONT_SIZE);
 
-    let display_names: Vec<String> = players.iter().map(|p| display_name_for(p)).collect();
+    let display_names: Vec<Vec<TextSpan>> = players
+        .iter()
+        .map(|p| display_name_for(p, scoreboard))
+        .collect();
     let max_name_w: i32 = display_names
         .iter()
-        .map(|n| font_w(n).ceil() as i32)
+        .map(|n| font_w(&span_text(n)).ceil() as i32)
         .max()
         .unwrap_or(0);
 
@@ -58,11 +65,11 @@ pub fn build_player_tab_overlay(
     let header_lines = tab_list
         .header
         .as_ref()
-        .map(|h| wrap_text(h, wrap_width_px, &font_w));
+        .map(|h| wrap_text(&span_text(h), wrap_width_px, &font_w));
     let footer_lines = tab_list
         .footer
         .as_ref()
-        .map(|f| wrap_text(f, wrap_width_px, &font_w));
+        .map(|f| wrap_text(&span_text(f), wrap_width_px, &font_w));
 
     let mut max_line_w = grid_w;
     for lines in [&header_lines, &footer_lines].into_iter().flatten() {
@@ -93,6 +100,15 @@ pub fn build_player_tab_overlay(
                 centered: false,
             });
         };
+    let push_spans = |elements: &mut Vec<MenuElement>, spans: Vec<TextSpan>, x: i32, y: i32| {
+        elements.push(MenuElement::TextSpans {
+            x: x as f32 * gs,
+            y: y as f32 * gs,
+            spans,
+            scale: FONT_SIZE * gs,
+            centered: false,
+        });
+    };
     let push_image =
         |elements: &mut Vec<MenuElement>, x: i32, y: i32, w: i32, h: i32, sprite: SpriteId| {
             elements.push(MenuElement::Image {
@@ -158,18 +174,13 @@ pub fn build_player_tab_overlay(
         push_image(elements, row_left, yo, 8, 8, SpriteId::SteveHead);
 
         let info = players[i];
-        let name_color = if info.game_mode == SPECTATOR_GAME_MODE {
-            COL_SPECTATOR
-        } else {
-            COL_NAME
-        };
-        push_text(
-            elements,
-            display_names[i].clone(),
-            row_left + HEAD_COL_W,
-            yo,
-            name_color,
-        );
+        let mut spans = display_names[i].clone();
+        if info.game_mode == SPECTATOR_GAME_MODE {
+            for span in &mut spans {
+                span.color[3] *= COL_SPECTATOR[3];
+            }
+        }
+        push_spans(elements, spans, row_left + HEAD_COL_W, yo);
         push_image(
             elements,
             row_left + slot_width - 11,
@@ -186,8 +197,54 @@ pub fn build_player_tab_overlay(
     }
 }
 
-fn display_name_for(p: &TabListPlayer) -> String {
-    p.display_name.clone().unwrap_or_else(|| p.name.clone())
+fn display_name_for(p: &TabListPlayer, scoreboard: &Scoreboard) -> Vec<TextSpan> {
+    scoreboard.player_name(&p.name, p.display_name.as_deref())
+}
+
+fn span_text(spans: &[TextSpan]) -> String {
+    spans.iter().map(|span| span.text.as_str()).collect()
+}
+
+pub fn build_player_nameplates(
+    elements: &mut Vec<MenuElement>,
+    entity_store: &EntityStore,
+    tab_list: &TabList,
+    scoreboard: &Scoreboard,
+    local_uuid: uuid::Uuid,
+    partial_tick: f32,
+    gs: f32,
+    camera_pos: glam::DVec3,
+    project: &dyn Fn(glam::DVec3) -> Option<(f32, f32)>,
+) {
+    for entity in entity_store.living.values() {
+        let Some(uuid) = entity.player_uuid else {
+            continue;
+        };
+        if uuid == local_uuid {
+            continue;
+        }
+        let Some(player) = tab_list.players.get(&uuid) else {
+            continue;
+        };
+        let pos = entity
+            .prev_position
+            .lerp(entity.position, partial_tick as f64)
+            + glam::DVec3::Y * if entity.is_crouching { 1.8 } else { 2.1 };
+        let max_distance = if entity.is_crouching { 32.0 } else { 64.0 };
+        if (*pos - camera_pos).length_squared() > max_distance * max_distance {
+            continue;
+        }
+        let Some((x, y)) = project(*pos) else {
+            continue;
+        };
+        elements.push(MenuElement::TextSpans {
+            x,
+            y: y - 4.0 * gs,
+            spans: display_name_for(player, scoreboard),
+            scale: FONT_SIZE * gs,
+            centered: true,
+        });
+    }
 }
 
 fn ping_sprite(latency: i32) -> SpriteId {

--- a/pomme-client/src/ui/player_tab.rs
+++ b/pomme-client/src/ui/player_tab.rs
@@ -16,7 +16,6 @@ const SPECTATOR_GAME_MODE: u8 = 3;
 const BG_BACKDROP: [f32; 4] = [0.0, 0.0, 0.0, 0.5]; // Integer.MIN_VALUE (0x80000000)
 const BG_ROW: [f32; 4] = [1.0, 1.0, 1.0, 0x20 as f32 / 255.0]; // 0x20FFFFFF
 const COL_NAME: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
-const COL_SPECTATOR: [f32; 4] = [1.0, 1.0, 1.0, 0x90 as f32 / 255.0]; // 0x90FFFFFF
 
 /// `text_width(text, FONT_SIZE)` must return the width in pixels at 1x GUI
 /// scale.
@@ -62,6 +61,8 @@ pub fn build_player_tab_overlay(
     let cx = (gw as i32) / 2;
 
     let wrap_width_px = (gw - 50.0).max(1.0);
+    // TODO: wrapping flattens the header/footer to plain text, dropping
+    // their formatting; wrap the spans themselves to keep it.
     let header_lines = tab_list
         .header
         .as_ref()
@@ -176,8 +177,9 @@ pub fn build_player_tab_overlay(
         let info = players[i];
         let mut spans = display_names[i].clone();
         if info.game_mode == SPECTATOR_GAME_MODE {
+            // Vanilla `decorateName`: spectators are italicized, nothing else.
             for span in &mut spans {
-                span.color[3] *= COL_SPECTATOR[3];
+                span.italic = true;
             }
         }
         push_spans(elements, spans, row_left + HEAD_COL_W, yo);
@@ -216,6 +218,11 @@ pub struct PlayerNameplates<'a> {
     pub project: &'a dyn Fn(glam::DVec3) -> Option<(f32, f32)>,
 }
 
+// TODO: vanilla renders name tags as world-space billboards (0.025 scale,
+// shrinking with distance, 25% black backdrop, a see-through pass behind
+// walls, sneak dimming, no shadow) and honors team nametagVisibility; this
+// screen-space projection is an approximation until a world-space text path
+// exists.
 pub fn build_player_nameplates(elements: &mut Vec<MenuElement>, nameplates: PlayerNameplates<'_>) {
     for entity in nameplates.entity_store.living.values() {
         let Some(uuid) = entity.player_uuid else {
@@ -230,7 +237,8 @@ pub fn build_player_nameplates(elements: &mut Vec<MenuElement>, nameplates: Play
         let pos = entity
             .prev_position
             .lerp(entity.position, nameplates.partial_tick as f64)
-            + glam::DVec3::Y * if entity.is_crouching { 1.8 } else { 2.1 };
+            // Vanilla anchors at the pose bounding-box height + 0.5.
+            + glam::DVec3::Y * if entity.is_crouching { 2.0 } else { 2.3 };
         let max_distance = if entity.is_crouching { 32.0 } else { 64.0 };
         if (*pos - nameplates.camera_pos).length_squared() > max_distance * max_distance {
             continue;
@@ -241,7 +249,9 @@ pub fn build_player_nameplates(elements: &mut Vec<MenuElement>, nameplates: Play
         elements.push(MenuElement::TextSpans {
             x,
             y: y - 4.0 * nameplates.gs,
-            spans: display_name_for(player, nameplates.scoreboard),
+            // The tab-list display name is tab-only in vanilla; name tags
+            // always use the team-formatted profile name.
+            spans: nameplates.scoreboard.player_name(&player.name, None),
             scale: FONT_SIZE * nameplates.gs,
             centered: true,
         });

--- a/pomme-client/src/ui/player_tab.rs
+++ b/pomme-client/src/ui/player_tab.rs
@@ -26,6 +26,7 @@ pub fn build_player_tab_overlay(
     scoreboard: &Scoreboard,
     gs: f32,
     text_width: &dyn Fn(&str, f32) -> f32,
+    spans_width: crate::ui::common::SpansWidthFn<'_>,
 ) {
     let players = tab_list.sorted_listed(scoreboard);
     if players.is_empty() {
@@ -41,7 +42,7 @@ pub fn build_player_tab_overlay(
         .collect();
     let max_name_w: i32 = display_names
         .iter()
-        .map(|n| font_w(&span_text(n)).ceil() as i32)
+        .map(|n| spans_width(n, FONT_SIZE).ceil() as i32)
         .max()
         .unwrap_or(0);
 

--- a/pomme-client/src/ui/player_tab.rs
+++ b/pomme-client/src/ui/player_tab.rs
@@ -205,43 +205,44 @@ fn span_text(spans: &[TextSpan]) -> String {
     spans.iter().map(|span| span.text.as_str()).collect()
 }
 
-pub fn build_player_nameplates(
-    elements: &mut Vec<MenuElement>,
-    entity_store: &EntityStore,
-    tab_list: &TabList,
-    scoreboard: &Scoreboard,
-    local_uuid: uuid::Uuid,
-    partial_tick: f32,
-    gs: f32,
-    camera_pos: glam::DVec3,
-    project: &dyn Fn(glam::DVec3) -> Option<(f32, f32)>,
-) {
-    for entity in entity_store.living.values() {
+pub struct PlayerNameplates<'a> {
+    pub entity_store: &'a EntityStore,
+    pub tab_list: &'a TabList,
+    pub scoreboard: &'a Scoreboard,
+    pub local_uuid: uuid::Uuid,
+    pub partial_tick: f32,
+    pub gs: f32,
+    pub camera_pos: glam::DVec3,
+    pub project: &'a dyn Fn(glam::DVec3) -> Option<(f32, f32)>,
+}
+
+pub fn build_player_nameplates(elements: &mut Vec<MenuElement>, nameplates: PlayerNameplates<'_>) {
+    for entity in nameplates.entity_store.living.values() {
         let Some(uuid) = entity.player_uuid else {
             continue;
         };
-        if uuid == local_uuid {
+        if uuid == nameplates.local_uuid {
             continue;
         }
-        let Some(player) = tab_list.players.get(&uuid) else {
+        let Some(player) = nameplates.tab_list.players.get(&uuid) else {
             continue;
         };
         let pos = entity
             .prev_position
-            .lerp(entity.position, partial_tick as f64)
+            .lerp(entity.position, nameplates.partial_tick as f64)
             + glam::DVec3::Y * if entity.is_crouching { 1.8 } else { 2.1 };
         let max_distance = if entity.is_crouching { 32.0 } else { 64.0 };
-        if (*pos - camera_pos).length_squared() > max_distance * max_distance {
+        if (*pos - nameplates.camera_pos).length_squared() > max_distance * max_distance {
             continue;
         }
-        let Some((x, y)) = project(*pos) else {
+        let Some((x, y)) = (nameplates.project)(*pos) else {
             continue;
         };
         elements.push(MenuElement::TextSpans {
             x,
-            y: y - 4.0 * gs,
-            spans: display_name_for(player, scoreboard),
-            scale: FONT_SIZE * gs,
+            y: y - 4.0 * nameplates.gs,
+            spans: display_name_for(player, nameplates.scoreboard),
+            scale: FONT_SIZE * nameplates.gs,
             centered: true,
         });
     }

--- a/pomme-client/src/ui/text.rs
+++ b/pomme-client/src/ui/text.rs
@@ -5,7 +5,7 @@ use azalea_chat::style::Style;
 
 /// A styled run of text (color plus formatting flags). The shared span type for
 /// rendering rich chat and server-MOTD text.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TextSpan {
     pub text: String,
     pub color: [f32; 4],


### PR DESCRIPTION
## Summary

  - add held item tooltip and action bar support
  - add sidebar scoreboard objectives, scores and team formatting
  - preserve formatted player-list components and render player nameplates
  - add chat clipboard paste and Cyrillic font glyphs
  - support lobby-to-backend configuration transitions
  - handle server resource-pack replies during configuration
  - add 1.21.11 entity metadata compatibility fixes

  ## Verification

  - `cargo check -p pomme-client`
  - `cargo test -p pomme-client translate_entity_ --quiet`
  - tested on a FlameCord server with a lobby, backend transfer and server.
  
  ### Notes
  Planning on adding full support to TAB plugin, so tab would show colors.