### PR TITLE
add title and subtitle text

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -358,6 +358,8 @@ impl AppCore {
         game.player.effects.clear();
         game.boss_bars.clear();
         game.toasts.clear();
+        // Vanilla Hud.onDisconnected: clearTitles + resetTitleTimes.
+        game.title.clear(true);
         self.requested_player_skins.clear();
         renderer.clear_player_entity_skins();
     }
@@ -771,6 +773,22 @@ impl AppCore {
                 }
                 NetworkEvent::RecipeToastAdd { entries } => {
                     game.toasts.add_recipes(entries);
+                }
+                NetworkEvent::TitleText { spans } => {
+                    game.title.set_title(spans);
+                }
+                NetworkEvent::SubtitleText { spans } => {
+                    game.title.set_subtitle(spans);
+                }
+                NetworkEvent::TitlesAnimation {
+                    fade_in,
+                    stay,
+                    fade_out,
+                } => {
+                    game.title.set_times(fade_in, stay, fade_out);
+                }
+                NetworkEvent::ClearTitles { reset_times } => {
+                    game.title.clear(reset_times);
                 }
                 NetworkEvent::ScoreboardObjective {
                     name,

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -151,6 +151,7 @@ pub struct GameState {
     pub tool_highlight_timer: u32,
     pub last_tool_highlight: azalea_inventory::ItemStack,
     pub action_bar: Option<(Vec<crate::ui::text::TextSpan>, u64)>,
+    pub title: crate::ui::title::TitleState,
     pub scoreboard: crate::ui::hud::Scoreboard,
     pub boss_bars: crate::ui::boss_bar::BossBarState,
     pub toasts: crate::ui::toast::ToastState,
@@ -334,6 +335,7 @@ impl GameState {
             tool_highlight_timer: 0,
             last_tool_highlight: azalea_inventory::ItemStack::Empty,
             action_bar: None,
+            title: crate::ui::title::TitleState::default(),
             scoreboard: crate::ui::hud::Scoreboard::default(),
             boss_bars: crate::ui::boss_bar::BossBarState::default(),
             toasts: crate::ui::toast::ToastState::default(),
@@ -1383,6 +1385,7 @@ pub fn update_game(
         game.item_entity_store.tick(&game.chunk_store);
         game.particle_store.tick(&game.chunk_store);
         game.block_entity_anim.tick();
+        game.title.tick();
         tick_tool_highlight(core, game);
         if let Some(c) = &mut game.open_container
             && let Some(state) = &mut c.enchant
@@ -2294,6 +2297,11 @@ pub fn update_game(
             crate::ui::creative_inventory::CreativeAction::None => {}
         }
         core.input.clear_just_pressed_actions();
+    }
+
+    // Before chat so chat draws over it (vanilla extract order).
+    if !benchmark_running && !game.hide_gui {
+        game.title.build(&mut elements, sw, sh, gs, partial_tick);
     }
 
     // F1 hides the closed-chat overlay; an open chat is a screen and renders

--- a/pomme-client/src/net/azalea_compat.rs
+++ b/pomme-client/src/net/azalea_compat.rs
@@ -86,6 +86,44 @@ fn packet_ids_match_azalea() {
         recipes.id(),
         table_id(Direction::Clientbound, "recipe_book_add")
     );
+
+    use azalea_protocol::packets::game::{
+        c_clear_titles, c_set_subtitle_text, c_set_title_text, c_set_titles_animation,
+    };
+
+    let title = ClientboundGamePacket::SetTitleText(c_set_title_text::ClientboundSetTitleText {
+        text: azalea_chat::FormattedText::default(),
+    });
+    assert_eq!(
+        title.id(),
+        table_id(Direction::Clientbound, "set_title_text")
+    );
+
+    let subtitle =
+        ClientboundGamePacket::SetSubtitleText(c_set_subtitle_text::ClientboundSetSubtitleText {
+            text: azalea_chat::FormattedText::default(),
+        });
+    assert_eq!(
+        subtitle.id(),
+        table_id(Direction::Clientbound, "set_subtitle_text")
+    );
+
+    let animation = ClientboundGamePacket::SetTitlesAnimation(
+        c_set_titles_animation::ClientboundSetTitlesAnimation {
+            fade_in: 10,
+            stay: 70,
+            fade_out: 20,
+        },
+    );
+    assert_eq!(
+        animation.id(),
+        table_id(Direction::Clientbound, "set_titles_animation")
+    );
+
+    let clear = ClientboundGamePacket::ClearTitles(c_clear_titles::ClientboundClearTitles {
+        reset_times: true,
+    });
+    assert_eq!(clear.id(), table_id(Direction::Clientbound, "clear_titles"));
 }
 
 /// Round-trip through azalea's `LpVec3` decoder to cross-check the port.

--- a/pomme-client/src/net/handler.rs
+++ b/pomme-client/src/net/handler.rs
@@ -402,6 +402,30 @@ pub fn handle_game_packet(
                 let _ = event_tx.try_send(NetworkEvent::RecipeToastAdd { entries });
             }
         }
+        ClientboundGamePacket::SetTitleText(p) => {
+            let _ = event_tx.try_send(NetworkEvent::TitleText {
+                spans: format_text_spans(&p.text, [1.0; 4]),
+            });
+        }
+        ClientboundGamePacket::SetSubtitleText(p) => {
+            let _ = event_tx.try_send(NetworkEvent::SubtitleText {
+                spans: format_text_spans(&p.text, [1.0; 4]),
+            });
+        }
+        ClientboundGamePacket::SetTitlesAnimation(p) => {
+            // azalea decodes the fields as u32; vanilla reads signed ints and
+            // ignores negatives, so restore the sign before forwarding.
+            let _ = event_tx.try_send(NetworkEvent::TitlesAnimation {
+                fade_in: p.fade_in as i32,
+                stay: p.stay as i32,
+                fade_out: p.fade_out as i32,
+            });
+        }
+        ClientboundGamePacket::ClearTitles(p) => {
+            let _ = event_tx.try_send(NetworkEvent::ClearTitles {
+                reset_times: p.reset_times,
+            });
+        }
         ClientboundGamePacket::SetObjective(p) => {
             use azalea_protocol::packets::game::c_set_objective::Method;
             let (display, number_format) = match &p.method {

--- a/pomme-client/src/net/mod.rs
+++ b/pomme-client/src/net/mod.rs
@@ -154,6 +154,20 @@ pub enum NetworkEvent {
     RecipeToastAdd {
         entries: Vec<crate::ui::toast::RecipeToastEntry>,
     },
+    TitleText {
+        spans: Vec<crate::ui::text::TextSpan>,
+    },
+    SubtitleText {
+        spans: Vec<crate::ui::text::TextSpan>,
+    },
+    TitlesAnimation {
+        fade_in: i32,
+        stay: i32,
+        fade_out: i32,
+    },
+    ClearTitles {
+        reset_times: bool,
+    },
     ScoreboardObjective {
         name: String,
         display: Option<Vec<crate::ui::text::TextSpan>>,

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -531,10 +531,7 @@ pub fn build_hud(
         && ticks < 60
     {
         let alpha = ((60 - ticks).min(20) as f32) / 20.0;
-        let mut spans = spans.to_vec();
-        for span in &mut spans {
-            span.color[3] *= alpha;
-        }
+        let spans = crate::ui::text::with_alpha(spans, alpha);
         elements.push(MenuElement::McText {
             x: cx,
             // Vanilla translates to height - 68 and draws at local y -4.

--- a/pomme-client/src/ui/mod.rs
+++ b/pomme-client/src/ui/mod.rs
@@ -22,4 +22,5 @@ pub mod player_tab;
 pub mod server_list;
 pub mod text;
 pub mod text_edit;
+pub mod title;
 pub mod toast;

--- a/pomme-client/src/ui/text.rs
+++ b/pomme-client/src/ui/text.rs
@@ -33,6 +33,15 @@ impl TextSpan {
     }
 }
 
+/// The spans with every alpha multiplied by `alpha` (for fade effects).
+pub fn with_alpha(spans: &[TextSpan], alpha: f32) -> Vec<TextSpan> {
+    let mut spans = spans.to_vec();
+    for span in &mut spans {
+        span.color[3] *= alpha;
+    }
+    spans
+}
+
 /// Flatten a `FormattedText` component into styled spans for rendering.
 ///
 /// `base_color` applies wherever the component carries no explicit color,

--- a/pomme-client/src/ui/title.rs
+++ b/pomme-client/src/ui/title.rs
@@ -1,0 +1,137 @@
+//! Title / subtitle overlay: the big centered fade-in text driven by the
+//! `/title` command (vanilla `Hud.extractTitle` and the title fields around
+//! it).
+
+use crate::renderer::pipelines::menu_overlay::MenuElement;
+use crate::ui::common::FONT_SIZE;
+use crate::ui::text::{TextSpan, with_alpha};
+
+pub struct TitleState {
+    title: Option<Vec<TextSpan>>,
+    subtitle: Option<Vec<TextSpan>>,
+    /// Remaining ticks; inactive at <= 0.
+    title_time: i32,
+    fade_in: i32,
+    stay: i32,
+    fade_out: i32,
+}
+
+impl Default for TitleState {
+    fn default() -> Self {
+        Self {
+            title: None,
+            subtitle: None,
+            title_time: 0,
+            fade_in: 10,
+            stay: 70,
+            fade_out: 20,
+        }
+    }
+}
+
+impl TitleState {
+    fn total_time(&self) -> i32 {
+        self.fade_in + self.stay + self.fade_out
+    }
+
+    pub fn set_title(&mut self, spans: Vec<TextSpan>) {
+        self.title = Some(spans);
+        self.title_time = self.total_time();
+    }
+
+    /// Stashes only; a subtitle never shows without an active title.
+    pub fn set_subtitle(&mut self, spans: Vec<TextSpan>) {
+        self.subtitle = Some(spans);
+    }
+
+    /// Negative fields keep their current value; an active countdown restarts
+    /// at the new total (vanilla `Hud.setTimes`).
+    pub fn set_times(&mut self, fade_in: i32, stay: i32, fade_out: i32) {
+        if fade_in >= 0 {
+            self.fade_in = fade_in;
+        }
+        if stay >= 0 {
+            self.stay = stay;
+        }
+        if fade_out >= 0 {
+            self.fade_out = fade_out;
+        }
+        if self.title_time > 0 {
+            self.title_time = self.total_time();
+        }
+    }
+
+    pub fn clear(&mut self, reset_times: bool) {
+        if reset_times {
+            *self = Self::default();
+        } else {
+            self.title = None;
+            self.subtitle = None;
+            self.title_time = 0;
+        }
+    }
+
+    pub fn tick(&mut self) {
+        if self.title_time > 0 {
+            self.title_time -= 1;
+            if self.title_time <= 0 {
+                self.title = None;
+                self.subtitle = None;
+            }
+        }
+    }
+
+    pub fn build(
+        &self,
+        elements: &mut Vec<MenuElement>,
+        screen_w: f32,
+        screen_h: f32,
+        gs: f32,
+        partial_tick: f32,
+    ) {
+        let Some(title) = &self.title else { return };
+        if self.title_time <= 0 {
+            return;
+        }
+
+        let t = self.title_time as f32 - partial_tick;
+        let mut alpha = 255;
+        if self.title_time > self.fade_out + self.stay {
+            alpha = if self.fade_in > 0 {
+                ((self.total_time() as f32 - t) * 255.0 / self.fade_in as f32) as i32
+            } else {
+                255
+            };
+        }
+        if self.title_time <= self.fade_out {
+            alpha = if self.fade_out > 0 {
+                (t * 255.0 / self.fade_out as f32) as i32
+            } else {
+                0
+            };
+        }
+        let alpha = alpha.clamp(0, 255) as f32 / 255.0;
+        if alpha <= 0.0 {
+            return;
+        }
+
+        let cx = (screen_w / 2.0).round();
+        let cy = (screen_h / 2.0).round();
+        // Vanilla draws at local y -10 under a 4x scale about the center, and
+        // the subtitle at local y 5 under a 2x scale.
+        let mut push = |spans: &[TextSpan], y_off: f32, size: f32| {
+            elements.push(MenuElement::McText {
+                x: cx,
+                y: cy + y_off * gs,
+                spans: with_alpha(spans, alpha),
+                scale: FONT_SIZE * gs * size,
+                centered: true,
+                shadow: true,
+            });
+        };
+        push(title, -40.0, 4.0);
+        if let Some(subtitle) = &self.subtitle {
+            push(subtitle, 10.0, 2.0);
+        }
+    }
+}

--- a/pomme-protocol/src/packets.rs
+++ b/pomme-protocol/src/packets.rs
@@ -201,6 +201,22 @@ mod tests {
             Some("bundle_delimiter")
         );
         assert_eq!(
+            t.id(Phase::Game, Direction::Clientbound, "clear_titles"),
+            Some(14)
+        );
+        assert_eq!(
+            t.id(Phase::Game, Direction::Clientbound, "set_subtitle_text"),
+            Some(112)
+        );
+        assert_eq!(
+            t.id(Phase::Game, Direction::Clientbound, "set_title_text"),
+            Some(114)
+        );
+        assert_eq!(
+            t.id(Phase::Game, Direction::Clientbound, "set_titles_animation"),
+            Some(115)
+        );
+        assert_eq!(
             t.id(Phase::Handshake, Direction::Serverbound, "intention"),
             Some(0)
         );


### PR DESCRIPTION
Handles set_title_text, set_subtitle_text, set_titles_animation and clear_titles with the standard fade in/stay/fade out timing, drawn centered at 4x/2x under chat. Includes id anchors and azalea cross-checks for the four packets.