### PR TITLE
add saving indicator

### DIFF
--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -158,6 +158,10 @@ pub struct GameState {
     pub subtitles: crate::ui::subtitles::SubtitleOverlayState,
     /// Client tick counter (vanilla `player.tickCount`).
     pub tick_count: u64,
+    /// Vanilla `Hud.autosaveIndicatorValue` / `lastAutosaveIndicatorValue`;
+    /// driven by in-flight screenshot writes (pomme saves no worlds).
+    pub saving_indicator_value: f32,
+    pub last_saving_indicator_value: f32,
     /// Tick of the last XP progress change; the XP bar outprioritizes the
     /// locator bar for 100 ticks after it (vanilla
     /// `experienceDisplayStartTick`; `i64::MIN` = untouched since (re)spawn,
@@ -352,6 +356,8 @@ impl GameState {
             toasts: crate::ui::toast::ToastState::default(),
             subtitles: crate::ui::subtitles::SubtitleOverlayState::default(),
             tick_count: 0,
+            saving_indicator_value: 0.0,
+            last_saving_indicator_value: 0.0,
             xp_display_start_tick: i64::MIN,
             controlled_vehicle_id: None,
             riding_vehicle_id: None,
@@ -1486,6 +1492,14 @@ pub fn update_game(
         // the darkness of the eye block's light level.
         let target = (1.0 - eye_lightmap_brightness(game)).clamp(0.0, 1.0);
         game.vignette_brightness += (target - game.vignette_brightness) * 0.01;
+        // Vanilla `Hud.tickAutosaveIndicator`.
+        game.last_saving_indicator_value = game.saving_indicator_value;
+        let target = if gfx.renderer.screenshot_saving() {
+            1.0
+        } else {
+            0.0
+        };
+        game.saving_indicator_value = game.saving_indicator_value.lerp(target, 0.2);
         if let Some(c) = &mut game.open_container
             && let Some(state) = &mut c.enchant
         {
@@ -2768,6 +2782,20 @@ pub fn update_game(
             _ => None,
         }
     };
+    // Last element pushed: vanilla draws the saving indicator on its own
+    // stratum above screens, with the GUI hidden (F1) included.
+    if !benchmark_running && core.menu.show_autosave_indicator {
+        let alpha = game
+            .last_saving_indicator_value
+            .lerp(game.saving_indicator_value, partial_tick)
+            .clamp(0.0, 1.0);
+        if (alpha * 255.0).floor() > 0.0 {
+            hud::build_saving_indicator(&mut elements, sw, sh, gs, alpha, &|t, s| {
+                gfx.renderer.menu_text_width(t, s)
+            });
+        }
+    }
+
     // Recompute after this frame's state changes (a finished benchmark releases
     // the cursor mid-frame), so the renderer doesn't re-hide it from a stale value.
     let hide_cursor = game.input_live() && !game.dead && core.input.is_cursor_captured();

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -960,6 +960,11 @@ impl Renderer {
         self.screenshot.drain_results()
     }
 
+    /// A screenshot capture or encode is still in flight.
+    pub fn screenshot_saving(&self) -> bool {
+        self.screenshot.saving()
+    }
+
     pub fn wait_for_all_frames(&self) {
         let _ = self
             .ctx

--- a/pomme-client/src/renderer/screenshot.rs
+++ b/pomme-client/src/renderer/screenshot.rs
@@ -26,6 +26,8 @@ struct PendingCapture {
 pub struct ScreenshotCapture {
     armed: bool,
     pending: Vec<PendingCapture>,
+    /// Encodes spawned but not yet drained from `result_rx`.
+    in_flight: u32,
     game_dir: PathBuf,
     result_tx: Sender<Result<String, String>>,
     result_rx: Receiver<Result<String, String>>,
@@ -37,6 +39,7 @@ impl ScreenshotCapture {
         Self {
             armed: false,
             pending: Vec::new(),
+            in_flight: 0,
             game_dir,
             result_tx,
             result_rx,
@@ -48,9 +51,17 @@ impl ScreenshotCapture {
         self.armed = true;
     }
 
+    /// A capture is somewhere between armed and written to disk; drives the
+    /// HUD saving indicator.
+    pub fn saving(&self) -> bool {
+        self.armed || !self.pending.is_empty() || self.in_flight > 0
+    }
+
     /// Drain completed captures: `Ok(bare filename)` or `Err(message)`.
     pub fn drain_results(&mut self) -> Vec<Result<String, String>> {
-        self.result_rx.try_iter().collect()
+        let results: Vec<_> = self.result_rx.try_iter().collect();
+        self.in_flight = self.in_flight.saturating_sub(results.len() as u32);
+        results
     }
 
     /// If armed, record the image->buffer copy into `cmd` after the final
@@ -182,11 +193,12 @@ impl ScreenshotCapture {
     }
 
     fn read_and_spawn(
-        &self,
+        &mut self,
         cap: PendingCapture,
         device: &vk::Device,
         allocator: &Arc<Mutex<Allocator>>,
     ) {
+        self.in_flight += 1;
         let px_bytes = cap.width as usize * cap.height as usize * 4;
         let pixels = cap
             .allocation

--- a/pomme-client/src/ui/hud.rs
+++ b/pomme-client/src/ui/hud.rs
@@ -1125,6 +1125,33 @@ fn build_scoreboard(
     }
 }
 
+/// Vanilla `Hud.extractSavingIndicator`: "Saving world" text 5 GUI units from
+/// the bottom-right, faded by `alpha`. No backdrop rect: vanilla's
+/// `getBackgroundColor(0.0f)` is 0 under default options.
+pub fn build_saving_indicator(
+    elements: &mut Vec<MenuElement>,
+    screen_w: f32,
+    screen_h: f32,
+    gs: f32,
+    alpha: f32,
+    text_width_fn: TextWidthFn,
+) {
+    let text = crate::lang::translate("menu.savingLevel").unwrap_or("Saving world");
+    let fs = FONT_SIZE * gs;
+    let w = text_width_fn(text, fs);
+    let mut span = TextSpan::new(text.into(), WHITE);
+    span.color[3] *= alpha;
+    elements.push(MenuElement::McText {
+        x: (screen_w - w - 5.0 * gs).round(),
+        // Vanilla `guiHeight - lineHeight(9) - 5`.
+        y: (screen_h - 14.0 * gs).round(),
+        spans: vec![span],
+        scale: fs,
+        centered: false,
+        shadow: true,
+    });
+}
+
 /// Right-aligned status icon x, matching vanilla `xRight - i * 8 - 9`.
 fn icon_row_x_rtl(x_right: f32, i: i32, gs: f32) -> f32 {
     (x_right - i as f32 * ICON_STRIDE * gs - ICON_SIZE * gs).round()

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -38,6 +38,8 @@ struct Settings {
     #[serde(default = "default_true")]
     vignette: bool,
     #[serde(default = "default_true")]
+    show_autosave_indicator: bool,
+    #[serde(default = "default_true")]
     vsync: bool,
     #[serde(default = "default_max_framerate")]
     max_framerate: u32,
@@ -136,6 +138,7 @@ impl Default for Settings {
             fov_effect_scale: 1.0,
             view_bobbing: true,
             show_subtitles: false,
+            show_autosave_indicator: true,
             vignette: true,
             vsync: true,
             max_framerate: 120,
@@ -421,6 +424,7 @@ pub struct MainMenu {
     pub fov_effect_scale: f32,
     pub view_bobbing: bool,
     pub show_subtitles: bool,
+    pub show_autosave_indicator: bool,
     pub vignette: bool,
     pub vsync: bool,
     pub max_framerate: u32,
@@ -528,6 +532,7 @@ impl MainMenu {
             fov_effect_scale: settings.fov_effect_scale,
             view_bobbing: settings.view_bobbing,
             show_subtitles: settings.show_subtitles,
+            show_autosave_indicator: settings.show_autosave_indicator,
             vignette: settings.vignette,
             vsync: settings.vsync,
             max_framerate: settings.max_framerate,
@@ -624,6 +629,7 @@ impl MainMenu {
                 fov_effect_scale: self.fov_effect_scale,
                 view_bobbing: self.view_bobbing,
                 show_subtitles: self.show_subtitles,
+                show_autosave_indicator: self.show_autosave_indicator,
                 vignette: self.vignette,
                 vsync: self.vsync,
                 max_framerate: self.max_framerate,

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -144,6 +144,11 @@ impl MainMenu {
         } else {
             "Vignette: OFF"
         };
+        let autosave_label = if self.show_autosave_indicator {
+            "Show Autosave Indicator: ON"
+        } else {
+            "Show Autosave Indicator: OFF"
+        };
         let rows: Vec<OptRow> = vec![
             OptRow::Header("Display"),
             OptRow::Big("Fullscreen Resolution: Current"),
@@ -165,7 +170,7 @@ impl MainMenu {
             OptRow::Pair("Texture Filtering: None", "Max Anisotropy: 1"),
             OptRow::PairLeft("Weather Radius: 10"),
             OptRow::Header("Preferences"),
-            OptRow::Pair("Show Autosave Indicator: ON", vignette_label),
+            OptRow::Pair(autosave_label, vignette_label),
             OptRow::Pair(&attack_label, "Chunk Fade-in: 1.0s"),
         ];
         let rd_frac = ((self.render_distance as f32 - 2.0) / (rd_max as f32 - 2.0)).clamp(0.0, 1.0);
@@ -747,6 +752,10 @@ impl MainMenu {
                     }
                     if label.starts_with("View Bobbing:") {
                         self.view_bobbing = !self.view_bobbing;
+                        self.save_settings();
+                    }
+                    if label.starts_with("Show Autosave Indicator:") {
+                        self.show_autosave_indicator = !self.show_autosave_indicator;
                         self.save_settings();
                     }
                     if label.starts_with("VSync:") {


### PR DESCRIPTION
Autosave indicator text bottom-right, faded in while a screenshot capture or encode is in flight (the client's only async save). Wires the stubbed Show Autosave Indicator toggle in video settings.

Closes #136 