### PR TITLE
add sound subtitle overlay

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -360,6 +360,7 @@ impl AppCore {
         game.toasts.clear();
         // Vanilla Hud.onDisconnected: clearTitles + resetTitleTimes.
         game.title.clear(true);
+        game.subtitles.clear();
         self.requested_player_skins.clear();
         renderer.clear_player_entity_skins();
     }

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -155,6 +155,7 @@ pub struct GameState {
     pub scoreboard: crate::ui::hud::Scoreboard,
     pub boss_bars: crate::ui::boss_bar::BossBarState,
     pub toasts: crate::ui::toast::ToastState,
+    pub subtitles: crate::ui::subtitles::SubtitleOverlayState,
     /// Client tick counter (vanilla `player.tickCount`).
     pub tick_count: u64,
     /// Tick of the last XP progress change; the XP bar outprioritizes the
@@ -339,6 +340,7 @@ impl GameState {
             scoreboard: crate::ui::hud::Scoreboard::default(),
             boss_bars: crate::ui::boss_bar::BossBarState::default(),
             toasts: crate::ui::toast::ToastState::default(),
+            subtitles: crate::ui::subtitles::SubtitleOverlayState::default(),
             tick_count: 0,
             xp_display_start_tick: i64::MIN,
             interaction: InteractionState::new(),
@@ -1296,6 +1298,7 @@ pub fn update_game(
     core.audio
         .set_listener(listener_pos, game.player.look_dir.y_rot_deg());
     core.audio.set_volumes(core.menu.category_volumes());
+    core.audio.set_subtitles_enabled(core.menu.show_subtitles);
 
     gfx.renderer.set_vsync(core.menu.vsync);
 
@@ -2310,6 +2313,28 @@ pub fn update_game(
         game.chat.build(&mut elements, sw, sh, gs, &|t, s| {
             gfx.renderer.menu_text_width(t, s)
         });
+    }
+
+    // Subtitles draw above chat and the tab list; toasts stay on top
+    // (vanilla extract order). The queue is empty while the option is off.
+    let subtitle_now = std::time::Instant::now();
+    for ev in core.audio.take_subtitle_events() {
+        game.subtitles
+            .on_play_sound(&ev.key, *ev.pos, ev.range, subtitle_now);
+    }
+    if core.menu.show_subtitles && !benchmark_running && !game.hide_gui {
+        let (yaw_deg, pitch_deg) = gfx.renderer.camera_effective_look_deg();
+        game.subtitles.build(
+            &mut elements,
+            sw,
+            sh,
+            gs,
+            gfx.renderer.camera_render_position(),
+            yaw_deg,
+            pitch_deg,
+            subtitle_now,
+            &|t, s| gfx.renderer.menu_text_width(t, s),
+        );
     }
 
     // Vanilla Gui.update() runs the toast manager every frame regardless of

--- a/pomme-client/src/audio/mod.rs
+++ b/pomme-client/src/audio/mod.rs
@@ -104,6 +104,17 @@ impl SoundRef {
     }
 }
 
+/// A played sound recorded for the subtitle overlay (vanilla
+/// `SoundEventListener.onPlaySound`).
+pub struct QueuedSubtitle {
+    /// Subtitle translation key, e.g. `subtitles.block.anvil.land`.
+    pub key: String,
+    pub pos: Position,
+    /// Audible range in blocks (vanilla `max(volume, 1.0) *
+    /// attenuationDistance`).
+    pub range: f32,
+}
+
 /// The rodio output device. The `MixerDeviceSink` must be kept alive for the
 /// whole program; sounds play by connecting `Player`s to its mixer.
 struct Output {
@@ -122,6 +133,12 @@ pub struct AudioEngine {
     volumes: [f32; 10],
     listener_left: [f32; 3],
     listener_right: [f32; 3],
+    /// Mirrors the Show Subtitles option; while off, sounds are never
+    /// recorded (vanilla removes the overlay listener entirely).
+    subtitles_enabled: bool,
+    /// Sounds recorded since the last [`Self::take_subtitle_events`] drain.
+    /// A Mutex only because `play_world_sound` takes `&self`.
+    subtitle_events: std::sync::Mutex<Vec<QueuedSubtitle>>,
     music_sink: Option<Player>,
     /// Per-entry `sounds.json` volume of the track currently in `music_sink`,
     /// reapplied each frame so live volume changes keep its relative loudness.
@@ -152,6 +169,8 @@ impl AudioEngine {
             volumes,
             listener_left: [-LISTENER_EAR_OFFSET, 0.0, 0.0],
             listener_right: [LISTENER_EAR_OFFSET, 0.0, 0.0],
+            subtitles_enabled: false,
+            subtitle_events: std::sync::Mutex::new(Vec::new()),
             music_sink: None,
             music_track_volume: 1.0,
             menu_music_active: false,
@@ -196,6 +215,22 @@ impl AudioEngine {
         self.listener_right = [pos.x as f32 + rx, pos.y as f32, pos.z as f32 + rz];
     }
 
+    /// Enables or disables subtitle recording. Cheap; callers can invoke it
+    /// every frame.
+    pub fn set_subtitles_enabled(&mut self, enabled: bool) {
+        self.subtitles_enabled = enabled;
+    }
+
+    /// Drains the sounds recorded for the subtitle overlay since the last
+    /// call.
+    pub fn take_subtitle_events(&mut self) -> Vec<QueuedSubtitle> {
+        std::mem::take(
+            self.subtitle_events
+                .get_mut()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        )
+    }
+
     /// Plays the vanilla button click: MASTER category at the fixed `forUI`
     /// volume.
     pub fn play_ui_click(&self) {
@@ -226,6 +261,19 @@ impl AudioEngine {
         let Some(output) = self.output.as_ref() else {
             return;
         };
+        // Vanilla notifies subtitle listeners before the volume and distance
+        // checks; the overlay applies its own range test.
+        if self.subtitles_enabled
+            && let SoundRef::Event(name) = sound
+            && let Some(key) = self.sounds.subtitle(name)
+            && let Ok(mut queue) = self.subtitle_events.lock()
+        {
+            queue.push(QueuedSubtitle {
+                key: key.to_string(),
+                pos,
+                range: volume.max(1.0) * SOUND_ATTENUATION_BLOCKS,
+            });
+        }
         let Some((source, entry_volume)) = self.decode_sound(sound, seed) else {
             return;
         };

--- a/pomme-client/src/audio/sounds.rs
+++ b/pomme-client/src/audio/sounds.rs
@@ -12,10 +12,17 @@ pub struct SoundVariant {
     pub volume: f32,
 }
 
+/// A sound event's entry in `sounds.json`: its variants and optional
+/// subtitle translation key.
+struct SoundEvent {
+    variants: Vec<SoundVariant>,
+    subtitle: Option<String>,
+}
+
 /// Parsed `sounds.json`: a map from event name (e.g. `music.menu`) to its
-/// variants.
+/// definition.
 pub struct SoundsIndex {
-    events: HashMap<String, Vec<SoundVariant>>,
+    events: HashMap<String, SoundEvent>,
 }
 
 impl SoundsIndex {
@@ -77,7 +84,11 @@ impl SoundsIndex {
                 }
             }
             if !variants.is_empty() {
-                events.insert(event.clone(), variants);
+                let subtitle = def
+                    .get("subtitle")
+                    .and_then(|s| s.as_str())
+                    .map(str::to_string);
+                events.insert(event.clone(), SoundEvent { variants, subtitle });
             }
         }
 
@@ -85,7 +96,13 @@ impl SoundsIndex {
     }
 
     pub fn variants(&self, event: &str) -> Option<&[SoundVariant]> {
-        self.events.get(event).map(Vec::as_slice)
+        self.events.get(event).map(|e| e.variants.as_slice())
+    }
+
+    /// The subtitle translation key for an event, e.g.
+    /// `subtitles.block.anvil.land`.
+    pub fn subtitle(&self, event: &str) -> Option<&str> {
+        self.events.get(event)?.subtitle.as_deref()
     }
 }
 

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -33,6 +33,8 @@ struct Settings {
     fov_effect_scale: f32,
     #[serde(default = "default_true")]
     view_bobbing: bool,
+    #[serde(default)]
+    show_subtitles: bool,
     #[serde(default = "default_true")]
     vsync: bool,
     #[serde(default = "default_max_framerate")]
@@ -131,6 +133,7 @@ impl Default for Settings {
             fov: 70,
             fov_effect_scale: 1.0,
             view_bobbing: true,
+            show_subtitles: false,
             vsync: true,
             max_framerate: 120,
             show_online_status: true,
@@ -414,6 +417,7 @@ pub struct MainMenu {
     /// FOV Effects slider fraction (0..1); squared by `fov_effect()`.
     pub fov_effect_scale: f32,
     pub view_bobbing: bool,
+    pub show_subtitles: bool,
     pub vsync: bool,
     pub max_framerate: u32,
     pub show_online_status: bool,
@@ -519,6 +523,7 @@ impl MainMenu {
             fov: settings.fov,
             fov_effect_scale: settings.fov_effect_scale,
             view_bobbing: settings.view_bobbing,
+            show_subtitles: settings.show_subtitles,
             vsync: settings.vsync,
             max_framerate: settings.max_framerate,
             show_online_status: settings.show_online_status,
@@ -613,6 +618,7 @@ impl MainMenu {
                 fov: self.fov,
                 fov_effect_scale: self.fov_effect_scale,
                 view_bobbing: self.view_bobbing,
+                show_subtitles: self.show_subtitles,
                 vsync: self.vsync,
                 max_framerate: self.max_framerate,
                 show_online_status: self.show_online_status,

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -85,6 +85,14 @@ impl MainMenu {
         }
     }
 
+    fn show_subtitles_label(&self) -> &'static str {
+        if self.show_subtitles {
+            "Show Subtitles: ON"
+        } else {
+            "Show Subtitles: OFF"
+        }
+    }
+
     /// Upper bound of the render distance slider: the server-announced view
     /// distance while connected (can exceed 32), 32 otherwise.
     fn render_distance_max(&self) -> u32 {
@@ -255,7 +263,7 @@ impl MainMenu {
             format!("FOV Effects: {}%", (self.fov_effect() * 100.0).round())
         };
         let rows: Vec<OptRow> = vec![
-            OptRow::Pair("Narrator: OFF", "Show Subtitles: OFF"),
+            OptRow::Pair("Narrator: OFF", self.show_subtitles_label()),
             OptRow::Pair("High Contrast: OFF", "Menu Background Blur: 50%"),
             OptRow::Pair(
                 "Text Background Opacity: 50%",
@@ -322,7 +330,7 @@ impl MainMenu {
             OptRow::Pair(&players, &ambient),
             OptRow::Pair(&voice, &ui),
             OptRow::Big("Device: Default"),
-            OptRow::Pair("Show Subtitles: OFF", "Directional Audio: OFF"),
+            OptRow::Pair(self.show_subtitles_label(), "Directional Audio: OFF"),
             OptRow::Pair("Music Frequency: Normal", "Music Toast: ON"),
         ];
         let sliders: &[(&str, f32)] = &[
@@ -738,6 +746,10 @@ impl MainMenu {
                     }
                     if label.starts_with("VSync:") {
                         self.vsync = !self.vsync;
+                        self.save_settings();
+                    }
+                    if label.starts_with("Show Subtitles:") {
+                        self.show_subtitles = !self.show_subtitles;
                         self.save_settings();
                     }
                     if label.starts_with("Show Online Status:") {

--- a/pomme-client/src/ui/mod.rs
+++ b/pomme-client/src/ui/mod.rs
@@ -20,6 +20,7 @@ pub mod menu;
 pub mod pause;
 pub mod player_tab;
 pub mod server_list;
+pub mod subtitles;
 pub mod text;
 pub mod text_edit;
 pub mod title;

--- a/pomme-client/src/ui/subtitles.rs
+++ b/pomme-client/src/ui/subtitles.rs
@@ -1,0 +1,286 @@
+//! Sound-cue subtitle overlay (vanilla `SubtitleOverlay`), bottom-right.
+
+use std::time::Instant;
+
+use glam::DVec3;
+
+use crate::renderer::pipelines::menu_overlay::MenuElement;
+use crate::ui::common::FONT_SIZE;
+use crate::ui::text::TextSpan;
+
+/// Vanilla `SubtitleOverlay.DISPLAY_TIME` (times the notification-display-time
+/// option, which pomme doesn't have).
+const DISPLAY_TIME_MS: f32 = 3000.0;
+
+/// Vanilla `Font.lineHeight`.
+const LINE_HEIGHT: i32 = 9;
+
+struct PlayedAt {
+    pos: DVec3,
+    time: Instant,
+}
+
+/// One subtitle row: a distinct sound cue and every recent position it played
+/// at (vanilla `SubtitleOverlay.Subtitle`).
+struct Subtitle {
+    key: String,
+    text: String,
+    /// Audible range in blocks, captured from the first play and never
+    /// updated (vanilla parity).
+    range: f32,
+    played_at: Vec<PlayedAt>,
+}
+
+impl Subtitle {
+    fn closest(&self, listener: DVec3) -> Option<&PlayedAt> {
+        self.played_at.iter().min_by(|a, b| {
+            a.pos
+                .distance_squared(listener)
+                .total_cmp(&b.pos.distance_squared(listener))
+        })
+    }
+
+    /// Vanilla `isAudibleFrom`: infinite-range sounds are always audible;
+    /// otherwise the nearest source must be strictly within range.
+    fn is_audible_from(&self, listener: DVec3) -> bool {
+        if self.range.is_infinite() {
+            return true;
+        }
+        let Some(closest) = self.closest(listener) else {
+            return false;
+        };
+        closest.pos.distance_squared(listener) < (self.range as f64).powi(2)
+    }
+}
+
+/// State for the Show Subtitles overlay. The master list is append-only:
+/// expired entries keep their slot with an empty `played_at` so a repeating
+/// sound reclaims its original stacking position (vanilla parity; bounded by
+/// the number of distinct subtitle keys).
+#[derive(Default)]
+pub struct SubtitleOverlayState {
+    subtitles: Vec<Subtitle>,
+}
+
+impl SubtitleOverlayState {
+    pub fn clear(&mut self) {
+        self.subtitles.clear();
+    }
+
+    /// Records a played sound (vanilla `onPlaySound` + `Subtitle.refresh`).
+    /// Dedup is by subtitle key; a replay at an identical position replaces
+    /// that position's timestamp, a new position is tracked alongside.
+    pub fn on_play_sound(&mut self, key: &str, pos: DVec3, range: f32, now: Instant) {
+        if let Some(existing) = self.subtitles.iter_mut().find(|s| s.key == key) {
+            existing.played_at.retain(|p| p.pos != pos);
+            existing.played_at.push(PlayedAt { pos, time: now });
+            return;
+        }
+        self.subtitles.push(Subtitle {
+            key: key.to_string(),
+            text: crate::lang::translate(key).unwrap_or(key).to_string(),
+            range,
+            played_at: vec![PlayedAt { pos, time: now }],
+        });
+    }
+
+    /// Builds the overlay: a shared-width column of black boxes anchored
+    /// bottom-right, oldest cue at the bottom, stacking upward, with `<`/`>`
+    /// arrows for sources outside the camera's forward cone.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build(
+        &mut self,
+        elements: &mut Vec<MenuElement>,
+        screen_w: f32,
+        screen_h: f32,
+        gs: f32,
+        cam_pos: DVec3,
+        yaw_deg: f32,
+        pitch_deg: f32,
+        now: Instant,
+        text_width: &dyn Fn(&str, f32) -> f32,
+    ) {
+        // Vanilla listener basis: forward = directionFromRotation(pitch, yaw),
+        // up = directionFromRotation(pitch - 90, yaw), right = forward x up.
+        let (sin_y, cos_y) = (yaw_deg.to_radians() as f64).sin_cos();
+        let (sin_p, cos_p) = (pitch_deg.to_radians() as f64).sin_cos();
+        let forward = DVec3::new(-sin_y * cos_p, -sin_p, cos_y * cos_p);
+        let up = DVec3::new(-sin_y * sin_p, cos_p, cos_y * sin_p);
+        let right = forward.cross(up);
+
+        // Audible pass, then purge expired positions; entries emptied by the
+        // purge drop out of this frame but keep their master-list slot.
+        let mut displayed: Vec<usize> = Vec::new();
+        for (i, subtitle) in self.subtitles.iter_mut().enumerate() {
+            if !subtitle.is_audible_from(cam_pos) {
+                continue;
+            }
+            subtitle
+                .played_at
+                .retain(|p| ms_since(now, p.time) <= DISPLAY_TIME_MS);
+            if !subtitle.played_at.is_empty() {
+                displayed.push(i);
+            }
+        }
+        if displayed.is_empty() {
+            return;
+        }
+
+        // Shared box width: the widest text plus vanilla's "< " / " >" padding,
+        // in integer GUI units to keep vanilla's integer-division layout.
+        let gui_w = |t: &str| text_width(t, FONT_SIZE).round() as i32;
+        let mut width = displayed
+            .iter()
+            .map(|&i| gui_w(&self.subtitles[i].text))
+            .max()
+            .unwrap_or(0);
+        width += gui_w("<") + gui_w(" ") + gui_w(">") + gui_w(" ");
+        let half_width = width / 2;
+        let half_height = LINE_HEIGHT / 2;
+
+        let mut row = 0;
+        for &i in &displayed {
+            let subtitle = &self.subtitles[i];
+            let Some(closest) = subtitle.closest(cam_pos) else {
+                continue;
+            };
+            let delta = normalize_or_zero(closest.pos - cam_pos);
+            let rightness = right.dot(delta);
+            let in_view = forward.dot(delta) > 0.5;
+
+            // Vanilla translates to the box center, then draws relative to it.
+            let cx = screen_w - (half_width as f32 + 2.0) * gs;
+            let cy = screen_h - (35.0 + row as f32 * (LINE_HEIGHT + 1) as f32) * gs;
+
+            elements.push(MenuElement::Rect {
+                x: cx - (half_width + 1) as f32 * gs,
+                y: cy - (half_height + 1) as f32 * gs,
+                w: (2 * half_width + 2) as f32 * gs,
+                h: (LINE_HEIGHT + 1) as f32 * gs,
+                corner_radius: 0.0,
+                color: [0.0, 0.0, 0.0, 0.8],
+            });
+
+            // Brightness fades 255 -> 75 over the display time; alpha stays 1.
+            let t = ms_since(now, closest.time) / DISPLAY_TIME_MS;
+            let b = clamped_lerp(t, 255.0, 75.0).floor() / 255.0;
+            let color = [b, b, b, 1.0];
+            let text_y = cy - half_height as f32 * gs;
+            let mut push_text = |text: String, x: f32| {
+                elements.push(MenuElement::McText {
+                    x,
+                    y: text_y,
+                    spans: vec![TextSpan::new(text, color)],
+                    scale: FONT_SIZE * gs,
+                    centered: false,
+                    shadow: true,
+                });
+            };
+
+            if !in_view {
+                if rightness > 0.0 {
+                    push_text(">".to_string(), cx + (half_width - gui_w(">")) as f32 * gs);
+                } else if rightness < 0.0 {
+                    push_text("<".to_string(), cx - half_width as f32 * gs);
+                }
+            }
+            let text_w = gui_w(&subtitle.text);
+            push_text(subtitle.text.clone(), cx - (text_w / 2) as f32 * gs);
+            row += 1;
+        }
+    }
+}
+
+fn ms_since(now: Instant, then: Instant) -> f32 {
+    now.saturating_duration_since(then).as_secs_f32() * 1000.0
+}
+
+/// Vanilla `Vec3.normalize`: the zero vector for lengths under 1e-5.
+fn normalize_or_zero(v: DVec3) -> DVec3 {
+    let len = v.length();
+    if len < 1.0e-5 { DVec3::ZERO } else { v / len }
+}
+
+/// Vanilla `Mth.clampedLerp`.
+fn clamped_lerp(t: f32, min: f32, max: f32) -> f32 {
+    if t < 0.0 {
+        min
+    } else if t > 1.0 {
+        max
+    } else {
+        min + t * (max - min)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn dummy_elements(state: &mut SubtitleOverlayState, now: Instant) -> Vec<MenuElement> {
+        let mut elements = Vec::new();
+        state.build(
+            &mut elements,
+            1920.0,
+            1080.0,
+            1.0,
+            DVec3::ZERO,
+            0.0,
+            0.0,
+            now,
+            &|t, s| t.len() as f32 * s * 0.75,
+        );
+        elements
+    }
+
+    #[test]
+    fn refresh_dedups_by_key_and_exact_position() {
+        let now = Instant::now();
+        let mut state = SubtitleOverlayState::default();
+        state.on_play_sound("subtitles.a", DVec3::new(1.0, 0.0, 0.0), 16.0, now);
+        state.on_play_sound("subtitles.a", DVec3::new(2.0, 0.0, 0.0), 16.0, now);
+        assert_eq!(state.subtitles.len(), 1);
+        assert_eq!(state.subtitles[0].played_at.len(), 2);
+
+        // Exact-position replay replaces rather than appends.
+        state.on_play_sound("subtitles.a", DVec3::new(1.0, 0.0, 0.0), 16.0, now);
+        assert_eq!(state.subtitles[0].played_at.len(), 2);
+    }
+
+    #[test]
+    fn positions_purge_after_display_time() {
+        let start = Instant::now();
+        let mut state = SubtitleOverlayState::default();
+        state.on_play_sound("subtitles.a", DVec3::new(1.0, 0.0, 0.0), 16.0, start);
+        let later = start + Duration::from_millis(3001);
+        assert!(dummy_elements(&mut state, later).is_empty());
+        // The master-list entry survives the purge.
+        assert_eq!(state.subtitles.len(), 1);
+        assert!(state.subtitles[0].played_at.is_empty());
+    }
+
+    #[test]
+    fn audible_range_is_strict() {
+        let now = Instant::now();
+        let mut state = SubtitleOverlayState::default();
+        state.on_play_sound("subtitles.a", DVec3::new(16.0, 0.0, 0.0), 16.0, now);
+        assert!(!state.subtitles[0].is_audible_from(DVec3::ZERO));
+        state.on_play_sound("subtitles.b", DVec3::new(15.9, 0.0, 0.0), 16.0, now);
+        assert!(state.subtitles[1].is_audible_from(DVec3::ZERO));
+    }
+
+    #[test]
+    fn expired_subtitle_keeps_its_slot_on_replay() {
+        let start = Instant::now();
+        let mut state = SubtitleOverlayState::default();
+        state.on_play_sound("subtitles.a", DVec3::new(1.0, 0.0, 0.0), 16.0, start);
+        state.on_play_sound("subtitles.b", DVec3::new(1.0, 0.0, 0.0), 16.0, start);
+        // Expire both, then replay A: it must stay at index 0 (bottom row).
+        let later = start + Duration::from_millis(4000);
+        dummy_elements(&mut state, later);
+        state.on_play_sound("subtitles.a", DVec3::new(1.0, 0.0, 0.0), 16.0, later);
+        assert_eq!(state.subtitles[0].key, "subtitles.a");
+        assert_eq!(state.subtitles[0].played_at.len(), 1);
+    }
+}


### PR DESCRIPTION
Sound cue subtitles bottom right with directional arrows, toggled via Show Subtitles in the Music & Sounds and Accessibility screens (off by default, persisted).

- sounds.json subtitle keys are now parsed; play_world_sound queues cues for the overlay when the option is on
- fixed 16 block audible range (attenuation_distance still unparsed, same as the audio path), 3s display time, 0.8 background alpha
- drawn above chat and the tab list; cleared on disconnect