### PR TITLE
add spectator menu

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -180,6 +180,10 @@ pub struct AppCore {
     player_skin_tx: crossbeam_channel::Sender<PlayerSkinResult>,
     player_skin_rx: crossbeam_channel::Receiver<PlayerSkinResult>,
     requested_player_skins: HashMap<uuid::Uuid, Option<String>>,
+    /// 8x8 RGBA faces of fetched player skins, for the spectator menu's
+    /// face atlas (the GPU-side skins keep no CPU pixels).
+    player_faces: HashMap<uuid::Uuid, Vec<u8>>,
+    player_faces_dirty: bool,
 }
 
 impl AppCore {
@@ -228,6 +232,8 @@ impl AppCore {
             player_skin_tx,
             player_skin_rx,
             requested_player_skins: HashMap::new(),
+            player_faces: HashMap::new(),
+            player_faces_dirty: false,
         }
     }
 
@@ -338,6 +344,14 @@ impl AppCore {
             }
             match skin.result {
                 Ok(data) => {
+                    if let Some(face) = crate::renderer::pipelines::menu_overlay::extract_face_8x8(
+                        &data.pixels,
+                        data.width,
+                        data.height,
+                    ) {
+                        self.player_faces.insert(skin.uuid, face);
+                        self.player_faces_dirty = true;
+                    }
                     renderer.update_player_entity_skin(&skin.uuid, &data);
                 }
                 Err(e) => {
@@ -347,8 +361,25 @@ impl AppCore {
         }
     }
 
+    /// Flush cached faces into the shared face/favicon atlas. Called only
+    /// while the spectator menu is open: the rebuild waits on the GPU queue,
+    /// so it must stay off the common frame path.
+    pub fn ensure_player_face_atlas(&mut self, renderer: &mut Renderer) {
+        if !self.player_faces_dirty || self.player_faces.is_empty() {
+            return;
+        }
+        self.player_faces_dirty = false;
+        let faces: Vec<(String, Vec<u8>, u32)> = self
+            .player_faces
+            .iter()
+            .map(|(uuid, face)| (uuid.to_string(), face.clone(), 8))
+            .collect();
+        renderer.update_face_atlas(&faces);
+    }
+
     fn remove_player_skin(&mut self, renderer: &mut Renderer, uuid: &uuid::Uuid) {
         self.requested_player_skins.remove(uuid);
+        self.player_faces.remove(uuid);
         renderer.remove_player_entity_skin(uuid);
     }
 
@@ -362,6 +393,8 @@ impl AppCore {
         game.title.clear(true);
         game.subtitles.clear();
         self.requested_player_skins.clear();
+        self.player_faces.clear();
+        self.player_faces_dirty = false;
         renderer.clear_player_entity_skins();
     }
 
@@ -849,13 +882,22 @@ impl AppCore {
                 }
                 NetworkEvent::ScoreboardTeam {
                     name,
+                    display_name,
                     prefix,
                     suffix,
                     color,
+                    fill_color,
                     members,
                 } => {
-                    game.scoreboard
-                        .set_team(name, prefix, suffix, color, members);
+                    game.scoreboard.set_team(
+                        name,
+                        display_name,
+                        prefix,
+                        suffix,
+                        color,
+                        fill_color,
+                        members,
+                    );
                 }
                 NetworkEvent::ScoreboardTeamMembers {
                     name,
@@ -1558,6 +1600,25 @@ impl AppCore {
             while self.input.consume_click(Action::SwapOffhand) {
                 if !spectator {
                     crate::player::interaction::send_swap_offhand(&connection.packet_tx);
+                }
+            }
+            for slot in self.input.take_spectator_slot_presses() {
+                if spectator {
+                    game.spectator.on_hotbar_selected(
+                        slot,
+                        &game.tab_list,
+                        &game.scoreboard,
+                        &connection.packet_tx,
+                    );
+                }
+            }
+            while self.input.consume_click(Action::SpectatorHotbar) {
+                if spectator {
+                    game.spectator.on_hotbar_action_key(
+                        &game.tab_list,
+                        &game.scoreboard,
+                        &connection.packet_tx,
+                    );
                 }
             }
         }

--- a/pomme-client/src/app/input.rs
+++ b/pomme-client/src/app/input.rs
@@ -32,6 +32,7 @@ pub enum Action {
     Close,
     DropItem,
     SwapOffhand,
+    SpectatorHotbar,
 }
 
 pub struct InputState {
@@ -52,6 +53,12 @@ pub struct InputState {
     /// A container screen (inventory, chest, creative) is open: it consumes
     /// hotbar digits and the drop/swap keys, like vanilla screens do.
     pub menu_capture: bool,
+    /// The player is a spectator: digits drive the spectator menu instead of
+    /// the carried slot, and middle click is `key.spectatorHotbar`.
+    pub spectator: bool,
+    /// Digit presses queued for the spectator menu, drained per tick like the
+    /// click counts (vanilla routes them in `handleKeybinds`).
+    spectator_slot_presses: Vec<u8>,
     /// Keys pressed since the last `end_frame`, including OS key repeats:
     /// vanilla dispatches GLFW repeats to screens and debug chords.
     just_pressed: HashSet<KeyCode>,
@@ -138,6 +145,8 @@ impl InputState {
             menu_scroll: 0.0,
             text_capture: false,
             menu_capture: false,
+            spectator: false,
+            spectator_slot_presses: Vec::new(),
             just_pressed: HashSet::new(),
             click_counts: HashMap::new(),
             text_events: Vec::new(),
@@ -302,13 +311,14 @@ impl InputState {
                 Button::RightTrigger2 => {
                     self.recent_actions.insert(Action::Destroy, true);
                 }
-                Button::RightTrigger => {
+                // TODO: gamepad spectator-menu support (vanilla has none).
+                Button::RightTrigger if !self.spectator => {
                     self.selected_slot = (self.selected_slot + 1) % 9;
                 }
                 Button::LeftTrigger2 => {
                     self.recent_actions.insert(Action::Use, true);
                 }
-                Button::LeftTrigger => {
+                Button::LeftTrigger if !self.spectator => {
                     self.selected_slot = (self.selected_slot + 8) % 9;
                 }
                 Button::North => {
@@ -402,6 +412,8 @@ impl InputState {
             // Click-count driven (`consume_click`); held state only.
             Action::DropItem => self.key_pressed(KeyCode::KeyQ),
             Action::SwapOffhand => self.key_pressed(KeyCode::KeyF),
+            // Vanilla `key.spectatorHotbar` default: middle mouse.
+            Action::SpectatorHotbar => self.middle_click.held,
         }
     }
 
@@ -476,6 +488,12 @@ impl InputState {
 
     pub fn clear_click_counts(&mut self) {
         self.click_counts.clear();
+        self.spectator_slot_presses.clear();
+    }
+
+    /// Digit presses queued for the spectator menu since the last tick.
+    pub fn take_spectator_slot_presses(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.spectator_slot_presses)
     }
 
     /// Frame-scoped input state; called once at the end of each redraw so a
@@ -511,7 +529,13 @@ impl InputState {
                         && !self.menu_capture
                         && let Some(slot) = hotbar_slot(code)
                     {
-                        self.selected_slot = slot;
+                        // Vanilla handleKeybinds: spectator digits drive the
+                        // spectator menu and never touch the carried slot.
+                        if self.spectator {
+                            self.spectator_slot_presses.push(slot);
+                        } else {
+                            self.selected_slot = slot;
+                        }
                     }
                     match code {
                         KeyCode::KeyE if !self.text_capture => {
@@ -713,6 +737,12 @@ impl InputState {
                 self.middle_click.held = was_pressed;
                 if was_pressed {
                     self.middle_click.just_pressed = true;
+                    if self.spectator && !self.menu_capture {
+                        *self
+                            .click_counts
+                            .entry(Action::SpectatorHotbar)
+                            .or_insert(0) += 1;
+                    }
                 } else {
                     self.middle_click.just_released = true;
                 }

--- a/pomme-client/src/app/mod.rs
+++ b/pomme-client/src/app/mod.rs
@@ -474,6 +474,28 @@ impl ApplicationHandler for App {
                     AppPhase::InGame { game, .. } if game.chat.is_open() => {
                         game.chat.scroll_chat(scroll.signum() as i32);
                     }
+                    // Vanilla MouseHandler: a spectator's wheel moves the menu
+                    // selection (sign-inverted) while it is open, and adjusts
+                    // flying speed (local-only) otherwise.
+                    AppPhase::InGame {
+                        game, connection, ..
+                    } if game.input_live()
+                        && crate::player::is_spectator(game.player.game_mode) =>
+                    {
+                        if game.spectator.is_menu_active() {
+                            // f32::signum maps 0.0 to 1.0; skip empty deltas.
+                            if scroll != 0.0 {
+                                game.spectator.on_mouse_scrolled(
+                                    -(scroll.signum() as i32),
+                                    &game.tab_list,
+                                    &connection.packet_tx,
+                                );
+                            }
+                        } else {
+                            game.player.fly_speed =
+                                (game.player.fly_speed + scroll * 0.005).clamp(0.0, 0.2);
+                        }
+                    }
                     AppPhase::InGame { game, .. } if game.input_live() => {
                         self.core.input.on_scroll(scroll)
                     }

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -189,6 +189,9 @@ pub struct GameState {
     pub dimension: String,
     /// F3+F4 game-mode switcher overlay, while open.
     pub game_mode_switcher: Option<crate::ui::game_mode_switcher::GameModeSwitcherState>,
+    /// Spectator hotbar menu (vanilla `SpectatorGui`). Not a GUI screen: the
+    /// cursor stays grabbed and mouse look stays live while it is open.
+    pub spectator: crate::ui::spectator_menu::SpectatorGuiState,
     /// Last frame's switcher presence, to re-apply the cursor grab on change.
     switcher_was_open: bool,
     pub last_sent_input: PlayerInputState,
@@ -364,6 +367,7 @@ impl GameState {
             previous_game_mode: None,
             dimension: String::new(),
             game_mode_switcher: None,
+            spectator: Default::default(),
             switcher_was_open: false,
             last_sent_input: PlayerInputState::default(),
             last_sent_pos: Position::default(),
@@ -1597,6 +1601,10 @@ pub fn update_game(
     // as game keys (vanilla suppresses KeyMappings while any screen is open).
     core.input.text_capture = game.wants_text_input() || game.chat.is_open();
     core.input.menu_capture = game.gui_open();
+    core.input.spectator = crate::player::is_spectator(game.player.game_mode);
+    if core.input.spectator && game.spectator.is_menu_active() {
+        core.ensure_player_face_atlas(&mut gfx.renderer);
+    }
 
     // The F3+F4 switcher shows the mouse cursor while open.
     let switcher_open = game.game_mode_switcher.is_some();
@@ -1876,6 +1884,17 @@ pub fn update_game(
             show_full,
             main_hand_right: core.menu.main_hand_right(),
         };
+        if crate::player::is_spectator(game.player.game_mode) {
+            crate::ui::spectator_menu::build_spectator_menu(
+                &mut elements,
+                &mut game.spectator,
+                &game.tab_list,
+                sw,
+                sh,
+                gs,
+                &|t, s| gfx.renderer.menu_text_width(t, s),
+            );
+        }
         hud::build_hud(
             &mut elements,
             sw,

--- a/pomme-client/src/net/azalea_compat.rs
+++ b/pomme-client/src/net/azalea_compat.rs
@@ -33,6 +33,16 @@ fn packet_ids_match_azalea() {
     });
     assert_eq!(attack.id(), table_id(Direction::Serverbound, "attack"));
 
+    let teleport = ServerboundGamePacket::TeleportToEntity(
+        azalea_protocol::packets::game::s_teleport_to_entity::ServerboundTeleportToEntity {
+            uuid: uuid::Uuid::nil(),
+        },
+    );
+    assert_eq!(
+        teleport.id(),
+        table_id(Direction::Serverbound, "teleport_to_entity")
+    );
+
     let particles = ClientboundGamePacket::LevelParticles(
         azalea_protocol::packets::game::c_level_particles::ClientboundLevelParticles {
             override_limiter: false,

--- a/pomme-client/src/net/handler.rs
+++ b/pomme-client/src/net/handler.rs
@@ -1037,9 +1037,11 @@ fn send_scoreboard_team(
     let color = team_color(parameters.color);
     let _ = event_tx.try_send(NetworkEvent::ScoreboardTeam {
         name: name.into(),
+        display_name: format_text_spans(&parameters.display_name, [1.0; 4]),
         prefix: format_text_spans(&parameters.player_prefix, color),
         suffix: format_text_spans(&parameters.player_suffix, color),
         color,
+        fill_color: parameters.color.color().map(crate::ui::common::rgb),
         members,
     });
 }

--- a/pomme-client/src/net/mod.rs
+++ b/pomme-client/src/net/mod.rs
@@ -197,9 +197,11 @@ pub enum NetworkEvent {
     },
     ScoreboardTeam {
         name: String,
+        display_name: Vec<crate::ui::text::TextSpan>,
         prefix: Vec<crate::ui::text::TextSpan>,
         suffix: Vec<crate::ui::text::TextSpan>,
         color: [f32; 4],
+        fill_color: Option<[f32; 4]>,
         members: Option<Vec<String>>,
     },
     ScoreboardTeamMembers {

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -965,9 +965,16 @@ impl MenuOverlayPipeline {
                         *x,
                         *y,
                         *size,
+                        [1.0, 1.0, 1.0, 1.0],
                     );
                 }
-                MenuElement::SkinFace { x, y, size, uuid } => {
+                MenuElement::SkinFace {
+                    x,
+                    y,
+                    size,
+                    uuid,
+                    tint,
+                } => {
                     push_atlas_image(
                         &mut vertices,
                         &self.favicon_regions,
@@ -977,6 +984,7 @@ impl MenuOverlayPipeline {
                         *x,
                         *y,
                         *size,
+                        *tint,
                     );
                 }
                 MenuElement::Vignette { w, h, brightness } => {
@@ -1739,6 +1747,7 @@ pub enum MenuElement {
         y: f32,
         size: f32,
         uuid: String,
+        tint: [f32; 4],
     },
     /// Split marker for the menu draw: elements before it are rendered into the
     /// scene so the blur pass captures them; elements after are drawn sharp on
@@ -1954,6 +1963,11 @@ pub enum SpriteId {
     FriendsReject,
     FriendsCancel,
     NetherPortal,
+    SpectatorClose,
+    SpectatorScrollLeft,
+    SpectatorScrollRight,
+    SpectatorTeleportToPlayer,
+    SpectatorTeleportToTeam,
 }
 
 pub const CREATIVE_TAB_SPRITES: [[[SpriteId; 7]; 2]; 2] = [
@@ -2065,6 +2079,31 @@ fn build_sprite_atlas(
         (
             SpriteId::EffectBackgroundAmbient,
             "minecraft/textures/gui/sprites/hud/effect_background_ambient.png",
+            0.0,
+        ),
+        (
+            SpriteId::SpectatorClose,
+            "minecraft/textures/gui/sprites/spectator/close.png",
+            0.0,
+        ),
+        (
+            SpriteId::SpectatorScrollLeft,
+            "minecraft/textures/gui/sprites/spectator/scroll_left.png",
+            0.0,
+        ),
+        (
+            SpriteId::SpectatorScrollRight,
+            "minecraft/textures/gui/sprites/spectator/scroll_right.png",
+            0.0,
+        ),
+        (
+            SpriteId::SpectatorTeleportToPlayer,
+            "minecraft/textures/gui/sprites/spectator/teleport_to_player.png",
+            0.0,
+        ),
+        (
+            SpriteId::SpectatorTeleportToTeam,
+            "minecraft/textures/gui/sprites/spectator/teleport_to_team.png",
             0.0,
         ),
         (
@@ -3237,8 +3276,8 @@ fn push_atlas_image(
     x: f32,
     y: f32,
     size: f32,
+    tint: [f32; 4],
 ) {
-    let white = [1.0, 1.0, 1.0, 1.0];
     if let Some([u0, v0, u1, v1]) = atlas_regions.get(key) {
         push_quad(
             verts,
@@ -3250,7 +3289,7 @@ fn push_atlas_image(
             *v0,
             *u1,
             *v1,
-            white,
+            tint,
             6.0,
             [size, size],
             0.0,
@@ -3266,7 +3305,7 @@ fn push_atlas_image(
             r.v0,
             r.u1,
             r.v1,
-            white,
+            tint,
             2.0,
             [size, size],
             0.0,

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -67,11 +67,15 @@ pub struct Scoreboard {
     teams: HashMap<String, ScoreboardTeam>,
 }
 
-struct ScoreboardTeam {
+pub(crate) struct ScoreboardTeam {
+    pub(crate) display_name: Vec<TextSpan>,
     prefix: Vec<TextSpan>,
     suffix: Vec<TextSpan>,
     color: [f32; 4],
-    members: HashSet<String>,
+    /// None for RESET / non-color formatting (no icon fill in the spectator
+    /// menu), like vanilla's `PlayerTeam.getColor()` Optional.
+    pub(crate) fill_color: Option<[f32; 4]>,
+    pub(crate) members: HashSet<String>,
 }
 
 impl Scoreboard {
@@ -139,12 +143,15 @@ impl Scoreboard {
         });
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn set_team(
         &mut self,
         name: String,
+        display_name: Vec<TextSpan>,
         prefix: Vec<TextSpan>,
         suffix: Vec<TextSpan>,
         color: [f32; 4],
+        fill_color: Option<[f32; 4]>,
         members: Option<Vec<String>>,
     ) {
         // Vanilla ignores a parameter change for a team it doesn't know;
@@ -156,14 +163,18 @@ impl Scoreboard {
             self.strip_members(members);
         }
         let team = self.teams.entry(name).or_insert_with(|| ScoreboardTeam {
+            display_name: Vec::new(),
             prefix: Vec::new(),
             suffix: Vec::new(),
             color,
+            fill_color: None,
             members: HashSet::new(),
         });
+        team.display_name = display_name;
         team.prefix = prefix;
         team.suffix = suffix;
         team.color = color;
+        team.fill_color = fill_color;
         // ADD unions its player list onto an existing team, like vanilla's
         // addPlayerTeam + per-player addPlayerToTeam.
         if let Some(members) = members {
@@ -193,6 +204,10 @@ impl Scoreboard {
 
     pub fn remove_team(&mut self, name: &str) {
         self.teams.remove(name);
+    }
+
+    pub(crate) fn teams(&self) -> impl Iterator<Item = (&String, &ScoreboardTeam)> {
+        self.teams.iter()
     }
 
     /// Team membership is exclusive: joining players leave their old team.
@@ -495,48 +510,53 @@ pub fn build_hud(
         build_debug_overlay(elements, info, gs, text_width_fn);
     }
 
+    // The bar geometry also anchors the status rows and XP bar below.
     let hotbar_w = HOTBAR_W * gs;
     let hotbar_h = HOTBAR_H * gs;
     let hotbar_x = (cx - hotbar_w / 2.0).round();
     let hotbar_y = (screen_h - hotbar_h).round();
 
-    elements.push(MenuElement::Image {
-        x: hotbar_x,
-        y: hotbar_y,
-        w: hotbar_w,
-        h: hotbar_h,
-        sprite: SpriteId::Hotbar,
-        tint: WHITE,
-    });
+    // Vanilla `Hud.extractHotbarAndDecorations`: spectators get the spectator
+    // command bar (pushed by the caller) instead of the item hotbar.
+    if game_mode != 3 {
+        elements.push(MenuElement::Image {
+            x: hotbar_x,
+            y: hotbar_y,
+            w: hotbar_w,
+            h: hotbar_h,
+            sprite: SpriteId::Hotbar,
+            tint: WHITE,
+        });
 
-    let sel_w = SELECTION_W * gs;
-    let sel_h = SELECTION_H * gs;
-    let sel_x = (hotbar_x - 1.0 * gs + selected_slot as f32 * SLOT_STRIDE * gs).round();
-    let sel_y = (hotbar_y - 1.0 * gs).round();
-    elements.push(MenuElement::Image {
-        x: sel_x,
-        y: sel_y,
-        w: sel_w,
-        h: sel_h,
-        sprite: SpriteId::HotbarSelection,
-        tint: WHITE,
-    });
+        let sel_w = SELECTION_W * gs;
+        let sel_h = SELECTION_H * gs;
+        let sel_x = (hotbar_x - 1.0 * gs + selected_slot as f32 * SLOT_STRIDE * gs).round();
+        let sel_y = (hotbar_y - 1.0 * gs).round();
+        elements.push(MenuElement::Image {
+            x: sel_x,
+            y: sel_y,
+            w: sel_w,
+            h: sel_h,
+            sprite: SpriteId::HotbarSelection,
+            tint: WHITE,
+        });
 
-    let item_size = 16.0 * gs;
-    for (i, item) in hotbar.iter().enumerate().take(9) {
-        if let ItemStack::Present(data) = item {
-            let ix = (hotbar_x + 3.0 * gs + i as f32 * SLOT_STRIDE * gs).round();
-            let iy = (hotbar_y + 3.0 * gs).round();
-            elements.push(MenuElement::ItemIcon {
-                x: ix,
-                y: iy,
-                w: item_size,
-                h: item_size,
-                item_name: item_resource_name(data.kind),
-                tint: WHITE,
-            });
-            if data.count > 1 {
-                push_item_count(elements, ix, iy, item_size, gs, data.count);
+        let item_size = 16.0 * gs;
+        for (i, item) in hotbar.iter().enumerate().take(9) {
+            if let ItemStack::Present(data) = item {
+                let ix = (hotbar_x + 3.0 * gs + i as f32 * SLOT_STRIDE * gs).round();
+                let iy = (hotbar_y + 3.0 * gs).round();
+                elements.push(MenuElement::ItemIcon {
+                    x: ix,
+                    y: iy,
+                    w: item_size,
+                    h: item_size,
+                    item_name: item_resource_name(data.kind),
+                    tint: WHITE,
+                });
+                if data.count > 1 {
+                    push_item_count(elements, ix, iy, item_size, gs, data.count);
+                }
             }
         }
     }

--- a/pomme-client/src/ui/menu/friends_screen.rs
+++ b/pomme-client/src/ui/menu/friends_screen.rs
@@ -828,6 +828,7 @@ fn push_face_name(
         y: ey + (row_h - face) / 2.0,
         size: face,
         uuid: uuid.into(),
+        tint: [1.0, 1.0, 1.0, 1.0],
     });
     let text_x = content_x + face + 4.0 * gs;
     match status {

--- a/pomme-client/src/ui/mod.rs
+++ b/pomme-client/src/ui/mod.rs
@@ -20,6 +20,7 @@ pub mod menu;
 pub mod pause;
 pub mod player_tab;
 pub mod server_list;
+pub mod spectator_menu;
 pub mod subtitles;
 pub mod text;
 pub mod text_edit;

--- a/pomme-client/src/ui/spectator_menu.rs
+++ b/pomme-client/src/ui/spectator_menu.rs
@@ -1,0 +1,493 @@
+//! Spectator hotbar menu, vanilla `SpectatorGui` + `SpectatorMenu`: a digit
+//! key opens a transient 9-slot command bar (teleport to player / team) that
+//! fades out after five seconds.
+
+use std::time::Instant;
+
+use azalea_protocol::packets::game::ServerboundGamePacket;
+use azalea_protocol::packets::game::s_teleport_to_entity::ServerboundTeleportToEntity;
+use uuid::Uuid;
+
+use super::common;
+use crate::net::sender::PacketSender;
+use crate::player::tab_list::{TabList, TabListPlayer};
+use crate::renderer::pipelines::menu_overlay::{MenuElement, SpriteId};
+use crate::ui::hud::Scoreboard;
+use crate::ui::text::TextSpan;
+
+const WHITE: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
+/// Vanilla `FADE_OUT_DELAY`: ms from the last interaction to fully faded.
+const FADE_OUT_DELAY_MS: f32 = 5000.0;
+/// Vanilla `FADE_OUT_TIME`: length of the linear fade at the end of the delay.
+const FADE_OUT_TIME_MS: f32 = 2000.0;
+
+#[derive(Default)]
+pub struct SpectatorGuiState {
+    menu: Option<SpectatorMenu>,
+    /// Vanilla `lastSelectionTime`; `None` is its `0` (alpha reads 0).
+    last_selection: Option<Instant>,
+}
+
+struct SpectatorMenu {
+    category: Category,
+    /// -1 = no selection (vanilla `SpectatorPage.NO_SELECTION`).
+    selected_slot: i32,
+    page: i32,
+}
+
+struct Category {
+    prompt_key: &'static str,
+    items: Vec<Item>,
+}
+
+#[derive(Clone)]
+enum Item {
+    /// Root "Teleport to Player" entry wrapping the player items.
+    TeleportToPlayers(Vec<Item>),
+    /// Root "Teleport to Team Member" entry wrapping the team items.
+    TeleportToTeams(Vec<Item>),
+    Player {
+        uuid: Uuid,
+        name: String,
+        /// Game mode at menu open; `enabled` falls back to it once the player
+        /// leaves, like vanilla holding onto the detached `PlayerInfo`.
+        snapshot_game_mode: u8,
+    },
+    Team {
+        display: Vec<TextSpan>,
+        fill_color: Option<[f32; 4]>,
+        /// Random member whose face becomes the icon, picked once at open.
+        face_uuid: Uuid,
+        players: Vec<Item>,
+    },
+}
+
+/// A rendered slot; Close/Scroll/Empty are synthesized per slot by `get_item`
+/// (vanilla's fixed CLOSE_ITEM / ScrollMenuItem / EMPTY_SLOT singletons).
+enum SlotItem<'a> {
+    Empty,
+    Close,
+    Scroll { direction: i32, enabled: bool },
+    Item(&'a Item),
+}
+
+enum Activation {
+    Select,
+    Exit,
+    Page(i32),
+    OpenCategory {
+        prompt_key: &'static str,
+        items: Vec<Item>,
+    },
+    Teleport(Uuid),
+}
+
+impl SlotItem<'_> {
+    fn is_enabled(&self, tab_list: &TabList) -> bool {
+        match self {
+            SlotItem::Empty => false,
+            SlotItem::Close => true,
+            SlotItem::Scroll { enabled, .. } => *enabled,
+            SlotItem::Item(item) => item.is_enabled(tab_list),
+        }
+    }
+}
+
+impl Item {
+    fn is_enabled(&self, tab_list: &TabList) -> bool {
+        match self {
+            Item::TeleportToPlayers(items) | Item::TeleportToTeams(items) => !items.is_empty(),
+            // Vanilla PlayerMenuItem reads the live PlayerInfo game mode.
+            Item::Player {
+                uuid,
+                snapshot_game_mode,
+                ..
+            } => tab_list
+                .players
+                .get(uuid)
+                .map_or(*snapshot_game_mode != 3, |p| p.game_mode != 3),
+            Item::Team { .. } => true,
+        }
+    }
+}
+
+/// Vanilla `TeleportToPlayerMenuCategory`: drop spectators, sort by UUID.
+fn player_items(players: Vec<&TabListPlayer>) -> Vec<Item> {
+    let mut players: Vec<_> = players.into_iter().filter(|p| p.game_mode != 3).collect();
+    players.sort_by_key(|p| p.uuid);
+    players
+        .into_iter()
+        .map(|p| Item::Player {
+            uuid: p.uuid,
+            name: p.name.clone(),
+            snapshot_game_mode: p.game_mode,
+        })
+        .collect()
+}
+
+/// Vanilla `TeleportToTeamMenuCategory`: members resolve by name against the
+/// full player-info map (no `listed` filter); spectators, offline names, and
+/// then empty teams are dropped.
+fn team_items(tab_list: &TabList, scoreboard: &Scoreboard) -> Vec<Item> {
+    let mut items = Vec::new();
+    for (name, team) in scoreboard.teams() {
+        let members: Vec<&TabListPlayer> = team
+            .members
+            .iter()
+            .filter_map(|member| tab_list.players.values().find(|p| &p.name == member))
+            .filter(|p| p.game_mode != 3)
+            .collect();
+        if members.is_empty() {
+            continue;
+        }
+        let face_uuid = members[fastrand::usize(..members.len())].uuid;
+        let display = if team.display_name.is_empty() {
+            // Vanilla's default team display name is the team name literal.
+            vec![TextSpan::new(name.clone(), WHITE)]
+        } else {
+            team.display_name.clone()
+        };
+        items.push(Item::Team {
+            display,
+            fill_color: team.fill_color,
+            face_uuid,
+            players: player_items(members),
+        });
+    }
+    items
+}
+
+impl SpectatorMenu {
+    fn new(tab_list: &TabList, scoreboard: &Scoreboard) -> Self {
+        // Vanilla TeleportToPlayerMenuCategory() snapshots the *listed*
+        // players; the team category resolves against the full map.
+        let players = player_items(tab_list.players.values().filter(|p| p.listed).collect());
+        Self {
+            category: Category {
+                prompt_key: "spectatorMenu.root.prompt",
+                items: vec![
+                    Item::TeleportToPlayers(players),
+                    Item::TeleportToTeams(team_items(tab_list, scoreboard)),
+                ],
+            },
+            selected_slot: -1,
+            page: 0,
+        }
+    }
+
+    /// Vanilla `SpectatorMenu.getItem`, including the stride-6 quirk: page 0
+    /// shows item indices 0..=6, page 1 shows 7..=12 via slots 1..=6 (index 6
+    /// on page 0 is never reachable again after paging).
+    fn get_item(&self, slot: i32) -> SlotItem<'_> {
+        let index = slot + self.page * 6;
+        if self.page > 0 && slot == 0 {
+            return SlotItem::Scroll {
+                direction: -1,
+                enabled: true,
+            };
+        }
+        if slot == 7 {
+            return SlotItem::Scroll {
+                direction: 1,
+                enabled: (index as usize) < self.category.items.len(),
+            };
+        }
+        if slot == 8 {
+            return SlotItem::Close;
+        }
+        if index < 0 || index as usize >= self.category.items.len() {
+            return SlotItem::Empty;
+        }
+        SlotItem::Item(&self.category.items[index as usize])
+    }
+
+    /// Vanilla `selectSlot`: the first press moves the selection, a second
+    /// press on the same enabled slot activates it. Returns true when the
+    /// activation closes the menu.
+    fn select_slot(&mut self, slot: i32, tab_list: &TabList, sender: &PacketSender) -> bool {
+        let activation = match self.get_item(slot) {
+            SlotItem::Empty => return false,
+            item if self.selected_slot != slot || !item.is_enabled(tab_list) => Activation::Select,
+            SlotItem::Close => Activation::Exit,
+            SlotItem::Scroll { direction, .. } => Activation::Page(direction),
+            SlotItem::Item(Item::TeleportToPlayers(items)) => Activation::OpenCategory {
+                prompt_key: "spectatorMenu.teleport.prompt",
+                items: items.clone(),
+            },
+            SlotItem::Item(Item::TeleportToTeams(items)) => Activation::OpenCategory {
+                prompt_key: "spectatorMenu.team_teleport.prompt",
+                items: items.clone(),
+            },
+            SlotItem::Item(Item::Team { players, .. }) => Activation::OpenCategory {
+                prompt_key: "spectatorMenu.teleport.prompt",
+                items: players.clone(),
+            },
+            SlotItem::Item(Item::Player { uuid, .. }) => Activation::Teleport(*uuid),
+        };
+        match activation {
+            Activation::Select => {
+                self.selected_slot = slot;
+                false
+            }
+            Activation::Exit => true,
+            Activation::Page(direction) => {
+                // Vanilla keeps the selection on the scroll slot so a repeat
+                // press pages again.
+                self.page += direction;
+                false
+            }
+            Activation::OpenCategory { prompt_key, items } => {
+                // Vanilla selectCategory: fresh selection and page.
+                self.category = Category { prompt_key, items };
+                self.selected_slot = -1;
+                self.page = 0;
+                false
+            }
+            Activation::Teleport(uuid) => {
+                // Vanilla PlayerMenuItem: send and leave the menu open.
+                sender.send(ServerboundGamePacket::TeleportToEntity(
+                    ServerboundTeleportToEntity { uuid },
+                ));
+                false
+            }
+        }
+    }
+}
+
+impl SpectatorGuiState {
+    /// Digit key 1-9 in spectator mode. Vanilla `onHotbarSelected`: the press
+    /// that opens the menu selects nothing.
+    pub fn on_hotbar_selected(
+        &mut self,
+        slot: u8,
+        tab_list: &TabList,
+        scoreboard: &Scoreboard,
+        sender: &PacketSender,
+    ) {
+        self.last_selection = Some(Instant::now());
+        if self.menu.is_none() {
+            self.menu = Some(SpectatorMenu::new(tab_list, scoreboard));
+        } else {
+            self.select(slot as i32, tab_list, sender);
+        }
+    }
+
+    /// Middle click (vanilla `keySpectatorHotbar`): open the menu, or
+    /// re-press the current selection to activate it.
+    pub fn on_hotbar_action_key(
+        &mut self,
+        tab_list: &TabList,
+        scoreboard: &Scoreboard,
+        sender: &PacketSender,
+    ) {
+        self.last_selection = Some(Instant::now());
+        match self.menu.as_ref().map(|m| m.selected_slot) {
+            None => self.menu = Some(SpectatorMenu::new(tab_list, scoreboard)),
+            Some(-1) => {}
+            Some(slot) => self.select(slot, tab_list, sender),
+        }
+    }
+
+    /// Vanilla `onMouseScrolled` (already sign-inverted by the caller): step
+    /// in the scroll direction skipping empty and disabled slots.
+    pub fn on_mouse_scrolled(&mut self, wheel: i32, tab_list: &TabList, sender: &PacketSender) {
+        let Some(menu) = &self.menu else { return };
+        let mut slot = menu.selected_slot + wheel;
+        while (0..=8).contains(&slot) && !menu.get_item(slot).is_enabled(tab_list) {
+            slot += wheel;
+        }
+        if (0..=8).contains(&slot) {
+            self.select(slot, tab_list, sender);
+            self.last_selection = Some(Instant::now());
+        }
+    }
+
+    /// `selectSlot` plus the listener's close-on-exit.
+    fn select(&mut self, slot: i32, tab_list: &TabList, sender: &PacketSender) {
+        if let Some(menu) = &mut self.menu
+            && menu.select_slot(slot, tab_list, sender)
+        {
+            self.close();
+        }
+    }
+
+    pub fn is_menu_active(&self) -> bool {
+        self.menu.is_some()
+    }
+
+    /// Vanilla `onSpectatorMenuClosed`: drop the menu and zero the timer so
+    /// alpha reads 0 immediately.
+    pub fn close(&mut self) {
+        self.menu = None;
+        self.last_selection = None;
+    }
+
+    /// Vanilla `getHotbarAlpha`: opaque for the first 3 s after the last
+    /// interaction, then a 2 s linear fade.
+    fn hotbar_alpha(&self) -> f32 {
+        let Some(last) = self.last_selection else {
+            return 0.0;
+        };
+        let elapsed = last.elapsed().as_millis() as f32;
+        ((FADE_OUT_DELAY_MS - elapsed) / FADE_OUT_TIME_MS).clamp(0.0, 1.0)
+    }
+}
+
+fn key_spans(key: &str) -> Vec<TextSpan> {
+    let text = crate::lang::translate(key).unwrap_or(key).to_string();
+    vec![TextSpan::new(text, WHITE)]
+}
+
+fn push_face(elements: &mut Vec<MenuElement>, x: f32, y: f32, gs: f32, uuid: Uuid, tint: [f32; 4]) {
+    elements.push(MenuElement::SkinFace {
+        x: x + 2.0 * gs,
+        y: y + 2.0 * gs,
+        size: 12.0 * gs,
+        uuid: uuid.to_string(),
+        tint,
+    });
+}
+
+/// Vanilla `SpectatorGui.extractHotbar` + `extractAction`: the sliding,
+/// fading command bar and the name/prompt line above it. Replaces the item
+/// hotbar while in spectator mode.
+pub fn build_spectator_menu(
+    elements: &mut Vec<MenuElement>,
+    state: &mut SpectatorGuiState,
+    tab_list: &TabList,
+    screen_w: f32,
+    screen_h: f32,
+    gs: f32,
+    text_width: common::TextWidthFn,
+) {
+    if state.menu.is_none() {
+        return;
+    }
+    let alpha = state.hotbar_alpha();
+    if alpha <= 0.0 {
+        // Vanilla extractHotbar: a fully faded menu closes itself.
+        state.close();
+        return;
+    }
+    let cx = screen_w / 2.0;
+    // The bar slides down as it fades: y = floor(guiHeight - 22 * alpha).
+    let y = (screen_h - 22.0 * alpha * gs).floor();
+    let fade = [1.0, 1.0, 1.0, alpha];
+    let menu = state.menu.as_ref().unwrap();
+
+    elements.push(MenuElement::Image {
+        x: (cx - 91.0 * gs).round(),
+        y,
+        w: 182.0 * gs,
+        h: 22.0 * gs,
+        sprite: SpriteId::Hotbar,
+        tint: fade,
+    });
+    if menu.selected_slot >= 0 {
+        elements.push(MenuElement::Image {
+            x: (cx - 92.0 * gs + menu.selected_slot as f32 * 20.0 * gs).round(),
+            y: y - 1.0 * gs,
+            w: 24.0 * gs,
+            h: 23.0 * gs,
+            sprite: SpriteId::HotbarSelection,
+            tint: fade,
+        });
+    }
+
+    for slot in 0..9 {
+        let item = menu.get_item(slot);
+        if matches!(item, SlotItem::Empty) {
+            continue;
+        }
+        let enabled = item.is_enabled(tab_list);
+        // Disabled icons dim to 25% brightness; alpha fades separately.
+        let b = if enabled { 1.0 } else { 0.25 };
+        let icon_x = (cx - 88.0 * gs + slot as f32 * 20.0 * gs).round();
+        let icon_y = y + 3.0 * gs;
+        let sprite = match &item {
+            SlotItem::Empty => None,
+            SlotItem::Close => Some(SpriteId::SpectatorClose),
+            SlotItem::Scroll { direction, .. } => Some(if *direction < 0 {
+                SpriteId::SpectatorScrollLeft
+            } else {
+                SpriteId::SpectatorScrollRight
+            }),
+            SlotItem::Item(Item::TeleportToPlayers(_)) => Some(SpriteId::SpectatorTeleportToPlayer),
+            SlotItem::Item(Item::TeleportToTeams(_)) => Some(SpriteId::SpectatorTeleportToTeam),
+            SlotItem::Item(Item::Player { uuid, .. }) => {
+                // Vanilla PlayerMenuItem: the face ignores the brightness dim.
+                push_face(elements, icon_x, icon_y, gs, *uuid, fade);
+                None
+            }
+            SlotItem::Item(Item::Team {
+                fill_color,
+                face_uuid,
+                ..
+            }) => {
+                if let Some([r, g, bl, _]) = fill_color {
+                    // Vanilla team icon: the color fill dims but never fades.
+                    elements.push(MenuElement::Rect {
+                        x: icon_x + 1.0 * gs,
+                        y: icon_y + 1.0 * gs,
+                        w: 14.0 * gs,
+                        h: 14.0 * gs,
+                        corner_radius: 0.0,
+                        color: [r * b, g * b, bl * b, 1.0],
+                    });
+                }
+                push_face(elements, icon_x, icon_y, gs, *face_uuid, [b, b, b, alpha]);
+                None
+            }
+        };
+        if let Some(sprite) = sprite {
+            elements.push(MenuElement::Image {
+                x: icon_x,
+                y: icon_y,
+                w: 16.0 * gs,
+                h: 16.0 * gs,
+                sprite,
+                tint: [b, b, b, alpha],
+            });
+        }
+        if enabled {
+            let label = (slot + 1).to_string();
+            let scale = common::FONT_SIZE * gs;
+            elements.push(MenuElement::McText {
+                x: icon_x + 17.0 * gs - text_width(&label, scale),
+                y: y + 12.0 * gs,
+                spans: vec![TextSpan::new(label, fade)],
+                scale,
+                centered: false,
+                shadow: true,
+            });
+        }
+    }
+
+    // Vanilla extractAction: the selected item's name, or the category prompt
+    // while nothing is selected. No backdrop: vanilla's textWithBackdrop
+    // resolves to color 0 under the default text-background options.
+    let mut spans = match menu.get_item(menu.selected_slot) {
+        SlotItem::Empty => key_spans(menu.category.prompt_key),
+        SlotItem::Close => key_spans("spectatorMenu.close"),
+        SlotItem::Scroll { direction, .. } => key_spans(if direction < 0 {
+            "spectatorMenu.previous_page"
+        } else {
+            "spectatorMenu.next_page"
+        }),
+        SlotItem::Item(Item::TeleportToPlayers(_)) => key_spans("spectatorMenu.teleport"),
+        SlotItem::Item(Item::TeleportToTeams(_)) => key_spans("spectatorMenu.team_teleport"),
+        SlotItem::Item(Item::Player { name, .. }) => vec![TextSpan::new(name.clone(), WHITE)],
+        SlotItem::Item(Item::Team { display, .. }) => display.clone(),
+    };
+    for span in &mut spans {
+        span.color[3] *= alpha;
+    }
+    elements.push(MenuElement::McText {
+        x: cx,
+        y: screen_h - 35.0 * gs,
+        spans,
+        scale: common::FONT_SIZE * gs,
+        centered: true,
+        shadow: true,
+    });
+}

--- a/pomme-protocol/src/packets.rs
+++ b/pomme-protocol/src/packets.rs
@@ -220,6 +220,10 @@ mod tests {
             t.id(Phase::Handshake, Direction::Serverbound, "intention"),
             Some(0)
         );
+        assert_eq!(
+            t.id(Phase::Game, Direction::Serverbound, "teleport_to_entity"),
+            Some(0x40)
+        );
         assert_eq!(t.id(Phase::Game, Direction::Serverbound, "no_such"), None);
     }
 


### PR DESCRIPTION
Hotbar-style command picker for spectator mode: a digit key opens a 9 slot bar with teleport to player and teleport to team, digit or middle click activates the selection, scroll moves it skipping disabled slots, and the bar slides out after 5 seconds. Player faces come from an 8x8 face cache flushed into the shared face atlas only while the menu is open. Digits in spectator no longer change the carried slot or send SetCarriedItem, and scroll with the menu closed adjusts fly speed. TeleportToEntity is pinned with a table anchor and an azalea id cross-check.