### PR TITLE
add camera overlays

### DIFF
--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -12,7 +12,7 @@ use glam::FloatExt as _;
 use crate::app::core::{AppCore, PlayerInputState};
 use crate::app::phases::Gfx;
 use crate::app::{TICK_RATE, input};
-use crate::audio::{CATEGORY_PLAYERS, SoundRef};
+use crate::audio::{CATEGORY_AMBIENT, CATEGORY_PLAYERS, SoundRef};
 use crate::benchmark::{
     Benchmark, BenchmarkResult, ChunkLoadBench, ChunkLoadResult, ChunkLoadStep, UploadHandle,
     UploadStatus, upload_result,
@@ -168,6 +168,8 @@ pub struct GameState {
     pub controlled_vehicle_id: Option<i32>,
     /// Vehicle we are any passenger of (vanilla `getVehicle`).
     pub riding_vehicle_id: Option<i32>,
+    /// Smoothed vignette darkness (vanilla `Hud.vignetteBrightness`).
+    pub vignette_brightness: f32,
     pub interaction: InteractionState,
     pub sky_state: crate::renderer::SkyState,
     pub show_debug: bool,
@@ -350,6 +352,7 @@ impl GameState {
             xp_display_start_tick: i64::MIN,
             controlled_vehicle_id: None,
             riding_vehicle_id: None,
+            vignette_brightness: 1.0,
             interaction: InteractionState::new(),
             sky_state: SkyState::default_day(),
             show_debug: false,
@@ -1278,6 +1281,49 @@ fn send_container_clicks(
     }
 }
 
+/// Vanilla `Lightmap.getBrightness` at a block position, with
+/// `getMaxLocalRawBrightness` = max(skyLight - skyDarken, blockLight).
+/// TODO: skyDarken (26.2: 15 - the SKY_LIGHT_LEVEL environment attribute) is
+/// untracked; 0 assumed, so the outdoor night-time vignette stays weak.
+fn lightmap_brightness(chunks: &ChunkStore, dimension: &str, x: i32, y: i32, z: i32) -> f32 {
+    let level = chunks
+        .get_sky_light(x, y, z)
+        .max(chunks.get_block_light(x, y, z)) as f32;
+    // Dimension-type ambient light, matched by id since the dimension-type
+    // registry isn't tracked; custom dimensions fall back to 0.
+    let ambient = if dimension == "minecraft:the_nether" {
+        0.1
+    } else {
+        0.0
+    };
+    let v = level / 15.0;
+    let curved = v / (4.0 - 3.0 * v);
+    // Mth.lerp(ambientLight, curved, 1.0)
+    curved + (1.0 - curved) * ambient
+}
+
+fn eye_lightmap_brightness(game: &GameState) -> f32 {
+    let eye = game.player.eye_pos();
+    lightmap_brightness(
+        &game.chunk_store,
+        &game.dimension,
+        eye.x.floor() as i32,
+        eye.y.floor() as i32,
+        eye.z.floor() as i32,
+    )
+}
+
+/// Approximates vanilla's data-driven `equippable.camera_overlay` component
+/// check (item components aren't tracked): a carved pumpkin in the head slot.
+fn head_is_carved_pumpkin(player: &LocalPlayer) -> bool {
+    match player.inventory.slot(crate::player::inventory::ARMOR_START) {
+        azalea_inventory::ItemStack::Present(d) => {
+            crate::player::inventory::item_resource_name(d.kind) == "carved_pumpkin"
+        }
+        _ => false,
+    }
+}
+
 /// Vanilla `Hud.tick`: the held-item tooltip timer resets to 40 when the
 /// selected item's type or hover name changes, clears when the slot empties,
 /// and otherwise counts down.
@@ -1415,6 +1461,26 @@ pub fn update_game(
         game.block_entity_anim.tick();
         game.title.tick();
         tick_tool_highlight(core, game);
+        // Vanilla LocalPlayer.handlePortalTransitionEffect.
+        // TODO: canUsePortal(false) also requires not riding (no passenger
+        // tracking yet).
+        let inside_portal = game.player.is_inside_nether_portal(&game.chunk_store);
+        if game.player.tick_portal_effect(inside_portal) {
+            // Vanilla forLocalAmbience: AMBIENT category at the listener,
+            // volume 0.25, pitch 0.8..1.2.
+            core.audio.play_world_sound(
+                &SoundRef::Event("block.portal.trigger".into()),
+                CATEGORY_AMBIENT,
+                game.player.position,
+                0.25,
+                fastrand::f32() * 0.4 + 0.8,
+                fastrand::u64(..),
+            );
+        }
+        // Vanilla Hud.updateVignetteBrightness: 1%-per-tick smoothing toward
+        // the darkness of the eye block's light level.
+        let target = (1.0 - eye_lightmap_brightness(game)).clamp(0.0, 1.0);
+        game.vignette_brightness += (target - game.vignette_brightness) * 0.01;
         if let Some(c) = &mut game.open_container
             && let Some(state) = &mut c.enchant
         {
@@ -1640,6 +1706,23 @@ pub fn update_game(
     // entities/player, held item, clouds, or weather — and skipping them also keeps
     // the measured frame times honest.
     let benchmark_running = game.chunk_load_bench.is_some();
+    // Underwater overlay (vanilla ScreenEffectRenderer.submitWater): part of
+    // the 3D pass in vanilla, so it shows even with the GUI hidden.
+    // TODO: vanilla also skips it while sleeping.
+    if !benchmark_running
+        && gfx.renderer.is_first_person()
+        && !crate::player::is_spectator(game.player.game_mode)
+        && game.player.eyes_in_water
+    {
+        hud::build_underwater_overlay(
+            &mut elements,
+            sw,
+            sh,
+            eye_lightmap_brightness(game),
+            game.player.look_dir.y_rot_deg(),
+            game.player.look_dir.x_rot_deg(),
+        );
+    }
     if !benchmark_running && game.hide_gui {
         // F1: vanilla still renders the debug overlay with the GUI hidden.
         if let Some(info) = debug.as_ref() {
@@ -1648,6 +1731,20 @@ pub fn update_game(
             });
         }
     } else if !benchmark_running {
+        // Vanilla Hud.extractCameraOverlays: vignette, pumpkin, and portal
+        // draw under everything else in the HUD.
+        let portal_intensity = game
+            .player
+            .prev_portal_effect_intensity
+            .lerp(game.player.portal_effect_intensity, partial_tick);
+        hud::build_camera_overlays(
+            &mut elements,
+            sw,
+            sh,
+            core.menu.vignette.then_some(game.vignette_brightness),
+            gfx.renderer.is_first_person() && head_is_carved_pumpkin(&game.player),
+            portal_intensity,
+        );
         let is_survival = crate::player::is_survival(game.player.game_mode);
         let air_bubbles = hud::air_bubbles(game.player.air_supply, game.player.eyes_in_water)
             .filter(|_| is_survival);

--- a/pomme-client/src/audio/mod.rs
+++ b/pomme-client/src/audio/mod.rs
@@ -53,6 +53,9 @@ pub const CATEGORY_BLOCKS: u8 = SoundCategory::Blocks as u8;
 /// pickup).
 pub const CATEGORY_PLAYERS: u8 = SoundCategory::Players as u8;
 
+/// `SoundSource::AMBIENT` index, for local ambience (e.g. the portal trigger).
+pub const CATEGORY_AMBIENT: u8 = SoundCategory::Ambient as u8;
+
 impl SoundCategory {
     fn from_index(index: u8) -> Self {
         match index {

--- a/pomme-client/src/player/mod.rs
+++ b/pomme-client/src/player/mod.rs
@@ -30,6 +30,11 @@ pub fn is_creative(game_mode: u8) -> bool {
     game_mode == 1
 }
 
+/// Spectator (3).
+pub fn is_spectator(game_mode: u8) -> bool {
+    game_mode == 3
+}
+
 fn is_water_block(state: azalea_block::BlockState) -> bool {
     fluid(state).kind == FluidKind::Water
 }
@@ -81,6 +86,10 @@ pub struct LocalPlayer {
     pub eyes_in_water: bool,
     pub swimming: bool,
     pub air_supply: i32,
+    /// Vanilla LocalPlayer.portalEffectIntensity: drives the full-screen
+    /// portal overlay while standing in a nether portal.
+    pub portal_effect_intensity: f32,
+    pub prev_portal_effect_intensity: f32,
     pub game_mode: u8,
     pub score: i32,
     pub entity_id: i32,
@@ -131,6 +140,8 @@ impl LocalPlayer {
             eyes_in_water: false,
             swimming: false,
             air_supply: MAX_AIR_SUPPLY,
+            portal_effect_intensity: 0.0,
+            prev_portal_effect_intensity: 0.0,
             game_mode: 0,
             score: 0,
             entity_id: -1,
@@ -247,5 +258,49 @@ impl LocalPlayer {
         self.in_water = fluid_height > 0.0;
         self.eyes_in_water = is_water_block(chunks.get_block_state(eye_x, eye_y, eye_z));
         self.swimming = self.sprinting && self.in_water && self.eyes_in_water;
+    }
+
+    /// Vanilla Entity.checkInsideBlocks: a nether portal counts as entered when
+    /// the bounding box deflated by 1.0E-5 overlaps its (full) block cell.
+    pub fn is_inside_nether_portal(&self, chunks: &crate::world::chunk::ChunkStore) -> bool {
+        const MARGIN: f64 = 1.0e-5;
+        let half_w = 0.3;
+        let x0 = (self.position.x - half_w + MARGIN).floor() as i32;
+        let x1 = (self.position.x + half_w - MARGIN).ceil() as i32 - 1;
+        let y0 = (self.position.y + MARGIN).floor() as i32;
+        let y1 = (self.position.y + self.height() - MARGIN).ceil() as i32 - 1;
+        let z0 = (self.position.z - half_w + MARGIN).floor() as i32;
+        let z1 = (self.position.z + half_w - MARGIN).ceil() as i32 - 1;
+
+        for bx in x0..=x1 {
+            for by in y0..=y1 {
+                for bz in z0..=z1 {
+                    if crate::world::block::block_id(chunks.get_block_state(bx, by, bz))
+                        == "nether_portal"
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// Vanilla LocalPlayer.handlePortalTransitionEffect: the overlay ramps up
+    /// over 80 ticks inside a portal and decays 4x as fast outside. Returns
+    /// true when the rise starts from zero (vanilla plays PORTAL_TRIGGER).
+    /// TODO: vanilla also force-closes portal-disallowed screens while rising.
+    pub fn tick_portal_effect(&mut self, inside_portal: bool) -> bool {
+        self.prev_portal_effect_intensity = self.portal_effect_intensity;
+        let mut step = 0.0;
+        let mut triggered = false;
+        if inside_portal {
+            triggered = self.portal_effect_intensity == 0.0;
+            step = 0.0125;
+        } else if self.portal_effect_intensity > 0.0 {
+            step = -0.05;
+        }
+        self.portal_effect_intensity = (self.portal_effect_intensity + step).clamp(0.0, 1.0);
+        triggered
     }
 }

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -233,6 +233,16 @@ pub struct MenuOverlayPipeline {
     favicon_allocation: Option<Allocation>,
     favicon_regions: std::collections::HashMap<String, [f32; 4]>,
     favicon_atlas_size: u32,
+    overlay_image: vk::Image,
+    overlay_view: vk::ImageView,
+    overlay_sampler: vk::Sampler,
+    overlay_allocation: Option<Allocation>,
+    overlay_vignette_uv: [f32; 4],
+    overlay_pumpkin_uv: [f32; 4],
+    underwater_image: vk::Image,
+    underwater_view: vk::ImageView,
+    underwater_sampler: vk::Sampler,
+    underwater_allocation: Option<Allocation>,
 }
 
 impl MenuOverlayPipeline {
@@ -253,50 +263,15 @@ impl MenuOverlayPipeline {
             vk::ShaderStageFlags::Vertex | vk::ShaderStageFlags::Fragment,
         );
 
-        let tex_bindings = [
-            vk::DescriptorSetLayoutBinding {
-                binding: 0,
+        // One combined image sampler per menu_overlay.frag binding.
+        let tex_bindings: [vk::DescriptorSetLayoutBinding; 8] =
+            std::array::from_fn(|binding| vk::DescriptorSetLayoutBinding {
+                binding: binding as u32,
                 descriptor_type: vk::DescriptorType::CombinedImageSampler,
                 descriptor_count: 1,
                 stage_flags: vk::ShaderStageFlags::Fragment,
                 ..Default::default()
-            },
-            vk::DescriptorSetLayoutBinding {
-                binding: 1,
-                descriptor_type: vk::DescriptorType::CombinedImageSampler,
-                descriptor_count: 1,
-                stage_flags: vk::ShaderStageFlags::Fragment,
-                ..Default::default()
-            },
-            vk::DescriptorSetLayoutBinding {
-                binding: 2,
-                descriptor_type: vk::DescriptorType::CombinedImageSampler,
-                descriptor_count: 1,
-                stage_flags: vk::ShaderStageFlags::Fragment,
-                ..Default::default()
-            },
-            vk::DescriptorSetLayoutBinding {
-                binding: 3,
-                descriptor_type: vk::DescriptorType::CombinedImageSampler,
-                descriptor_count: 1,
-                stage_flags: vk::ShaderStageFlags::Fragment,
-                ..Default::default()
-            },
-            vk::DescriptorSetLayoutBinding {
-                binding: 4,
-                descriptor_type: vk::DescriptorType::CombinedImageSampler,
-                descriptor_count: 1,
-                stage_flags: vk::ShaderStageFlags::Fragment,
-                ..Default::default()
-            },
-            vk::DescriptorSetLayoutBinding {
-                binding: 5,
-                descriptor_type: vk::DescriptorType::CombinedImageSampler,
-                descriptor_count: 1,
-                stage_flags: vk::ShaderStageFlags::Fragment,
-                ..Default::default()
-            },
-        ];
+            });
         let tex_layout_info = vk::DescriptorSetLayoutCreateInfo {
             binding_count: tex_bindings.len() as u32,
             bindings: tex_bindings.as_ptr(),
@@ -326,7 +301,7 @@ impl MenuOverlayPipeline {
             },
             vk::DescriptorPoolSize {
                 ty: vk::DescriptorType::CombinedImageSampler,
-                descriptor_count: 6,
+                descriptor_count: tex_bindings.len() as u32,
             },
         ];
         let pool_info = vk::DescriptorPoolCreateInfo {
@@ -529,56 +504,66 @@ impl MenuOverlayPipeline {
             image_layout: vk::ImageLayout::ShaderReadOnlyOptimal,
         };
 
-        let writes = [
-            vk::WriteDescriptorSet {
-                dst_set: tex_set,
-                dst_binding: 0,
-                descriptor_count: 1,
-                descriptor_type: vk::DescriptorType::CombinedImageSampler,
-                image_info: &font_img_info,
-                ..Default::default()
-            },
-            vk::WriteDescriptorSet {
-                dst_set: tex_set,
-                dst_binding: 1,
-                descriptor_count: 1,
-                descriptor_type: vk::DescriptorType::CombinedImageSampler,
-                image_info: &sprite_img_info,
-                ..Default::default()
-            },
-            vk::WriteDescriptorSet {
-                dst_set: tex_set,
-                dst_binding: 2,
-                descriptor_count: 1,
-                descriptor_type: vk::DescriptorType::CombinedImageSampler,
-                image_info: &item_img_info,
-                ..Default::default()
-            },
-            vk::WriteDescriptorSet {
-                dst_set: tex_set,
-                dst_binding: 3,
-                descriptor_count: 1,
-                descriptor_type: vk::DescriptorType::CombinedImageSampler,
-                image_info: &mc_font_img_info,
-                ..Default::default()
-            },
-            vk::WriteDescriptorSet {
-                dst_set: tex_set,
-                dst_binding: 4,
-                descriptor_count: 1,
-                descriptor_type: vk::DescriptorType::CombinedImageSampler,
-                image_info: &font_img_info,
-                ..Default::default()
-            },
-            vk::WriteDescriptorSet {
-                dst_set: tex_set,
-                dst_binding: 5,
-                descriptor_count: 1,
-                descriptor_type: vk::DescriptorType::CombinedImageSampler,
-                image_info: &favicon_img_info,
-                ..Default::default()
-            },
+        let (overlay_image, overlay_view, overlay_alloc, overlay_vignette_uv, overlay_pumpkin_uv) =
+            build_camera_overlay_texture(
+                device,
+                queue,
+                command_pool,
+                allocator,
+                jar_assets_dir,
+                asset_index,
+            );
+        // Both source textures ship mcmeta `blur: true`.
+        let overlay_sampler = unsafe { util::create_linear_sampler(device) };
+
+        let (underwater_image, underwater_view, underwater_alloc) = load_single_texture(
+            device,
+            queue,
+            command_pool,
+            allocator,
+            jar_assets_dir,
+            asset_index,
+            "minecraft/textures/misc/underwater.png",
+            "underwater_overlay",
+        );
+        // Repeat wrapping: the overlay tiles 4x and scrolls with the look direction.
+        let underwater_sampler = unsafe { util::create_nearest_repeat_sampler(device) };
+
+        let overlay_img_info = vk::DescriptorImageInfo {
+            sampler: overlay_sampler,
+            image_view: overlay_view,
+            image_layout: vk::ImageLayout::ShaderReadOnlyOptimal,
+        };
+        let underwater_img_info = vk::DescriptorImageInfo {
+            sampler: underwater_sampler,
+            image_view: underwater_view,
+            image_layout: vk::ImageLayout::ShaderReadOnlyOptimal,
+        };
+
+        // In menu_overlay.frag binding order; blur (4) starts as a font-atlas
+        // placeholder until set_blur_texture.
+        let tex_image_infos = [
+            &font_img_info,
+            &sprite_img_info,
+            &item_img_info,
+            &mc_font_img_info,
+            &font_img_info,
+            &favicon_img_info,
+            &overlay_img_info,
+            &underwater_img_info,
         ];
+        let writes: Vec<_> = tex_image_infos
+            .iter()
+            .enumerate()
+            .map(|(binding, info)| vk::WriteDescriptorSet {
+                dst_set: tex_set,
+                dst_binding: binding as u32,
+                descriptor_count: 1,
+                descriptor_type: vk::DescriptorType::CombinedImageSampler,
+                image_info: *info,
+                ..Default::default()
+            })
+            .collect();
         device.update_descriptor_sets(&writes, &[]);
 
         let (vertex_buffer, vertex_allocation) = util::create_host_buffer(
@@ -630,6 +615,16 @@ impl MenuOverlayPipeline {
             favicon_allocation: Some(favicon_alloc),
             favicon_regions: std::collections::HashMap::new(),
             favicon_atlas_size: 1,
+            overlay_image,
+            overlay_view,
+            overlay_sampler,
+            overlay_allocation: Some(overlay_alloc),
+            overlay_vignette_uv,
+            overlay_pumpkin_uv,
+            underwater_image,
+            underwater_view,
+            underwater_sampler,
+            underwater_allocation: Some(underwater_alloc),
         }
     }
 
@@ -982,6 +977,46 @@ impl MenuOverlayPipeline {
                         *x,
                         *y,
                         *size,
+                    );
+                }
+                MenuElement::Vignette { w, h, brightness } => {
+                    // Clamp mirrors vanilla Hud.extractVignette.
+                    let b = brightness.clamp(0.0, 1.0);
+                    push_fullscreen_quad(
+                        &mut vertices,
+                        *w,
+                        *h,
+                        self.overlay_vignette_uv,
+                        [b, b, b, 1.0],
+                        8.0,
+                    );
+                }
+                MenuElement::PumpkinOverlay { w, h } => {
+                    push_fullscreen_quad(
+                        &mut vertices,
+                        *w,
+                        *h,
+                        self.overlay_pumpkin_uv,
+                        [1.0; 4],
+                        7.0,
+                    );
+                }
+                MenuElement::UnderwaterOverlay {
+                    w,
+                    h,
+                    u0,
+                    v0,
+                    brightness,
+                } => {
+                    // Vanilla submitWater UVs: U decreases rightward, V
+                    // increases downward.
+                    push_fullscreen_quad(
+                        &mut vertices,
+                        *w,
+                        *h,
+                        [*u0 + 4.0, *v0, *u0, *v0 + 4.0],
+                        [*brightness, *brightness, *brightness, 0.1],
+                        9.0,
                     );
                 }
                 _ => {}
@@ -1494,6 +1529,20 @@ impl MenuOverlayPipeline {
             alloc.free(a).ok();
         }
 
+        device.destroy_sampler(self.overlay_sampler, None);
+        device.destroy_image_view(self.overlay_view, None);
+        device.destroy_image(self.overlay_image, None);
+        if let Some(a) = self.overlay_allocation.take() {
+            alloc.free(a).ok();
+        }
+
+        device.destroy_sampler(self.underwater_sampler, None);
+        device.destroy_image_view(self.underwater_view, None);
+        device.destroy_image(self.underwater_image, None);
+        if let Some(a) = self.underwater_allocation.take() {
+            alloc.free(a).ok();
+        }
+
         drop(alloc);
 
         device.destroy_pipeline(self.pipeline, None);
@@ -1677,6 +1726,25 @@ pub enum MenuElement {
     /// scene so the blur pass captures them; elements after are drawn sharp on
     /// top. Used to render the title screen blurred behind the Friends dialog.
     BlurBackdrop,
+    /// Full-screen vignette, multiplying the framebuffer down by `brightness`.
+    Vignette {
+        w: f32,
+        h: f32,
+        brightness: f32,
+    },
+    /// Full-screen pumpkin-blur camera overlay.
+    PumpkinOverlay {
+        w: f32,
+        h: f32,
+    },
+    /// Full-screen underwater tint, its 4x-tiled UVs scrolled to `(u0, v0)`.
+    UnderwaterOverlay {
+        w: f32,
+        h: f32,
+        u0: f32,
+        v0: f32,
+        brightness: f32,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -1860,6 +1928,7 @@ pub enum SpriteId {
     FriendsAccept,
     FriendsReject,
     FriendsCancel,
+    NetherPortal,
 }
 
 pub const CREATIVE_TAB_SPRITES: [[[SpriteId; 7]; 2]; 2] = [
@@ -2830,6 +2899,15 @@ fn build_sprite_atlas(
             195,
             136,
         ),
+        // Frame 0 of the animated portal strip, stretched full-screen by the
+        // portal camera overlay. TODO: animate.
+        (
+            SpriteId::NetherPortal,
+            "minecraft/textures/block/nether_portal.png",
+            0,
+            16,
+            16,
+        ),
     ] {
         let path = resolve_asset_path(jar_assets_dir, asset_index, path);
         match crate::assets::load_image(&path) {
@@ -2849,7 +2927,7 @@ fn build_sprite_atlas(
                 images.push((id, cropped, crop_w, crop_h, 0.0));
             }
             Err(e) => {
-                tracing::warn!("Failed to load container background {id:?}: {e}");
+                tracing::warn!("Failed to load sprite {id:?}: {e}");
                 images.push((id, vec![255, 0, 255, 255], 1, 1, 0.0));
             }
         }
@@ -2948,6 +3026,129 @@ fn build_sprite_atlas(
         staging_buffer,
         Some(staging_allocation),
     )
+}
+
+fn load_overlay_rgba(
+    jar_assets_dir: &Path,
+    asset_index: &Option<AssetIndex>,
+    asset_key: &str,
+) -> (Vec<u8>, u32, u32) {
+    let path = resolve_asset_path(jar_assets_dir, asset_index, asset_key);
+    match crate::assets::load_image(&path) {
+        Ok(img) => {
+            let rgba = img.to_rgba8();
+            let (w, h) = (rgba.width(), rgba.height());
+            (rgba.into_raw(), w, h)
+        }
+        Err(e) => {
+            tracing::warn!("Failed to load overlay texture {asset_key}: {e}");
+            (vec![255, 0, 255, 255], 1, 1)
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn upload_and_free_staging(
+    device: &vk::Device,
+    queue: vk::Queue,
+    command_pool: vk::CommandPool,
+    allocator: &Arc<Mutex<Allocator>>,
+    pixels: &[u8],
+    image: vk::Image,
+    w: u32,
+    h: u32,
+    name: &str,
+) {
+    let (staging, staging_alloc) = util::create_staging_buffer(device, allocator, pixels, name);
+    util::upload_image(device, queue, command_pool, staging, image, w, h);
+    // upload_image waits for the copy, so the staging buffer can go right away.
+    device.destroy_buffer(staging, None);
+    allocator.lock().unwrap().free(staging_alloc).ok();
+}
+
+/// Compose the full-screen camera overlay textures (vignette + pumpkin blur)
+/// side by side into one linear-sampled image. Returns the image and each
+/// half's UV rect, inset half a texel so filtering never crosses the seam.
+fn build_camera_overlay_texture(
+    device: &vk::Device,
+    queue: vk::Queue,
+    command_pool: vk::CommandPool,
+    allocator: &Arc<Mutex<Allocator>>,
+    jar_assets_dir: &Path,
+    asset_index: &Option<AssetIndex>,
+) -> (vk::Image, vk::ImageView, Allocation, [f32; 4], [f32; 4]) {
+    let (vig, vw, vh) = load_overlay_rgba(
+        jar_assets_dir,
+        asset_index,
+        "minecraft/textures/misc/vignette.png",
+    );
+    let (pump, pw, ph) = load_overlay_rgba(
+        jar_assets_dir,
+        asset_index,
+        "minecraft/textures/misc/pumpkinblur.png",
+    );
+
+    let w = vw + pw;
+    let h = vh.max(ph);
+    let mut pixels = vec![0u8; (w * h * 4) as usize];
+    blit_image(&mut pixels, w, &vig, vw, 0, 0, vw, vh);
+    blit_image(&mut pixels, w, &pump, pw, vw, 0, pw, ph);
+
+    let (image, view, allocation) =
+        util::create_gpu_image(device, allocator, w, h, "camera_overlay");
+    upload_and_free_staging(
+        device,
+        queue,
+        command_pool,
+        allocator,
+        &pixels,
+        image,
+        w,
+        h,
+        "camera_overlay_staging",
+    );
+
+    let (iw, ih) = (w as f32, h as f32);
+    let vignette_uv = [
+        0.5 / iw,
+        0.5 / ih,
+        (vw as f32 - 0.5) / iw,
+        (vh as f32 - 0.5) / ih,
+    ];
+    let pumpkin_uv = [
+        (vw as f32 + 0.5) / iw,
+        0.5 / ih,
+        (iw - 0.5) / iw,
+        (ph as f32 - 0.5) / ih,
+    ];
+    (image, view, allocation, vignette_uv, pumpkin_uv)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn load_single_texture(
+    device: &vk::Device,
+    queue: vk::Queue,
+    command_pool: vk::CommandPool,
+    allocator: &Arc<Mutex<Allocator>>,
+    jar_assets_dir: &Path,
+    asset_index: &Option<AssetIndex>,
+    asset_key: &str,
+    name: &str,
+) -> (vk::Image, vk::ImageView, Allocation) {
+    let (pixels, w, h) = load_overlay_rgba(jar_assets_dir, asset_index, asset_key);
+    let (image, view, allocation) = util::create_gpu_image(device, allocator, w, h, name);
+    upload_and_free_staging(
+        device,
+        queue,
+        command_pool,
+        allocator,
+        &pixels,
+        image,
+        w,
+        h,
+        name,
+    );
+    (image, view, allocation)
 }
 
 struct TextureResources {
@@ -3083,6 +3284,31 @@ fn push_quad(
             corner_radius,
         });
     }
+}
+
+fn push_fullscreen_quad(
+    verts: &mut Vec<Vertex>,
+    w: f32,
+    h: f32,
+    [u0, v0, u1, v1]: [f32; 4],
+    color: [f32; 4],
+    mode: f32,
+) {
+    push_quad(
+        verts,
+        0.0,
+        0.0,
+        w,
+        h,
+        u0,
+        v0,
+        u1,
+        v1,
+        color,
+        mode,
+        [0.0, 0.0],
+        0.0,
+    );
 }
 
 fn push_rect(

--- a/pomme-client/src/renderer/shaders/menu_overlay.frag
+++ b/pomme-client/src/renderer/shaders/menu_overlay.frag
@@ -11,6 +11,8 @@ layout(set = 1, binding = 2) uniform sampler2D item_tex;
 layout(set = 1, binding = 3) uniform sampler2D mc_font_tex;
 layout(set = 1, binding = 4) uniform sampler2D blur_tex;
 layout(set = 1, binding = 5) uniform sampler2D favicon_tex;
+layout(set = 1, binding = 6) uniform sampler2D overlay_tex;
+layout(set = 1, binding = 7) uniform sampler2D underwater_tex;
 
 layout(location = 0) in vec2 v_uv;
 layout(location = 1) in vec4 v_color;
@@ -26,6 +28,34 @@ float sdf_rounded_rect(vec2 p, vec2 half_size, float radius) {
 }
 
 void main() {
+    if (v_mode > 8.5) {
+        // Underwater tint: standard alpha blend over the scene.
+        vec4 tex = texture(underwater_tex, v_uv);
+        out_color = vec4(tex.rgb * v_color.rgb * tex.a * v_color.a, tex.a * v_color.a);
+        return;
+    }
+
+    if (v_mode > 7.5) {
+        // Vignette. Vanilla blends (ZERO, ONE_MINUS_SRC_COLOR): each channel of
+        // dst is scaled by 1 - src, where src = grayscale texture * brightness,
+        // in the gamma-space GL framebuffer. Emitting (0, 0, 0, a) through the
+        // premultiplied One / OneMinusSrcAlpha blend scales dst by 1 - a, and
+        // converting the gamma-space factor to linear keeps the darkening
+        // identical on the sRGB target. (dst alpha is scaled too, unlike
+        // vanilla; the swapchain composite ignores alpha.)
+        float tex_gamma = pow(texture(overlay_tex, v_uv).r, 1.0 / 2.2);
+        float src = tex_gamma * v_color.r;
+        out_color = vec4(0.0, 0.0, 0.0, 1.0 - pow(1.0 - src, 2.2));
+        return;
+    }
+
+    if (v_mode > 6.5) {
+        // Camera overlay (pumpkin blur): standard alpha blend.
+        vec4 tex = texture(overlay_tex, v_uv);
+        out_color = vec4(tex.rgb * v_color.rgb * tex.a * v_color.a, tex.a * v_color.a);
+        return;
+    }
+
     if (v_mode > 5.5) {
         vec4 tex = texture(favicon_tex, v_uv);
         out_color = vec4(tex.rgb * tex.a * v_color.a, tex.a * v_color.a);

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -358,6 +358,72 @@ pub fn gui_scale(screen_w: f32, screen_h: f32, setting: u32) -> f32 {
     }
 }
 
+/// Vanilla `ScreenEffectRenderer.submitWater`: underwater.png tiled 4x and
+/// scrolled by the look direction, alpha 0.1, tinted by the local lightmap
+/// brightness.
+pub fn build_underwater_overlay(
+    elements: &mut Vec<MenuElement>,
+    screen_w: f32,
+    screen_h: f32,
+    brightness: f32,
+    yaw_deg: f32,
+    pitch_deg: f32,
+) {
+    elements.push(MenuElement::UnderwaterOverlay {
+        w: screen_w,
+        h: screen_h,
+        u0: -yaw_deg / 64.0,
+        v0: pitch_deg / 64.0,
+        brightness,
+    });
+}
+
+/// Vanilla `Hud.extractCameraOverlays`: vignette, equippable camera overlay
+/// (pumpkin), and nether-portal overlay, drawn under the rest of the HUD.
+/// TODO: powder snow, spyglass, nausea overlays; the portal/nausea projection
+/// spin warp lives in GameRenderer and is also unimplemented.
+pub fn build_camera_overlays(
+    elements: &mut Vec<MenuElement>,
+    screen_w: f32,
+    screen_h: f32,
+    vignette_brightness: Option<f32>,
+    pumpkin: bool,
+    portal_intensity: f32,
+) {
+    if let Some(brightness) = vignette_brightness {
+        // TODO: nearing the world border tints the vignette cyan (no border
+        // tracking yet).
+        elements.push(MenuElement::Vignette {
+            w: screen_w,
+            h: screen_h,
+            brightness,
+        });
+    }
+    if pumpkin {
+        elements.push(MenuElement::PumpkinOverlay {
+            w: screen_w,
+            h: screen_h,
+        });
+    }
+    if portal_intensity > 0.0 {
+        // Vanilla Hud.extractPortalOverlay's alpha curve (0.2 floor).
+        let mut a = portal_intensity;
+        if a < 1.0 {
+            a *= a;
+            a *= a;
+            a = a * 0.8 + 0.2;
+        }
+        elements.push(MenuElement::Image {
+            x: 0.0,
+            y: 0.0,
+            w: screen_w,
+            h: screen_h,
+            sprite: SpriteId::NetherPortal,
+            tint: [1.0, 1.0, 1.0, a],
+        });
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn build_hud(
     elements: &mut Vec<MenuElement>,

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -36,6 +36,8 @@ struct Settings {
     #[serde(default)]
     show_subtitles: bool,
     #[serde(default = "default_true")]
+    vignette: bool,
+    #[serde(default = "default_true")]
     vsync: bool,
     #[serde(default = "default_max_framerate")]
     max_framerate: u32,
@@ -134,6 +136,7 @@ impl Default for Settings {
             fov_effect_scale: 1.0,
             view_bobbing: true,
             show_subtitles: false,
+            vignette: true,
             vsync: true,
             max_framerate: 120,
             show_online_status: true,
@@ -418,6 +421,7 @@ pub struct MainMenu {
     pub fov_effect_scale: f32,
     pub view_bobbing: bool,
     pub show_subtitles: bool,
+    pub vignette: bool,
     pub vsync: bool,
     pub max_framerate: u32,
     pub show_online_status: bool,
@@ -524,6 +528,7 @@ impl MainMenu {
             fov_effect_scale: settings.fov_effect_scale,
             view_bobbing: settings.view_bobbing,
             show_subtitles: settings.show_subtitles,
+            vignette: settings.vignette,
             vsync: settings.vsync,
             max_framerate: settings.max_framerate,
             show_online_status: settings.show_online_status,
@@ -619,6 +624,7 @@ impl MainMenu {
                 fov_effect_scale: self.fov_effect_scale,
                 view_bobbing: self.view_bobbing,
                 show_subtitles: self.show_subtitles,
+                vignette: self.vignette,
                 vsync: self.vsync,
                 max_framerate: self.max_framerate,
                 show_online_status: self.show_online_status,

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -139,6 +139,11 @@ impl MainMenu {
         };
         let clouds_label = format!("Clouds: {}", self.cloud_mode.label());
         let attack_label = format!("Attack Indicator: {}", self.attack_indicator.label());
+        let vignette_label = if self.vignette {
+            "Vignette: ON"
+        } else {
+            "Vignette: OFF"
+        };
         let rows: Vec<OptRow> = vec![
             OptRow::Header("Display"),
             OptRow::Big("Fullscreen Resolution: Current"),
@@ -160,7 +165,7 @@ impl MainMenu {
             OptRow::Pair("Texture Filtering: None", "Max Anisotropy: 1"),
             OptRow::PairLeft("Weather Radius: 10"),
             OptRow::Header("Preferences"),
-            OptRow::Pair("Show Autosave Indicator: ON", "Vignette: ON"),
+            OptRow::Pair("Show Autosave Indicator: ON", vignette_label),
             OptRow::Pair(&attack_label, "Chunk Fade-in: 1.0s"),
         ];
         let rd_frac = ((self.render_distance as f32 - 2.0) / (rd_max as f32 - 2.0)).clamp(0.0, 1.0);
@@ -750,6 +755,10 @@ impl MainMenu {
                     }
                     if label.starts_with("Show Subtitles:") {
                         self.show_subtitles = !self.show_subtitles;
+                        self.save_settings();
+                    }
+                    if label.starts_with("Vignette:") {
+                        self.vignette = !self.vignette;
                         self.save_settings();
                     }
                     if label.starts_with("Show Online Status:") {


### PR DESCRIPTION
Vignette, underwater tint, pumpkin blur, and nether portal overlays.

- vignette multiplies the framebuffer down by smoothed eye-block light, gated by a now-working Vignette toggle in video settings
- underwater tint tiles 4x, scrolls with the look direction, and shows with the GUI hidden
- pumpkin blur checks the head slot for a carved pumpkin (item components untracked)
- portal intensity ticks on the client (+0.0125 in portal, -0.05 out) with the trigger sound on rise; sprite pinned to frame 0

Remaining gaps are marked TODO in code: sky darken, portal animation, spin warp, nausea/powder snow/spyglass/fire overlays, world border tint.