### PR TITLE
add mount jump bar

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -422,6 +422,9 @@ impl AppCore {
                     // Login/respawn recreate vanilla's LocalPlayer, resetting
                     // the XP display sentinel; waypoints persist.
                     game.xp_display_start_tick = i64::MIN;
+                    game.controlled_vehicle_id = None;
+                    game.player.jump_riding_ticks = 0;
+                    game.player.jump_riding_scale = 0.0;
 
                     renderer.clear_chunk_meshes();
                     game.mesh_dispatcher =
@@ -572,6 +575,26 @@ impl AppCore {
 
                         let _ = window.set_cursor_grab(CursorGrabMode::None);
                         window.set_cursor_visible(true);
+                    }
+                }
+                NetworkEvent::SetPassengers {
+                    vehicle,
+                    passengers,
+                } => {
+                    let me = game.player.entity_id;
+                    if passengers.first() == Some(&me) {
+                        game.controlled_vehicle_id = Some(vehicle);
+                    } else if passengers.contains(&me)
+                        || game.controlled_vehicle_id == Some(vehicle)
+                    {
+                        // Riding but not controlling, or removed from this
+                        // vehicle (vanilla getControlledVehicle -> null).
+                        game.controlled_vehicle_id = None;
+                    }
+                }
+                NetworkEvent::EntitySaddle { entity_id, saddled } => {
+                    if let Some(e) = game.entity_store.living.get_mut(&entity_id) {
+                        e.saddled = saddled;
                     }
                 }
                 NetworkEvent::PlayerExperience { progress, level } => {
@@ -1172,6 +1195,9 @@ impl AppCore {
                         }
                     }
                     game.item_entity_store.remove(&ids);
