### PR TITLE
center cursor on capture change and pause on lost focus

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -177,6 +177,9 @@ pub struct AppCore {
     pub audio: crate::audio::AudioEngine,
     pub tick_accumulator: f32,
     pub time_tick_accumulator: f32,
+    /// When the window lost OS focus, for pause-on-lost-focus (vanilla
+    /// `pauseIfInactive`); `None` while focused.
+    pub unfocused_since: Option<Instant>,
     player_skin_tx: crossbeam_channel::Sender<PlayerSkinResult>,
     player_skin_rx: crossbeam_channel::Receiver<PlayerSkinResult>,
     requested_player_skins: HashMap<uuid::Uuid, Option<String>>,
@@ -229,6 +232,7 @@ impl AppCore {
             audio,
             tick_accumulator: 0.0,
             time_tick_accumulator: 0.0,
+            unfocused_since: None,
             player_skin_tx,
             player_skin_rx,
             requested_player_skins: HashMap::new(),
@@ -277,18 +281,36 @@ impl AppCore {
         }
     }
 
-    pub fn apply_cursor_grab(&self, window: &Window, game: Option<&mut GameState>) {
+    pub fn apply_cursor_grab(&mut self, window: &Window, game: Option<&mut GameState>) {
         let captured =
             game.is_some_and(|g| g.input_live() && !g.dead && self.input.is_cursor_captured());
         if captured {
+            // Vanilla centers on grab too; warp before locking, which
+            // freezes the position on some platforms.
+            self.center_cursor(window);
             let _ = window
                 .set_cursor_grab(CursorGrabMode::Locked)
                 .or_else(|_| window.set_cursor_grab(CursorGrabMode::Confined));
             window.set_cursor_visible(false);
         } else {
-            let _ = window.set_cursor_grab(CursorGrabMode::None);
-            window.set_cursor_visible(true);
+            self.release_cursor(window);
         }
+    }
+
+    /// Releases the cursor and warps it to the window center, like vanilla
+    /// `MouseHandler.releaseMouse` (every screen opens with a centered
+    /// cursor instead of wherever the last one closed).
+    fn release_cursor(&mut self, window: &Window) {
+        let _ = window.set_cursor_grab(CursorGrabMode::None);
+        window.set_cursor_visible(true);
+        self.center_cursor(window);
+    }
+
+    fn center_cursor(&mut self, window: &Window) {
+        let size = window.inner_size();
+        let (x, y) = (size.width as f32 / 2.0, size.height as f32 / 2.0);
+        let _ = window.set_cursor_position(winit::dpi::PhysicalPosition::new(x, y));
+        self.input.on_cursor_moved(x, y);
     }
 
     pub fn send_respawn(&mut self, connection: &ConnectionHandle, game: &mut GameState) {
@@ -607,8 +629,7 @@ impl AppCore {
                         game.death_confirm = false;
                         game.respawn_sent = false;
 
-                        let _ = window.set_cursor_grab(CursorGrabMode::None);
-                        window.set_cursor_visible(true);
+                        self.release_cursor(window);
                     }
                 }
                 NetworkEvent::SetPassengers {
@@ -1417,8 +1438,7 @@ impl AppCore {
                     game.death_confirm = false;
                     game.respawn_sent = false;
 
-                    let _ = window.set_cursor_grab(CursorGrabMode::None);
-                    window.set_cursor_visible(true);
+                    self.release_cursor(window);
                 }
                 NetworkEvent::ResourcePackPush {
                     id,

--- a/pomme-client/src/app/mod.rs
+++ b/pomme-client/src/app/mod.rs
@@ -521,6 +521,10 @@ impl ApplicationHandler for App {
                 self.occluded = occluded;
             }
 
+            WindowEvent::Focused(focused) => {
+                self.core.unfocused_since = (!focused).then(Instant::now);
+            }
+
             WindowEvent::RedrawRequested => {
                 if matches!(self.phase.get(), AppPhase::Setup { .. }) {
                     return;

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -1152,7 +1152,7 @@ fn apply_result_action(
     kind: ResultKind,
     status: Option<UploadStatus>,
     json: String,
-    core: &AppCore,
+    core: &mut AppCore,
     gfx: &Gfx,
     game: &mut GameState,
 ) {
@@ -1382,6 +1382,21 @@ pub fn update_game(
     core.audio.set_subtitles_enabled(core.menu.show_subtitles);
 
     gfx.renderer.set_vsync(core.menu.vsync);
+
+    // Vanilla pauseIfInactive: losing OS focus for more than half a second
+    // with no screen open pauses the game, which also releases the cursor
+    // (otherwise a system overlay like Win-key search opens over a still
+    // captured cursor). TODO: F3+P toggle (options.pauseOnLostFocus).
+    if core
+        .unfocused_since
+        .is_some_and(|t| t.elapsed().as_millis() > 500)
+        && game.input_live()
+        && !game.dead
+    {
+        game.paused = true;
+        game.pause_screen = PauseScreen::Main;
+        core.apply_cursor_grab(&gfx.window, Some(game));
+    }
 
     let disconnect_reason =
         core.drain_network_events(connection, None, &mut gfx.renderer, &gfx.window, game);


### PR DESCRIPTION
Screens open with a centered cursor, and losing OS focus in gameplay opens the pause menu so the cursor is released.