### PR TITLE
add copy link fallback to launcher sign-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5217,6 +5217,7 @@ dependencies = [
  "specta-typescript",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-shell",
@@ -7292,6 +7293,21 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.1
         version: 2.11.1
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ~2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.2
         version: 2.7.2
@@ -327,42 +330,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.2.5':
     resolution: {integrity: sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.5':
     resolution: {integrity: sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.5':
     resolution: {integrity: sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.5':
     resolution: {integrity: sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.2.5':
     resolution: {integrity: sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.2.5':
     resolution: {integrity: sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==}
@@ -411,35 +408,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.4':
     resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
     resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.4':
     resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.4':
     resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
     resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
@@ -463,6 +455,9 @@ packages:
     resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
   '@tauri-apps/plugin-dialog@2.7.2':
     resolution: {integrity: sha512-pX0IGm1I3I6wc+zeKYcq1GSqogK6okCNX5fOdaNU5ab1AjGS6l1E5wFNjEb7meg7ZFSp0JUs+0jQGQNyOvLrsg==}
@@ -642,109 +637,91 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-gnu@1.12.2':
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -1125,28 +1102,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -1759,6 +1732,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-dialog@2.7.2':
     dependencies:

--- a/pomme-launcher/package.json
+++ b/pomme-launcher/package.json
@@ -20,6 +20,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@tauri-apps/api": "^2.11.1",
+    "@tauri-apps/plugin-clipboard-manager": "~2.3.2",
     "@tauri-apps/plugin-dialog": "^2.7.2",
     "@tauri-apps/plugin-opener": "~2.5.4",
     "@tauri-apps/plugin-shell": "^2.3.5",

--- a/pomme-launcher/src-tauri/Cargo.toml
+++ b/pomme-launcher/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-opener = "2"
+tauri-plugin-clipboard-manager = "2"
 log = "0.4"
 rand = "0.10"
 keyring = { version = "3", features = ["apple-native", "sync-secret-service", "windows-native"] }

--- a/pomme-launcher/src-tauri/capabilities/default.json
+++ b/pomme-launcher/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "shell:allow-open",
     "dialog:allow-open",
     "opener:default",
+    "clipboard-manager:allow-write-text",
     {
       "identifier": "opener:allow-reveal-item-in-dir",
       "allow": [

--- a/pomme-launcher/src-tauri/src/auth.rs
+++ b/pomme-launcher/src-tauri/src/auth.rs
@@ -6,6 +6,11 @@ const CLIENT_ID: &str = "b2dd2c0f-8a09-4549-9d76-ab43b8572695";
 const REDIRECT_URI: &str = "http://localhost:25585";
 const SCOPE: &str = "XboxLive.signin offline_access";
 
+#[derive(Serialize, Clone, specta::Type, tauri_specta::Event)]
+pub struct AuthUrlEvent {
+    pub url: String,
+}
+
 #[derive(Serialize, Deserialize, Clone, specta::Type)]
 pub struct AuthAccount {
     pub username: String,
@@ -168,7 +173,9 @@ fn generate_pkce() -> (String, String) {
     (verifier, challenge)
 }
 
-pub async fn oauth_sign_in() -> Result<AuthAccount, String> {
+pub async fn oauth_sign_in(app: tauri::AppHandle) -> Result<AuthAccount, String> {
+    use tauri_specta::Event;
+
     let (verifier, challenge) = generate_pkce();
 
     let state: String = (0..16)
@@ -187,9 +194,21 @@ pub async fn oauth_sign_in() -> Result<AuthAccount, String> {
         urlencoding::encode(SCOPE),
     );
 
-    let _ = open::that(&auth_url);
+    // Bind before opening the browser so a taken port fails immediately.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:25585")
+        .await
+        .map_err(|e| format!("Failed to bind callback listener: {e}"))?;
 
-    let code = listen_for_callback(&state).await?;
+    let _ = AuthUrlEvent {
+        url: auth_url.clone(),
+    }
+    .emit(&app);
+
+    if let Err(e) = open::that_detached(&auth_url) {
+        log::warn!("failed to open browser for sign-in: {e}");
+    }
+
+    let code = listen_for_callback(listener, &state).await?;
 
     let client = reqwest::Client::new();
     let resp = client
@@ -233,12 +252,11 @@ async fn finish_msa_exchange(
     Ok(account)
 }
 
-async fn listen_for_callback(expected_state: &str) -> Result<String, String> {
+async fn listen_for_callback(
+    listener: tokio::net::TcpListener,
+    expected_state: &str,
+) -> Result<String, String> {
     use tokio::io::AsyncReadExt;
-
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:25585")
-        .await
-        .map_err(|e| format!("Failed to bind callback listener: {e}"))?;
 
     let timeout = Duration::from_secs(300);
     let (mut stream, _) = tokio::time::timeout(timeout, listener.accept())
@@ -265,17 +283,19 @@ async fn listen_for_callback(expected_state: &str) -> Result<String, String> {
 
     if let Some(error) = params.get("error") {
         let desc = params.get("error_description").unwrap_or(error);
-        let body = format!("Authentication failed: {desc}");
-        send_http_response(&mut stream, 400, &body).await;
+        reject(&mut stream, desc).await;
         return Err(format!("OAuth error: {desc}"));
     }
 
-    let state = params.get("state").ok_or("Missing state")?;
-    if *state != expected_state {
+    if params.get("state").copied() != Some(expected_state) {
+        reject(&mut stream, "state mismatch").await;
         return Err("State mismatch".to_string());
     }
 
-    let raw_code = params.get("code").ok_or("Missing auth code")?;
+    let Some(raw_code) = params.get("code") else {
+        reject(&mut stream, "missing auth code").await;
+        return Err("Missing auth code".to_string());
+    };
     let code = urlencoding::decode(raw_code)
         .map_err(|e| format!("Failed to decode auth code: {e}"))?
         .into_owned();
@@ -288,6 +308,10 @@ async fn listen_for_callback(expected_state: &str) -> Result<String, String> {
     .await;
 
     Ok(code)
+}
+
+async fn reject(stream: &mut tokio::net::TcpStream, desc: &str) {
+    send_http_response(stream, 400, &format!("Authentication failed: {desc}")).await;
 }
 
 async fn send_http_response(stream: &mut tokio::net::TcpStream, status: u16, body: &str) {

--- a/pomme-launcher/src-tauri/src/commands.rs
+++ b/pomme-launcher/src-tauri/src/commands.rs
@@ -167,8 +167,8 @@ pub fn get_all_accounts() -> Vec<crate::auth::AuthAccount> {
 
 #[tauri::command]
 #[specta::specta]
-pub async fn add_account() -> Result<crate::auth::AuthAccount, String> {
-    crate::auth::oauth_sign_in().await
+pub async fn add_account(app: AppHandle) -> Result<crate::auth::AuthAccount, String> {
+    crate::auth::oauth_sign_in(app).await
 }
 
 #[tauri::command]

--- a/pomme-launcher/src-tauri/src/lib.rs
+++ b/pomme-launcher/src-tauri/src/lib.rs
@@ -78,6 +78,7 @@ pub fn get_builder() -> tauri_specta::Builder {
             commands::update_friend_settings,
         ])
         .events(tauri_specta::collect_events![
+            auth::AuthUrlEvent,
             commands::ConsoleMessageEvent,
             commands::GameExitedEvent,
             downloader::DownloadProgressEvent,

--- a/pomme-launcher/src-tauri/src/main.rs
+++ b/pomme-launcher/src-tauri/src/main.rs
@@ -24,6 +24,7 @@ fn main() {
         })
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .invoke_handler(invoke_handler)
         .run(tauri::generate_context!())
         .expect("failed to run Pomme launcher");

--- a/pomme-launcher/src/App.tsx
+++ b/pomme-launcher/src/App.tsx
@@ -37,6 +37,7 @@ function App() {
     downloadedVersions,
     setLaunchingStatus,
     setAuthLoading,
+    setAuthUrl,
     setStatus,
     setNews,
     setSkinUrl,
@@ -115,6 +116,15 @@ function App() {
     };
   }, [setDownloadProgress]);
 
+  useEffect(() => {
+    const unlisten = events.authUrlEvent.listen((event) => {
+      setAuthUrl(event.payload.url);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [setAuthUrl]);
+
   const startAddAccount = useCallback(async () => {
     setAccountDropdownOpen(false);
     setAuthLoading(true);
@@ -133,6 +143,7 @@ function App() {
       setStatus(`Auth failed: ${res.error}`);
     }
     setAuthLoading(false);
+    setAuthUrl(null);
   }, [
     accounts,
     loadSkin,
@@ -140,6 +151,7 @@ function App() {
     setAccounts,
     setActiveIndex,
     setAuthLoading,
+    setAuthUrl,
     setStatus,
   ]);
 

--- a/pomme-launcher/src/bindings/index.ts
+++ b/pomme-launcher/src/bindings/index.ts
@@ -51,6 +51,7 @@ export const commands = {
 
 /** Events */
 export const events = {
+	authUrlEvent: makeEvent<pomme_launcher$auth.AuthUrlEvent>("auth-url-event"),
 	consoleMessageEvent: makeEvent<pomme_launcher$commands.ConsoleMessageEvent>("console-message-event"),
 	downloadProgressEvent: makeEvent<pomme_launcher$downloader.DownloadProgressEvent>("download-progress-event"),
 	gameExitedEvent: makeEvent<pomme_launcher$commands.GameExitedEvent>("game-exited-event"),

--- a/pomme-launcher/src/bindings/pomme_launcher/auth.ts
+++ b/pomme-launcher/src/bindings/pomme_launcher/auth.ts
@@ -5,3 +5,7 @@ export type AuthAccount = {
 	access_token: string,
 	expires_at: number,
 };
+
+export type AuthUrlEvent = {
+	url: string,
+};

--- a/pomme-launcher/src/components/Navbar.tsx
+++ b/pomme-launcher/src/components/Navbar.tsx
@@ -1,3 +1,4 @@
+import { getVersion } from "@tauri-apps/api/app";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { useEffect, useState } from "react";
 import {
@@ -61,6 +62,11 @@ export default function Navbar({ startAddAccount, switchAccount, removeAccount }
     friendsList,
   } = useAppStateContext();
 
+  const [version, setVersion] = useState("");
+  useEffect(() => {
+    getVersion().then(setVersion).catch(console.error);
+  }, []);
+
   const [copied, setCopied] = useState(false);
   useEffect(() => {
     if (!copied) return;
@@ -89,7 +95,7 @@ export default function Navbar({ startAddAccount, switchAccount, removeAccount }
           <span className="brand-name">POMME</span>
           <span className="brand-sub">LAUNCHER</span>
         </div>
-        <span className="brand-version">v0.1.0</span>
+        <span className="brand-version">{version && `v${version}`}</span>
       </div>
 
       <div className="sidebar-nav">

--- a/pomme-launcher/src/components/Navbar.tsx
+++ b/pomme-launcher/src/components/Navbar.tsx
@@ -1,5 +1,8 @@
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { useEffect, useState } from "react";
 import {
   HiArrowRightOnRectangle,
+  HiClipboardDocument,
   HiChevronDown,
   HiCog6Tooth,
   HiHome,
@@ -54,8 +57,23 @@ export default function Navbar({ startAddAccount, switchAccount, removeAccount }
 
     activeIndex,
     authLoading,
+    authUrl,
     friendsList,
   } = useAppStateContext();
+
+  const [copied, setCopied] = useState(false);
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  const copyAuthUrl = () => {
+    if (!authUrl) return;
+    writeText(authUrl)
+      .then(() => setCopied(true))
+      .catch((e) => console.error("Failed to copy sign-in link:", e));
+  };
 
   const incomingCount = friendsList.incomingRequests?.length ?? 0;
 
@@ -146,6 +164,12 @@ export default function Navbar({ startAddAccount, switchAccount, removeAccount }
         ) : (
           <button className="sign-in-sidebar" onClick={startAddAccount} disabled={authLoading}>
             {authLoading ? "Signing in..." : "SIGN IN"}
+          </button>
+        )}
+        {authLoading && authUrl && (
+          <button className="auth-copy-link" onClick={copyAuthUrl}>
+            <HiClipboardDocument />
+            <span>{copied ? "Copied!" : "Link didn't open? Copy it"}</span>
           </button>
         )}
       </div>

--- a/pomme-launcher/src/lib/state.ts
+++ b/pomme-launcher/src/lib/state.ts
@@ -69,6 +69,7 @@ const useAppState = () => {
   const [versions, setVersions] = useState<GameVersion[]>([]);
   const [launchingStatus, setLaunchingStatus] = useState<LaunchingStatus>(null);
   const [authLoading, setAuthLoading] = useState(false);
+  const [authUrl, setAuthUrl] = useState<string | null>(null);
   const [status, setStatus] = useState("");
   const [news, setNews] = useState<PatchNote[]>([]);
   const [skinUrl, setSkinUrl] = useState<string | null>(null);
@@ -106,6 +107,8 @@ const useAppState = () => {
     setLaunchingStatus,
     authLoading,
     setAuthLoading,
+    authUrl,
+    setAuthUrl,
     status,
     setStatus,
     news,

--- a/pomme-launcher/src/styles.css
+++ b/pomme-launcher/src/styles.css
@@ -694,6 +694,28 @@ body {
   cursor: wait;
 }
 
+.auth-copy-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--glass);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-dim);
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.auth-copy-link:hover {
+  background: var(--glass-hover);
+  color: var(--accent);
+}
+
 /* ═══ Hero Banner ═══ */
 
 .hero-banner {


### PR DESCRIPTION
shows a copy button for the auth url during sign-in for when the browser fails to open, opens detached, binds the callback port before opening, responds to bad callbacks, unhardcodes the navbar version