+                    if game.controlled_vehicle_id.is_some_and(|v| ids.contains(&v)) {
+                        game.controlled_vehicle_id = None;
+                    }
                 }
                 NetworkEvent::EntityHeadRotation {
                     id,
@@ -1516,6 +1542,50 @@ impl AppCore {
 
         let neutral = InputState::released();
         let input = if input_live { &self.input } else { &neutral };
+
+        // Vanilla LocalPlayer.aiStep ride-jump charge. `was_jump_pressed`
+        // still holds last tick's key here (movement::tick overwrites it
+        // below), matching vanilla's wasJumping sampled before input.tick().
+        // Equine jump cooldown is always 0, so the cooldown gate collapses
+        // into the vehicle check.
+        let jump_held = input.performing_action(Action::Jump);
+        if game.riding_jumpable_vehicle() {
+            let p = &mut game.player;
+            if p.jump_riding_ticks < 0 {
+                p.jump_riding_ticks += 1;
+                if p.jump_riding_ticks == 0 {
+                    p.jump_riding_scale = 0.0;
+                }
+            }
+            if p.was_jump_pressed && !jump_held {
+                p.jump_riding_ticks = -10;
+                // Vanilla also calls vehicle.onPlayerJump() for client horse
+                // physics; pomme has no vehicle physics, the server moves us.
+                use azalea_protocol::packets::game::s_player_command as cmd;
+                connection
+                    .packet_tx
+                    .send(ServerboundGamePacket::PlayerCommand(
+                        cmd::ServerboundPlayerCommand {
+                            id: azalea_core::entity_id::MinecraftEntityId(p.entity_id),
+                            action: cmd::Action::StartRidingJump,
+                            data: (p.jump_riding_scale * 100.0).floor() as u32,
+                        },
+                    ));
+            } else if !p.was_jump_pressed && jump_held {
+                p.jump_riding_ticks = 0;
+                p.jump_riding_scale = 0.0;
+            } else if p.was_jump_pressed {
+                p.jump_riding_ticks += 1;
+                p.jump_riding_scale = if p.jump_riding_ticks < 10 {
+                    p.jump_riding_ticks as f32 * 0.1
+                } else {
+                    0.8 + 2.0 / (p.jump_riding_ticks - 9) as f32 * 0.1
+                };
+            }
+        } else {
+            // Vanilla keeps jumpRidingTicks; only the scale resets.
+            game.player.jump_riding_scale = 0.0;
+        }
 
         game.player.prev_look_dir = game.player.look_dir;
         game.player.look_dir = renderer.camera_look_dir();

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -163,6 +163,9 @@ pub struct GameState {
     /// `experienceDisplayStartTick`; `i64::MIN` = untouched since (re)spawn,
     /// so the first change after joining never takes priority).
     pub xp_display_start_tick: i64,
+    /// Vehicle we are the controlling (first) passenger of, from
+    /// `SetPassengers` (vanilla `getControlledVehicle`).
+    pub controlled_vehicle_id: Option<i32>,
     pub interaction: InteractionState,
     pub sky_state: crate::renderer::SkyState,
     pub show_debug: bool,
@@ -343,6 +346,7 @@ impl GameState {
             subtitles: crate::ui::subtitles::SubtitleOverlayState::default(),
             tick_count: 0,
             xp_display_start_tick: i64::MIN,
+            controlled_vehicle_id: None,
             interaction: InteractionState::new(),
             sky_state: SkyState::default_day(),
             show_debug: false,
@@ -384,6 +388,15 @@ impl GameState {
             vis_task: None,
             chunk_occlusion_enabled: true,
         }
+    }
+
+    /// Vanilla `LocalPlayer.jumpableVehicle() != null`: controlling a saddled
+    /// equine. Equine `getJumpCooldown()` is always 0; camels/nautilus (dash
+    /// cooldown) aren't tracked by the entity store yet.
+    pub fn riding_jumpable_vehicle(&self) -> bool {
+        self.controlled_vehicle_id
+            .and_then(|id| self.entity_store.living.get(&id))
+            .is_some_and(|e| crate::entity::is_equine(&e.entity_type) && e.saddled)
     }
 
     pub fn gui_open(&self) -> bool {
@@ -1646,10 +1659,35 @@ pub fn update_game(
             }
         }
         // Contextual bar choice (vanilla Hud.nextContextualInfoState): the
-        // locator bar takes the XP bar's slot while waypoints are tracked,
-        // except for 100 ticks after an XP change.
-        let show_locator = game.waypoints.has_waypoints()
-            && !(is_survival && game.xp_display_start_tick + 100 > game.tick_count as i64);
+        // jump bar takes the slot while controlling a saddled mount, the
+        // locator bar while waypoints are tracked; an active jump charge or
+        // an XP change within 100 ticks outprioritizes the locator.
+        enum BarChoice {
+            Jump,
+            Xp,
+            Locator,
+            Empty,
+        }
+        let can_jump_bar = game.riding_jumpable_vehicle();
+        let jump_charge = game.player.jump_riding_scale;
+        let xp_prioritized =
+            is_survival && game.xp_display_start_tick + 100 > game.tick_count as i64;
+        let bar_choice = if game.waypoints.has_waypoints() {
+            if can_jump_bar && jump_charge > 0.0 {
+                BarChoice::Jump
+            } else if xp_prioritized {
+                BarChoice::Xp
+            } else {
+                BarChoice::Locator
+            }
+        } else if can_jump_bar {
+            BarChoice::Jump
+        } else if is_survival {
+            BarChoice::Xp
+        } else {
+            BarChoice::Empty
+        };
+        let show_locator = matches!(bar_choice, BarChoice::Locator);
         let locator_dots = if show_locator {
             let (yaw_deg, pitch_deg) = gfx.renderer.camera_effective_look_deg();
             let cam = crate::world::waypoints::WaypointCamera {
@@ -1686,15 +1724,16 @@ pub fn update_game(
         } else {
             Vec::new()
         };
-        let bar = if show_locator {
-            hud::ContextualBarKind::Locator {
+        let bar = match bar_choice {
+            BarChoice::Jump => hud::ContextualBarKind::JumpableVehicle {
+                charge: jump_charge,
+            },
+            BarChoice::Xp => hud::ContextualBarKind::Experience,
+            BarChoice::Locator => hud::ContextualBarKind::Locator {
                 dots: &locator_dots,
                 arrow_frame_1: game.tick_count % 14 >= 10,
-            }
-        } else if is_survival {
-            hud::ContextualBarKind::Experience
-        } else {
-            hud::ContextualBarKind::Empty
+            },
+            BarChoice::Empty => hud::ContextualBarKind::Empty,
         };
         // Vanilla `renderMaxAttackIndicator`: the picked entity is living
         // (implicit: pomme entity hits only come from `living`), alive, at

--- a/pomme-client/src/entity/mod.rs
+++ b/pomme-client/src/entity/mod.rs
@@ -156,6 +156,8 @@ pub struct LivingEntity {
     pub mouth_anim: f32,
     pub prev_mouth_anim: f32,
     pub has_chest: bool,
+    /// Saddle equipment slot occupied (`SetEquipment`); gates the jump bar.
+    pub saddled: bool,
     /// Packet-driven velocity (vanilla remote entities never integrate their
     /// own); feeds the squid body-rotation sim.
     pub velocity: DVec3,
@@ -298,6 +300,7 @@ impl LivingEntity {
             mouth_anim: 0.0,
             prev_mouth_anim: 0.0,
             has_chest: false,
+            saddled: false,
             velocity: DVec3::ZERO,
             is_in_water: false,
             x_body_rot: 0.0,

--- a/pomme-client/src/net/handler.rs
+++ b/pomme-client/src/net/handler.rs
@@ -666,6 +666,23 @@ pub fn handle_game_packet(
             let ids: Vec<i32> = p.entity_ids.iter().map(|id| id.0).collect();
             let _ = event_tx.try_send(NetworkEvent::EntitiesRemoved { ids });
         }
+        ClientboundGamePacket::SetPassengers(p) => {
+            let _ = event_tx.try_send(NetworkEvent::SetPassengers {
+                vehicle: p.vehicle.0,
+                passengers: p.passengers.iter().map(|id| id.0).collect(),
+            });
+        }
+        ClientboundGamePacket::SetEquipment(p) => {
+            // Only the saddle slot is tracked; equipment rendering is a TODO.
+            for (slot, item) in &p.slots.slots {
+                if *slot == azalea_inventory::components::EquipmentSlot::Saddle {
+                    let _ = event_tx.try_send(NetworkEvent::EntitySaddle {
+                        entity_id: p.entity_id.0,
+                        saddled: item.is_present(),
+                    });
+                }
+            }
+        }
         ClientboundGamePacket::SetEntityData(p) => {
             for item in p.packed_items.iter() {
                 // index 8 = item stack data for item entities

--- a/pomme-client/src/net/mod.rs
+++ b/pomme-client/src/net/mod.rs
@@ -101,6 +101,14 @@ pub enum NetworkEvent {
         effect_id: u32,
     },
     ClearMobEffects,
+    SetPassengers {
+        vehicle: i32,
+        passengers: Vec<i32>,
+    },
+    EntitySaddle {
+        entity_id: i32,
+        saddled: bool,
+    },
     Waypoint {
         operation: azalea_protocol::packets::game::c_waypoint::WaypointOperation,
         waypoint: azalea_protocol::packets::game::c_waypoint::TrackedWaypoint,

--- a/pomme-client/src/player/mod.rs
+++ b/pomme-client/src/player/mod.rs
@@ -58,6 +58,11 @@ pub struct LocalPlayer {
     pub jump_trigger_time: u32,
     pub no_jump_delay: u32,
     pub was_jump_pressed: bool,
+    /// Vanilla `jumpRidingTicks`: ride-jump charge ticks; negative counts up
+    /// through the post-jump refractory window.
+    pub jump_riding_ticks: i32,
+    /// Vanilla `jumpRidingScale`: jump-bar fill, 0..=1.
+    pub jump_riding_scale: f32,
     /// Vanilla `onUpdateAbilities`: a locally toggled `flying` still has to be
     /// reported to the server via `ServerboundPlayerAbilities`.
     pub abilities_dirty: bool,
@@ -109,6 +114,8 @@ impl LocalPlayer {
             jump_trigger_time: 0,
             no_jump_delay: 0,
             was_jump_pressed: false,
+            jump_riding_ticks: 0,
+            jump_riding_scale: 0.0,
             abilities_dirty: false,
             eye_height: STANDING_EYE_HEIGHT,
             prev_eye_height: STANDING_EYE_HEIGHT,

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -1725,6 +1725,8 @@ pub enum SpriteId {
     ToastWoodenPlanks,
     ToastSocialInteractions,
     ToastRightClick,
+    JumpBarBackground,
+    JumpBarProgress,
     LocatorBarBackground,
     LocatorDotDefault0,
     LocatorDotDefault1,
@@ -2076,6 +2078,16 @@ fn build_sprite_atlas(
         (
             SpriteId::HotbarAttackIndicatorProgress,
             "minecraft/textures/gui/sprites/hud/hotbar_attack_indicator_progress.png",
+            0.0,
+        ),
+        (
+            SpriteId::JumpBarBackground,
+            "minecraft/textures/gui/sprites/hud/jump_bar_background.png",
+            0.0,
+        ),
+        (
+            SpriteId::JumpBarProgress,
+            "minecraft/textures/gui/sprites/hud/jump_bar_progress.png",
             0.0,
         ),
         (

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -13,13 +13,17 @@ use crate::ui::text::TextSpan;
 use crate::world::waypoints::{LocatorDot, PitchDirection, WaypointStyleId};
 
 /// Which bar occupies the slot above the hotbar (vanilla `ContextualInfo`).
-// TODO: JumpableVehicle bar.
 pub enum ContextualBarKind<'a> {
     Empty,
     Experience,
     Locator {
         dots: &'a [LocatorDot],
         arrow_frame_1: bool,
+    },
+    /// Ride-jump charge meter (vanilla `JumpableVehicleBar`).
+    // TODO: cooldown overlay when camel/nautilus dash mounts land.
+    JumpableVehicle {
+        charge: f32,
     },
 }
 
@@ -615,6 +619,7 @@ pub fn build_hud(
     let bar_background = match bar {
         ContextualBarKind::Experience => Some(SpriteId::ExperienceBarBackground),
         ContextualBarKind::Locator { .. } => Some(SpriteId::LocatorBarBackground),
+        ContextualBarKind::JumpableVehicle { .. } => Some(SpriteId::JumpBarBackground),
         ContextualBarKind::Empty => None,
     };
     if let Some(sprite) = bar_background {
@@ -628,27 +633,39 @@ pub fn build_hud(
         });
     }
 
-    if matches!(bar, ContextualBarKind::Experience) {
+    // Left-clipped progress fill; the scissored full-width draw is pixel-
+    // equivalent to vanilla's UV sub-rect blit at identical scale.
+    let bar_fill = match bar {
         // Vanilla ExperienceBar: (int)(experienceProgress * 183).
-        let fill_px = (experience_progress.clamp(0.0, 1.0) * 183.0) as i32;
-        if fill_px > 0 {
-            let fill_w = (fill_px as f32 * gs).round();
-            elements.push(MenuElement::ScissorPush {
-                x: bar_x,
-                y: bar_y,
-                w: fill_w,
-                h: bar_h,
-            });
-            elements.push(MenuElement::Image {
-                x: bar_x,
-                y: bar_y,
-                w: bar_w,
-                h: bar_h,
-                sprite: SpriteId::ExperienceBarProgress,
-                tint: WHITE,
-            });
-            elements.push(MenuElement::ScissorPop);
-        }
+        ContextualBarKind::Experience => Some((
+            (experience_progress.clamp(0.0, 1.0) * 183.0) as i32,
+            SpriteId::ExperienceBarProgress,
+        )),
+        // Vanilla JumpableVehicleBar: Mth.lerpDiscrete(scale, 0, 182).
+        ContextualBarKind::JumpableVehicle { charge } => Some((
+            (charge.clamp(0.0, 1.0) * 181.0).floor() as i32 + i32::from(charge > 0.0),
+            SpriteId::JumpBarProgress,
+        )),
+        _ => None,
+    };
+    if let Some((fill_px, sprite)) = bar_fill
+        && fill_px > 0
+    {
+        elements.push(MenuElement::ScissorPush {
+            x: bar_x,
+            y: bar_y,
+            w: (fill_px as f32 * gs).round(),
+            h: bar_h,
+        });
+        elements.push(MenuElement::Image {
+            x: bar_x,
+            y: bar_y,
+            w: bar_w,
+            h: bar_h,
+            sprite,
+            tint: WHITE,
+        });
+        elements.push(MenuElement::ScissorPop);
     }
 
     // Vanilla draws the level number over whichever bar is showing, between


### PR DESCRIPTION
Jump charge meter replaces the XP bar while riding a saddled horse family mount. Tracks SetPassengers and the saddle equipment slot, ports the LocalPlayer charge curve, sends StartRidingJump on release. Camel/nautilus dash cooldown left as a TODO (not in the entity store yet).