### PR TITLE
add mount health row

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -423,6 +423,7 @@ impl AppCore {
                     // the XP display sentinel; waypoints persist.
                     game.xp_display_start_tick = i64::MIN;
                     game.controlled_vehicle_id = None;
+                    game.riding_vehicle_id = None;
                     game.player.jump_riding_ticks = 0;
                     game.player.jump_riding_scale = 0.0;
 
@@ -582,14 +583,20 @@ impl AppCore {
                     passengers,
                 } => {
                     let me = game.player.entity_id;
-                    if passengers.first() == Some(&me) {
-                        game.controlled_vehicle_id = Some(vehicle);
-                    } else if passengers.contains(&me)
-                        || game.controlled_vehicle_id == Some(vehicle)
-                    {
-                        // Riding but not controlling, or removed from this
-                        // vehicle (vanilla getControlledVehicle -> null).
-                        game.controlled_vehicle_id = None;
+                    if passengers.contains(&me) {
+                        game.riding_vehicle_id = Some(vehicle);
+                        // Only the first passenger controls (vanilla
+                        // getControlledVehicle -> null otherwise).
+                        game.controlled_vehicle_id =
+                            (passengers.first() == Some(&me)).then_some(vehicle);
+                    } else {
+                        // Removed from this vehicle.
+                        if game.riding_vehicle_id == Some(vehicle) {
+                            game.riding_vehicle_id = None;
+                        }
+                        if game.controlled_vehicle_id == Some(vehicle) {
+                            game.controlled_vehicle_id = None;
+                        }
                     }
                 }
                 NetworkEvent::EntitySaddle { entity_id, saddled } => {
@@ -644,6 +651,9 @@ impl AppCore {
                 } => {
                     if entity_id == game.player.entity_id {
                         game.player.max_health = max_health;
+                    }
+                    if let Some(e) = game.entity_store.living.get_mut(&entity_id) {
+                        e.max_health = max_health;
                     }
                 }
                 NetworkEvent::ContainerContent {
@@ -1197,6 +1207,9 @@ impl AppCore {
                     game.item_entity_store.remove(&ids);
                     if game.controlled_vehicle_id.is_some_and(|v| ids.contains(&v)) {
                         game.controlled_vehicle_id = None;
+                    }
+                    if game.riding_vehicle_id.is_some_and(|v| ids.contains(&v)) {
+                        game.riding_vehicle_id = None;
                     }
                 }
                 NetworkEvent::EntityHeadRotation {

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -166,6 +166,8 @@ pub struct GameState {
     /// Vehicle we are the controlling (first) passenger of, from
     /// `SetPassengers` (vanilla `getControlledVehicle`).
     pub controlled_vehicle_id: Option<i32>,
+    /// Vehicle we are any passenger of (vanilla `getVehicle`).
+    pub riding_vehicle_id: Option<i32>,
     pub interaction: InteractionState,
     pub sky_state: crate::renderer::SkyState,
     pub show_debug: bool,
@@ -347,6 +349,7 @@ impl GameState {
             tick_count: 0,
             xp_display_start_tick: i64::MIN,
             controlled_vehicle_id: None,
+            riding_vehicle_id: None,
             interaction: InteractionState::new(),
             sky_state: SkyState::default_day(),
             show_debug: false,
@@ -397,6 +400,15 @@ impl GameState {
         self.controlled_vehicle_id
             .and_then(|id| self.entity_store.living.get(&id))
             .is_some_and(|e| crate::entity::is_equine(&e.entity_type) && e.saddled)
+    }
+
+    /// Vanilla `Hud.getPlayerVehicleWithHealth`: (health, max health) of the
+    /// ridden vehicle when it is living (`Entity.showVehicleHealth`); the
+    /// living-store lookup is the `instanceof LivingEntity` gate.
+    pub fn vehicle_health(&self) -> Option<(f32, f32)> {
+        self.riding_vehicle_id
+            .and_then(|id| self.entity_store.living.get(&id))
+            .map(|e| (e.health, e.max_health))
     }
 
     pub fn gui_open(&self) -> bool {
@@ -1769,6 +1781,7 @@ pub fn update_game(
             game.player.armor,
             air_bubbles,
             game.player.eyes_in_water,
+            game.vehicle_health(),
             game.tick_count,
             game.player.experience_level,
             game.player.experience_progress,

--- a/pomme-client/src/entity/mod.rs
+++ b/pomme-client/src/entity/mod.rs
@@ -131,6 +131,8 @@ pub struct LivingEntity {
     pub anger_end_time: i64,
     /// Metadata health; drives the tame wolf's tail angle.
     pub health: f32,
+    /// `max_health` attribute (`UpdateAttributes`); sizes the mount heart row.
+    pub max_health: f32,
     pub interested_angle: f32,
     pub prev_interested_angle: f32,
     pub shake_anim: f32,
@@ -226,6 +228,11 @@ impl LivingEntity {
         body_y_rot_deg: f32,
         player_uuid: Option<uuid::Uuid>,
     ) -> Self {
+        let default_health = if entity_type == EntityKind::IronGolem {
+            100.0
+        } else {
+            20.0
+        };
         Self {
             position,
             prev_position: position,
@@ -272,11 +279,8 @@ impl LivingEntity {
             anger_end_time: -1,
             // Vanilla constructs at max health; the golem's crack overlay
             // reads it before the metadata arrives.
-            health: if entity_type == EntityKind::IronGolem {
-                100.0
-            } else {
-                20.0
-            },
+            health: default_health,
+            max_health: default_health,
             interested_angle: 0.0,
             prev_interested_angle: 0.0,
             shake_anim: 0.0,

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -1688,6 +1688,9 @@ pub enum SpriteId {
     HeartHalf,
     HeartAbsorbingFull,
     HeartAbsorbingHalf,
+    HeartVehicleContainer,
+    HeartVehicleFull,
+    HeartVehicleHalf,
     FoodEmpty,
     FoodFull,
     FoodHalf,
@@ -1993,6 +1996,21 @@ fn build_sprite_atlas(
         (
             SpriteId::HeartAbsorbingHalf,
             "minecraft/textures/gui/sprites/hud/heart/absorbing_half.png",
+            0.0,
+        ),
+        (
+            SpriteId::HeartVehicleContainer,
+            "minecraft/textures/gui/sprites/hud/heart/vehicle_container.png",
+            0.0,
+        ),
+        (
+            SpriteId::HeartVehicleFull,
+            "minecraft/textures/gui/sprites/hud/heart/vehicle_full.png",
+            0.0,
+        ),
+        (
+            SpriteId::HeartVehicleHalf,
+            "minecraft/textures/gui/sprites/hud/heart/vehicle_half.png",
             0.0,
         ),
         (

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -372,6 +372,8 @@ pub fn build_hud(
     // Gated to survival by the caller.
     air_bubbles: Option<AirBubbles>,
     eyes_in_water: bool,
+    // (health, max health) of the ridden living vehicle, if any.
+    vehicle_health: Option<(f32, f32)>,
     tick: u64,
     experience_level: i32,
     experience_progress: f32,
@@ -565,6 +567,9 @@ pub fn build_hud(
     // Vanilla Hud shares one Random across heart jitter, food shake and bubble
     // wobble, seeded once per frame; `tickCount * 312871` wraps at 32 bits.
     let mut hud_rng = crate::util::JavaRandom::new((tick as i32).wrapping_mul(312871) as i64);
+    // Vanilla getVehicleMaxHearts: (maxHealth + 0.5) / 2 hearts, capped at 30.
+    let vehicle_hearts = vehicle_health.map_or(0, |(_, max)| ((max + 0.5) as i32 / 2).min(30));
+    let vehicle_rows = (vehicle_hearts + 9) / 10;
     let is_survival = crate::player::is_survival(game_mode);
     if is_survival {
         let absorption_halves = absorption.ceil().max(0.0) as i32;
@@ -579,19 +584,22 @@ pub fn build_hud(
             &mut hud_rng,
             gs,
         );
+        // Mount hearts replace the food bar (vanilla extractPlayerHealth).
         // TODO: food shake consumes from hud_rng between hearts and bubbles in
         // vanilla.
-        build_status_bar(
-            elements,
-            hotbar_x + hotbar_w,
-            status_bar_y,
-            food as f32,
-            true,
-            SpriteId::FoodEmpty,
-            SpriteId::FoodFull,
-            SpriteId::FoodHalf,
-            gs,
-        );
+        if vehicle_hearts == 0 {
+            build_status_bar(
+                elements,
+                hotbar_x + hotbar_w,
+                status_bar_y,
+                food as f32,
+                true,
+                SpriteId::FoodEmpty,
+                SpriteId::FoodFull,
+                SpriteId::FoodHalf,
+                gs,
+            );
+        }
 
         if armor > 0 {
             // Vanilla `yLineBase - (rows - 1) * rowHeight - 10`.
@@ -609,6 +617,21 @@ pub fn build_hud(
                 gs,
             );
         }
+    }
+
+    // Vanilla draws these outside the canHurtPlayer gate, so creative shows
+    // mount hearts too.
+    if let Some((vehicle_hp, _)) = vehicle_health
+        && vehicle_hearts > 0
+    {
+        build_vehicle_hearts(
+            elements,
+            hotbar_x + hotbar_w,
+            status_bar_y,
+            vehicle_hearts,
+            vehicle_hp,
+            gs,
+        );
     }
 
     let bar_w = XP_BAR_W * gs;
@@ -705,7 +728,12 @@ pub fn build_hud(
     }
 
     if let Some(bubbles) = air_bubbles {
-        let bubble_y = (status_bar_y - (ICON_SIZE * 2.0 + 1.0) * gs).round();
+        // Vanilla getAirBubbleYLine: one 10px slot above the topmost mount
+        // heart row (or the food bar when there is no mount).
+        let bubble_y = (status_bar_y
+            - (ICON_SIZE * 2.0 + 1.0) * gs
+            - (vehicle_rows.max(1) - 1) as f32 * 10.0 * gs)
+            .round();
         let icon_size = ICON_SIZE * gs;
         let wobbling = bubbles.empty == 10 && tick.is_multiple_of(2);
         for b in 1..=10i32 {
@@ -1305,6 +1333,51 @@ fn build_status_bar(
                 tint: WHITE,
             });
         }
+    }
+}
+
+/// Vanilla `Hud.extractVehicleHealth`: right-aligned mount hearts in rows of
+/// 10 stacked 10px apart, bottom row first; no blink or hardcore variants.
+fn build_vehicle_hearts(
+    elements: &mut Vec<MenuElement>,
+    x_right: f32,
+    y: f32,
+    hearts: i32,
+    health: f32,
+    gs: f32,
+) {
+    let icon_size = ICON_SIZE * gs;
+    let current = health.ceil() as i32;
+    let mut remaining = hearts;
+    let mut row_y = y;
+    let mut base_health = 0;
+    while remaining > 0 {
+        let row_hearts = remaining.min(10);
+        remaining -= row_hearts;
+        let iy = (row_y - icon_size).round();
+        for i in 0..row_hearts {
+            let x = icon_row_x_rtl(x_right, i, gs);
+            let mut push = |sprite| {
+                elements.push(MenuElement::Image {
+                    x,
+                    y: iy,
+                    w: icon_size,
+                    h: icon_size,
+                    sprite,
+                    tint: WHITE,
+                });
+            };
+            push(SpriteId::HeartVehicleContainer);
+            let halves = i * 2 + 1 + base_health;
+            if halves < current {
+                push(SpriteId::HeartVehicleFull);
+            }
+            if halves == current {
+                push(SpriteId::HeartVehicleHalf);
+            }
+        }
+        row_y -= 10.0 * gs;
+        base_health += 20;
     }
 }
 


### PR DESCRIPTION
Second row of hearts for the ridden mount, replacing the food bar while mounted. Air bubbles shift up for multi row mounts. Stacked on #476.