### PR TITLE
hide client console window on windows

### DIFF
--- a/pomme-launcher/src-tauri/src/commands.rs
+++ b/pomme-launcher/src-tauri/src/commands.rs
@@ -452,6 +452,11 @@ pub async fn launch_game(
     #[cfg(unix)]
     cmd.process_group(0);
 
+    // The client is a console-subsystem binary; without this, Windows pops a
+    // terminal window for it alongside the game.
+    #[cfg(windows)]
+    cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
+
     let mut child = cmd.spawn().map_err(|e| e.to_string())?;
 
     let stdout = child.stdout.take().expect("couldn't take stdout");


### PR DESCRIPTION
The launcher spawns the client, a console-subsystem binary, without CREATE_NO_WINDOW, so Windows pops a terminal alongside the game. Sets the flag on the spawn; piped log capture is unaffected.