### PR TITLE
pomme-client: fix crosshair targeting on partial blocks

### DIFF
--- a/pomme-client/src/particle.rs
+++ b/pomme-client/src/particle.rs
@@ -359,13 +359,12 @@ impl ParticleStore {
         };
         let light = world_brightness(chunks, pos.x, pos.y, pos.z);
 
-        const FULL_CUBE: LocalBox = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0];
         let boxes: &[LocalBox] = match block_shape::partial_shape(state) {
             Some(boxes) if !boxes.is_empty() => boxes,
             // None = full cube. Some(&[]) = no collision (flowers, torches):
             // vanilla scatters over the outline shape, which pomme doesn't
             // have, so fall back to the full cube.
-            _ => &[FULL_CUBE],
+            _ => &[block_shape::FULL_CUBE],
         };
 
         for b in boxes {

--- a/pomme-client/src/particle.rs
+++ b/pomme-client/src/particle.rs
@@ -359,13 +359,9 @@ impl ParticleStore {
         };
         let light = world_brightness(chunks, pos.x, pos.y, pos.z);
 
-        let boxes: &[LocalBox] = match block_shape::partial_shape(state) {
-            Some(boxes) if !boxes.is_empty() => boxes,
-            // None = full cube. Some(&[]) = no collision (flowers, torches):
-            // vanilla scatters over the outline shape, which pomme doesn't
-            // have, so fall back to the full cube.
-            _ => &[block_shape::FULL_CUBE],
-        };
+        // Vanilla `ParticleEngine.destroy` scatters over the outline shape's
+        // boxes, so a block with an empty outline emits nothing.
+        let boxes: &[LocalBox] = block_shape::outline_shape(state);
 
         for b in boxes {
             let width_x = (b[3] - b[0]).min(1.0);

--- a/pomme-client/src/physics/aabb.rs
+++ b/pomme-client/src/physics/aabb.rs
@@ -1,5 +1,10 @@
 use glam::{DVec3, dvec3};
 
+use super::block_shape::LocalBox;
+
+/// Vanilla `Mth.EPSILON`, the slop `AABB.clip` works to.
+const EPSILON: f64 = 1.0e-7;
+
 #[derive(Debug, Clone, Copy)]
 pub struct Aabb {
     pub min: DVec3,
@@ -19,6 +24,14 @@ impl Aabb {
         )
     }
 
+    /// A block-local box placed at `offset`, usually the block position.
+    pub fn from_local([min_x, min_y, min_z, max_x, max_y, max_z]: LocalBox, offset: DVec3) -> Self {
+        Self::new(
+            offset + dvec3(min_x, min_y, min_z),
+            offset + dvec3(max_x, max_y, max_z),
+        )
+    }
+
     pub fn from_center(center: DVec3, half_width: f64, half_height: f64) -> Self {
         Self {
             min: dvec3(center.x - half_width, center.y, center.z - half_width),
@@ -28,6 +41,16 @@ impl Aabb {
                 center.z + half_width,
             ),
         }
+    }
+
+    /// Vanilla `AABB.contains`: half-open, so a point on a max face is outside.
+    pub fn contains(&self, point: DVec3) -> bool {
+        point.x >= self.min.x
+            && point.x < self.max.x
+            && point.y >= self.min.y
+            && point.y < self.max.y
+            && point.z >= self.min.z
+            && point.z < self.max.z
     }
 
     pub fn intersects(&self, other: &Aabb) -> bool {
@@ -118,8 +141,79 @@ impl Aabb {
     }
 }
 
-#[derive(Clone, Copy)]
-enum Axis {
+/// The face of a box a ray entered through: the axis it lies on plus whether
+/// it is the box's max side. Callers that need vanilla's `Direction` map it at
+/// their own boundary, keeping this module free of wire types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Face {
+    pub axis: Axis,
+    pub max: bool,
+}
+
+/// Ports vanilla `AABB.clip(Iterable<AABB>, Vec3, Vec3, BlockPos)`: the nearest
+/// entry across `boxes` (block-local, shifted by `offset`), as the fraction
+/// along `from -> to` and the face entered. `None` if the ray misses them all.
+pub fn clip_boxes(
+    boxes: &[LocalBox],
+    offset: DVec3,
+    from: DVec3,
+    to: DVec3,
+) -> Option<(f64, Face)> {
+    let delta = to - from;
+    let mut nearest = 1.0;
+    let mut face = None;
+
+    for &local in boxes {
+        let aabb = Aabb::from_local(local, offset);
+        for axis in [Axis::X, Axis::Y, Axis::Z] {
+            // A ray only enters through the face it travels towards, so the
+            // sign of its component picks which plane to test.
+            let d = component(delta, axis);
+            let max = if d > EPSILON {
+                false
+            } else if d < -EPSILON {
+                true
+            } else {
+                continue;
+            };
+            let plane = component(if max { aabb.max } else { aabb.min }, axis);
+            if let Some(t) = clip_point(&aabb, plane, axis, from, delta, nearest) {
+                nearest = t;
+                face = Some(Face { axis, max });
+            }
+        }
+    }
+
+    face.map(|face| (nearest, face))
+}
+
+/// Ports vanilla `AABB.clipPoint`: the fraction at which the ray crosses
+/// `plane` on `axis`, if that lands inside the box's face rect and nearer than
+/// `nearest`.
+fn clip_point(
+    aabb: &Aabb,
+    plane: f64,
+    axis: Axis,
+    from: DVec3,
+    delta: DVec3,
+    nearest: f64,
+) -> Option<f64> {
+    let t = (plane - component(from, axis)) / component(delta, axis);
+    if t <= 0.0 || t >= nearest {
+        return None;
+    }
+    let (b, c) = axis.cross_axes();
+    for cross in [b, c] {
+        let p = component(from, cross) + t * component(delta, cross);
+        if p <= component(aabb.min, cross) - EPSILON || p >= component(aabb.max, cross) + EPSILON {
+            return None;
+        }
+    }
+    Some(t)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Axis {
     X,
     Y,
     Z,
@@ -140,5 +234,81 @@ fn component(v: DVec3, axis: Axis) -> f64 {
         Axis::X => v.x,
         Axis::Y => v.y,
         Axis::Z => v.z,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BOTTOM_SLAB: LocalBox = [0.0, 0.0, 0.0, 1.0, 0.5, 1.0];
+
+    #[test]
+    fn contains_is_half_open() {
+        let unit = Aabb::block(0, 0, 0);
+        assert!(unit.contains(dvec3(0.0, 0.0, 0.0)));
+        assert!(unit.contains(dvec3(0.5, 0.5, 0.5)));
+        assert!(!unit.contains(dvec3(1.0, 0.5, 0.5)));
+        assert!(!unit.contains(dvec3(0.5, -0.001, 0.5)));
+    }
+
+    #[test]
+    fn clip_hits_the_top_of_a_slab() {
+        let from = dvec3(0.5, 2.0, 0.5);
+        let to = dvec3(0.5, -1.0, 0.5);
+        let (t, face) = clip_boxes(&[BOTTOM_SLAB], DVec3::ZERO, from, to).unwrap();
+
+        assert_eq!(
+            face,
+            Face {
+                axis: Axis::Y,
+                max: true
+            }
+        );
+        let hit = from + (to - from) * t;
+        assert!((hit.y - 0.5).abs() < 1e-9, "hit {hit:?}");
+    }
+
+    /// A ray passing through the block cell but over the slab's shape misses.
+    #[test]
+    fn clip_misses_above_a_slab() {
+        let from = dvec3(-1.0, 0.75, 0.5);
+        let to = dvec3(2.0, 0.75, 0.5);
+        assert!(clip_boxes(&[BOTTOM_SLAB], DVec3::ZERO, from, to).is_none());
+    }
+
+    /// Vanilla carries `t` across the whole iterable, so listing order can't
+    /// change the answer.
+    #[test]
+    fn clip_keeps_the_nearest_of_several_boxes() {
+        let far: LocalBox = [0.0, 0.0, 0.0, 1.0, 0.25, 1.0];
+        let near: LocalBox = [0.0, 0.5, 0.0, 1.0, 0.75, 1.0];
+        let from = dvec3(0.5, 2.0, 0.5);
+        let to = dvec3(0.5, -1.0, 0.5);
+
+        for boxes in [[far, near], [near, far]] {
+            let (t, face) = clip_boxes(&boxes, DVec3::ZERO, from, to).unwrap();
+            assert_eq!(
+                face,
+                Face {
+                    axis: Axis::Y,
+                    max: true
+                }
+            );
+            let hit = from + (to - from) * t;
+            assert!((hit.y - 0.75).abs() < 1e-9, "hit {hit:?}");
+        }
+    }
+
+    #[test]
+    fn clip_respects_the_block_offset() {
+        let from = dvec3(3.5, 2.0, -4.5);
+        let to = dvec3(3.5, -1.0, -4.5);
+        let offset = dvec3(3.0, 0.0, -5.0);
+        let (t, _) = clip_boxes(&[BOTTOM_SLAB], offset, from, to).unwrap();
+
+        let hit = from + (to - from) * t;
+        assert!((hit.y - 0.5).abs() < 1e-9, "hit {hit:?}");
+        assert!(clip_boxes(&[BOTTOM_SLAB], DVec3::ZERO, from, to).is_none());
     }
 }

--- a/pomme-client/src/physics/block_shape.rs
+++ b/pomme-client/src/physics/block_shape.rs
@@ -5,12 +5,14 @@
 //!
 //! TODO: walls, fences, fence gates, panes, trapdoors, doors, beds, chests,
 //! cake, etc. still fall back to a full cube.
-
-use std::borrow::Cow;
+//!
+//! TODO: blocks with no collision but a small outline (torches, flowers,
+//! buttons, plants, redstone dust) fall back to a full cube too, so the
+//! crosshair still reaches them from a block away.
 
 use azalea_block::BlockState;
 
-use crate::world::block::{PropMap, block_id, block_properties};
+use crate::world::block::PropMap;
 
 /// A block-local axis-aligned box: `[min_x, min_y, min_z, max_x, max_y,
 /// max_z]`.
@@ -22,33 +24,13 @@ pub fn partial_shape(state: BlockState) -> Option<&'static [LocalBox]> {
     crate::world::block::block_shape(state)
 }
 
-pub const FULL_CUBE: LocalBox = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0];
-static FULL_CUBE_SHAPE: [LocalBox; 1] = [FULL_CUBE];
+const FULL_CUBE_SHAPE: &[LocalBox] = &[[0.0, 0.0, 0.0, 1.0, 1.0, 1.0]];
 
-const SNOW_BLOCK_ID: &str = "snow";
-const SNOW_LAYERS_PROPERTY: &str = "layers";
-const DEFAULT_SNOW_LAYERS: i32 = 1;
-const SNOW_LAYER_HEIGHT: f64 = 2.0 / 16.0;
-
-pub fn outline_shape(state: BlockState) -> Cow<'static, [LocalBox]> {
-    let is_snow = block_id(state) == SNOW_BLOCK_ID;
-    if is_snow {
-        let layers = get_snow_layers(block_properties(state));
-        let height = layers as f64 * SNOW_LAYER_HEIGHT;
-        return Cow::Owned(vec![[0.0, 0.0, 0.0, 1.0, height, 1.0]]);
-    }
-
-    match partial_shape(state) {
-        Some(boxes) if !boxes.is_empty() => Cow::Borrowed(boxes),
-        _ => Cow::Borrowed(&FULL_CUBE_SHAPE[..]),
-    }
-}
-
-fn get_snow_layers(props: &PropMap) -> i32 {
-    props
-        .get(SNOW_LAYERS_PROPERTY)
-        .and_then(|value| value.parse().ok())
-        .unwrap_or(DEFAULT_SNOW_LAYERS)
+/// Boxes the interaction raycast clips against (vanilla `getShape`). Unlike
+/// `partial_shape` the full-cube case is already resolved, so an empty slice
+/// means "not targetable" rather than "no collision".
+pub fn outline_shape(state: BlockState) -> &'static [LocalBox] {
+    crate::world::block::block_outline(state).unwrap_or(FULL_CUBE_SHAPE)
 }
 
 /// Computes one state's shape. Takes id/props rather than a `BlockState` so
@@ -73,20 +55,39 @@ pub(crate) fn compute_shape(id: &str, props: &PropMap) -> Option<Vec<LocalBox>> 
     match id {
         "dirt_path" | "farmland" => Some(vec![[0.0, 0.0, 0.0, 1.0, 0.9375, 1.0]]),
         _ if id.ends_with("_carpet") => Some(vec![[0.0, 0.0, 0.0, 1.0, 0.0625, 1.0]]),
-        // Snow's collision shape is one layer shorter than its outline; a single
-        // layer has no collision at all.
-        SNOW_BLOCK_ID => {
-            let layers = get_snow_layers(props);
-            let height = (layers - 1) as f64 * SNOW_LAYER_HEIGHT;
-            let has_collision = height > 0.0;
-            Some(if has_collision {
-                vec![[0.0, 0.0, 0.0, 1.0, height, 1.0]]
-            } else {
-                vec![]
-            })
-        }
+        // `SnowLayerBlock.getCollisionShape` is one layer shorter than its
+        // outline, so a single layer has no collision at all.
+        "snow" => Some(snow_shape(snow_layers(props) - 1)),
         _ => None,
     }
+}
+
+/// Vanilla `getShape` where it differs from `getCollisionShape`. `None` means
+/// the two agree, so `compute_shape`'s result doubles as the outline.
+pub(crate) fn compute_outline(id: &str, props: &PropMap) -> Option<Vec<LocalBox>> {
+    match id {
+        "snow" => Some(snow_shape(snow_layers(props))),
+        // `LiquidBlock.getShape` and `BubbleColumnBlock.getShape` are
+        // `Shapes.empty()`: the pick ray clips straight through them.
+        "water" | "lava" | "bubble_column" => Some(Vec::new()),
+        _ => None,
+    }
+}
+
+fn snow_layers(props: &PropMap) -> i32 {
+    props
+        .get("layers")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1)
+}
+
+/// Vanilla `SnowLayerBlock.SHAPES[layers]`, two pixels per layer; index 0 is
+/// empty.
+fn snow_shape(layers: i32) -> Vec<LocalBox> {
+    if layers <= 0 {
+        return Vec::new();
+    }
+    vec![[0.0, 0.0, 0.0, 1.0, layers as f64 * 2.0 / 16.0, 1.0]]
 }
 
 /// Vanilla `StairBlock` shape: a half-slab plus 1–3 upper corner pillars,

--- a/pomme-client/src/physics/block_shape.rs
+++ b/pomme-client/src/physics/block_shape.rs
@@ -6,9 +6,11 @@
 //! TODO: walls, fences, fence gates, panes, trapdoors, doors, beds, chests,
 //! cake, etc. still fall back to a full cube.
 
+use std::borrow::Cow;
+
 use azalea_block::BlockState;
 
-use crate::world::block::PropMap;
+use crate::world::block::{PropMap, block_id, block_properties};
 
 /// A block-local axis-aligned box: `[min_x, min_y, min_z, max_x, max_y,
 /// max_z]`.
@@ -18,6 +20,35 @@ pub type LocalBox = [f64; 6];
 /// no collision, `Some(boxes)` for a partial shape.
 pub fn partial_shape(state: BlockState) -> Option<&'static [LocalBox]> {
     crate::world::block::block_shape(state)
+}
+
+pub const FULL_CUBE: LocalBox = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0];
+static FULL_CUBE_SHAPE: [LocalBox; 1] = [FULL_CUBE];
+
+const SNOW_BLOCK_ID: &str = "snow";
+const SNOW_LAYERS_PROPERTY: &str = "layers";
+const DEFAULT_SNOW_LAYERS: i32 = 1;
+const SNOW_LAYER_HEIGHT: f64 = 2.0 / 16.0;
+
+pub fn outline_shape(state: BlockState) -> Cow<'static, [LocalBox]> {
+    let is_snow = block_id(state) == SNOW_BLOCK_ID;
+    if is_snow {
+        let layers = get_snow_layers(block_properties(state));
+        let height = layers as f64 * SNOW_LAYER_HEIGHT;
+        return Cow::Owned(vec![[0.0, 0.0, 0.0, 1.0, height, 1.0]]);
+    }
+
+    match partial_shape(state) {
+        Some(boxes) if !boxes.is_empty() => Cow::Borrowed(boxes),
+        _ => Cow::Borrowed(&FULL_CUBE_SHAPE[..]),
+    }
+}
+
+fn get_snow_layers(props: &PropMap) -> i32 {
+    props
+        .get(SNOW_LAYERS_PROPERTY)
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_SNOW_LAYERS)
 }
 
 /// Computes one state's shape. Takes id/props rather than a `BlockState` so
@@ -44,14 +75,12 @@ pub(crate) fn compute_shape(id: &str, props: &PropMap) -> Option<Vec<LocalBox>> 
         _ if id.ends_with("_carpet") => Some(vec![[0.0, 0.0, 0.0, 1.0, 0.0625, 1.0]]),
         // Snow's collision shape is one layer shorter than its outline; a single
         // layer has no collision at all.
-        "snow" => {
-            let layers: i32 = props
-                .get("layers")
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(1);
-            let h = (layers - 1) as f64 * 2.0 / 16.0;
-            Some(if h > 0.0 {
-                vec![[0.0, 0.0, 0.0, 1.0, h, 1.0]]
+        SNOW_BLOCK_ID => {
+            let layers = get_snow_layers(props);
+            let height = (layers - 1) as f64 * SNOW_LAYER_HEIGHT;
+            let has_collision = height > 0.0;
+            Some(if has_collision {
+                vec![[0.0, 0.0, 0.0, 1.0, height, 1.0]]
             } else {
                 vec![]
             })

--- a/pomme-client/src/physics/collision.rs
+++ b/pomme-client/src/physics/collision.rs
@@ -25,12 +25,8 @@ pub fn collect_block_aabbs(chunk_store: &ChunkStore, region: &Aabb) -> Vec<Aabb>
                 }
                 match block_shape::partial_shape(state) {
                     Some(boxes) => {
-                        for &[lx0, ly0, lz0, lx1, ly1, lz1] in boxes {
-                            aabbs.push(Aabb::new(
-                                dvec3(bx as f64 + lx0, by as f64 + ly0, bz as f64 + lz0),
-                                dvec3(bx as f64 + lx1, by as f64 + ly1, bz as f64 + lz1),
-                            ));
-                        }
+                        let offset = dvec3(bx as f64, by as f64, bz as f64);
+                        aabbs.extend(boxes.iter().map(|&b| Aabb::from_local(b, offset)));
                     }
                     None => aabbs.push(Aabb::block(bx, by, bz)),
                 }

--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use azalea_block::BlockState;
-use azalea_core::aabb::Aabb as AzaleaAabb;
 use azalea_core::attribute_modifier_operation::AttributeModifierOperation;
 use azalea_core::direction::Direction;
 use azalea_core::position::BlockPos;
@@ -19,7 +18,7 @@ use azalea_protocol::packets::game::s_set_carried_item::ServerboundSetCarriedIte
 use azalea_protocol::packets::game::s_use_item::ServerboundUseItem;
 use azalea_protocol::packets::game::s_use_item_on::{BlockHit, ServerboundUseItemOn};
 use azalea_registry::builtin::{Attribute, BlockKind, EntityKind, ItemKind};
-use glam::{DVec3, Vec3};
+use glam::{DVec3, Vec3, dvec3};
 use pomme_protocol::wire;
 
 use crate::app::input::{self, InputState};
@@ -28,7 +27,7 @@ use crate::entity::EntityStore;
 use crate::entity::components::{LookDirection, Position};
 use crate::net::sender::PacketSender;
 use crate::particle::ParticleStore;
-use crate::physics::aabb::Aabb;
+use crate::physics::aabb::{self, Aabb, Axis, Face};
 use crate::physics::block_shape::{self, LocalBox};
 use crate::physics::movement::{PLAYER_HALF_WIDTH, PLAYER_HEIGHT};
 use crate::player::inventory::item_resource_name;
@@ -1401,6 +1400,7 @@ pub fn raycast(
         (origin.z - bz as f64) * t_delta_z
     };
 
+    let reach_end = origin + dir * max_dist as f64;
     let mut t = 0.0_f64;
     while t <= max_dist as f64 {
         let state = chunks.get_block_state(bx, by, bz);
@@ -1410,10 +1410,8 @@ pub fn raycast(
                 y: by,
                 z: bz,
             };
-            let reach_end = origin + dir * max_dist as f64;
             let outline = block_shape::outline_shape(state);
-            let hit = get_ray_hit_on_boxes(origin, reach_end, block_pos, &outline);
-            if let Some((hit_point, face)) = hit {
+            if let Some((hit_point, face)) = clip_shape(origin, reach_end, block_pos, outline) {
                 return Some(BlockHitResult {
                     block_pos,
                     face,
@@ -1490,38 +1488,50 @@ fn azalea_vec3(v: DVec3) -> azalea_core::position::Vec3 {
     azalea_core::position::Vec3::new(v.x, v.y, v.z)
 }
 
+/// How far along the ray vanilla `VoxelShape.clip` probes to decide whether it
+/// started inside the shape.
 const INSIDE_PROBE_FRACTION: f64 = 0.001;
 
-fn get_ray_hit_on_boxes(
+/// Ports vanilla `VoxelShape.clip`: a ray starting inside the shape hits it at
+/// the probe point, otherwise the nearest box entry wins. An empty shape is
+/// never hit, so the caller walks on to the next block. Vanilla's
+/// degenerate-ray guard is dropped; `raycast` always passes a scaled unit
+/// direction.
+fn clip_shape(
     from: DVec3,
     to: DVec3,
     block_pos: BlockPos,
     boxes: &[LocalBox],
 ) -> Option<(DVec3, Direction)> {
-    let from_v = azalea_vec3(from);
-    let to_v = azalea_vec3(to);
-    let aabbs: Vec<AzaleaAabb> = boxes
-        .iter()
-        .map(|&[min_x, min_y, min_z, max_x, max_y, max_z]| AzaleaAabb {
-            min: azalea_core::position::Vec3::new(min_x, min_y, min_z),
-            max: azalea_core::position::Vec3::new(max_x, max_y, max_z),
-        })
-        .collect();
+    if boxes.is_empty() {
+        return None;
+    }
+    let offset = dvec3(block_pos.x as f64, block_pos.y as f64, block_pos.z as f64);
+    let ray = to - from;
+    let probe = from + ray * INSIDE_PROBE_FRACTION;
 
-    let ray = to_v - from_v;
-    let probe = from_v + ray * INSIDE_PROBE_FRACTION;
-    let block_offset = block_pos.to_vec3_floored();
-    let starts_inside = aabbs
+    let starts_inside = boxes
         .iter()
-        .any(|aabb| aabb.move_relative(block_offset).contains(probe));
+        .any(|&b| Aabb::from_local(b, offset).contains(probe));
     if starts_inside {
-        let looked_at_face = Direction::nearest(ray).opposite();
-        return Some((from, looked_at_face));
+        return Some((probe, Direction::nearest(azalea_vec3(ray)).opposite()));
     }
 
-    let hit = AzaleaAabb::clip_iterable(&aabbs, from_v, to_v, block_pos)?;
-    let hit_point = DVec3::new(hit.location.x, hit.location.y, hit.location.z);
-    Some((hit_point, hit.direction))
+    let (t, face) = aabb::clip_boxes(boxes, offset, from, to)?;
+    Some((from + ray * t, face_direction(face)))
+}
+
+/// Vanilla `AABB.getDirection`: a ray entering a box's min face on an axis is
+/// travelling positive along it, so the face it hit points back the other way.
+fn face_direction(face: Face) -> Direction {
+    match (face.axis, face.max) {
+        (Axis::X, false) => Direction::West,
+        (Axis::X, true) => Direction::East,
+        (Axis::Y, false) => Direction::Down,
+        (Axis::Y, true) => Direction::Up,
+        (Axis::Z, false) => Direction::North,
+        (Axis::Z, true) => Direction::South,
+    }
 }
 
 fn send_action(
@@ -1573,7 +1583,6 @@ pub(crate) fn send_swap_offhand(sender: &PacketSender) {
 mod tests {
     use azalea_registry::HolderSet;
     use azalea_registry::identifier::Identifier;
-    use glam::dvec3;
 
     use super::*;
 
@@ -1602,30 +1611,39 @@ mod tests {
         let origin = dvec3(-1.0, 1.5, 0.5);
 
         let over_the_slab = origin + dvec3(4.0, -1.4, 0.0);
-        let slab_hit = get_ray_hit_on_boxes(origin, over_the_slab, block, &bottom_slab);
+        let slab_hit = clip_shape(origin, over_the_slab, block, &bottom_slab);
         assert!(slab_hit.is_none());
 
         let onto_the_slab = origin + dvec3(3.0, -2.75, 0.0);
-        let (hit_point, face) =
-            get_ray_hit_on_boxes(origin, onto_the_slab, block, &bottom_slab).unwrap();
+        let (hit_point, face) = clip_shape(origin, onto_the_slab, block, &bottom_slab).unwrap();
         let tolerance = 1e-9;
         let is_on_slab_surface = (hit_point.y - slab_height).abs() < tolerance;
         assert!(is_on_slab_surface, "hit {hit_point:?}");
         assert_eq!(face, Direction::Up);
     }
 
+    /// Vanilla `VoxelShape.clip` reports the inside case at the probe point,
+    /// not at the ray's origin.
     #[test]
     fn ray_starting_inside_partial_block_hits_immediately() {
-        let slab_height = 0.5;
         let block = BlockPos::new(0, 0, 0);
-        let bottom_slab: [LocalBox; 1] = [[0.0, 0.0, 0.0, 1.0, slab_height, 1.0]];
+        let bottom_slab: [LocalBox; 1] = [[0.0, 0.0, 0.0, 1.0, 0.5, 1.0]];
         let inside_the_slab = dvec3(0.5, 0.25, 0.5);
-        let straight_down = inside_the_slab + dvec3(0.0, -4.0, 0.0);
+        let ray = dvec3(0.0, -4.0, 0.0);
 
         let (hit_point, face) =
-            get_ray_hit_on_boxes(inside_the_slab, straight_down, block, &bottom_slab).unwrap();
-        assert_eq!(hit_point, inside_the_slab);
+            clip_shape(inside_the_slab, inside_the_slab + ray, block, &bottom_slab).unwrap();
+        assert_eq!(hit_point, inside_the_slab + ray * INSIDE_PROBE_FRACTION);
         assert_eq!(face, Direction::Up);
+    }
+
+    /// Vanilla clips straight through an empty shape (`LiquidBlock.getShape`),
+    /// so the caller walks on to the block behind it.
+    #[test]
+    fn ray_passes_through_an_empty_shape() {
+        let block = BlockPos::new(0, 0, 0);
+        let from = dvec3(0.5, 2.0, 0.5);
+        assert!(clip_shape(from, from + dvec3(0.0, -4.0, 0.0), block, &[]).is_none());
     }
 
     fn rule(blocks: Vec<BlockKind>, speed: Option<f32>, correct: Option<bool>) -> ToolRule {

--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use azalea_block::BlockState;
+use azalea_core::aabb::Aabb as AzaleaAabb;
 use azalea_core::attribute_modifier_operation::AttributeModifierOperation;
 use azalea_core::direction::Direction;
 use azalea_core::position::BlockPos;
@@ -18,7 +19,7 @@ use azalea_protocol::packets::game::s_set_carried_item::ServerboundSetCarriedIte
 use azalea_protocol::packets::game::s_use_item::ServerboundUseItem;
 use azalea_protocol::packets::game::s_use_item_on::{BlockHit, ServerboundUseItemOn};
 use azalea_registry::builtin::{Attribute, BlockKind, EntityKind, ItemKind};
-use glam::{DVec3, Vec3, dvec3};
+use glam::{DVec3, Vec3};
 use pomme_protocol::wire;
 
 use crate::app::input::{self, InputState};
@@ -28,6 +29,7 @@ use crate::entity::components::{LookDirection, Position};
 use crate::net::sender::PacketSender;
 use crate::particle::ParticleStore;
 use crate::physics::aabb::Aabb;
+use crate::physics::block_shape::{self, LocalBox};
 use crate::physics::movement::{PLAYER_HALF_WIDTH, PLAYER_HEIGHT};
 use crate::player::inventory::item_resource_name;
 use crate::renderer::pipelines::held_item::UseAnim;
@@ -1408,13 +1410,16 @@ pub fn raycast(
                 y: by,
                 z: bz,
             };
-            let hit_point = origin + dir * t;
-            let face = hit_face(origin, dir.as_vec3(), &block_pos);
-            return Some(BlockHitResult {
-                block_pos,
-                face,
-                hit_point,
-            });
+            let reach_end = origin + dir * max_dist as f64;
+            let outline = block_shape::outline_shape(state);
+            let hit = get_ray_hit_on_boxes(origin, reach_end, block_pos, &outline);
+            if let Some((hit_point, face)) = hit {
+                return Some(BlockHitResult {
+                    block_pos,
+                    face,
+                    hit_point,
+                });
+            }
         }
         if t_max_x < t_max_y && t_max_x < t_max_z {
             t = t_max_x;
@@ -1485,44 +1490,38 @@ fn azalea_vec3(v: DVec3) -> azalea_core::position::Vec3 {
     azalea_core::position::Vec3::new(v.x, v.y, v.z)
 }
 
-fn hit_face(origin: DVec3, dir: Vec3, pos: &BlockPos) -> Direction {
-    let dir = dir.as_dvec3();
-    let min = dvec3(pos.x as f64, pos.y as f64, pos.z as f64);
-    let max = min + DVec3::ONE;
+const INSIDE_PROBE_FRACTION: f64 = 0.001;
 
-    let mut best_t = f64::MAX;
-    let mut best_face = Direction::Up;
+fn get_ray_hit_on_boxes(
+    from: DVec3,
+    to: DVec3,
+    block_pos: BlockPos,
+    boxes: &[LocalBox],
+) -> Option<(DVec3, Direction)> {
+    let from_v = azalea_vec3(from);
+    let to_v = azalea_vec3(to);
+    let aabbs: Vec<AzaleaAabb> = boxes
+        .iter()
+        .map(|&[min_x, min_y, min_z, max_x, max_y, max_z]| AzaleaAabb {
+            min: azalea_core::position::Vec3::new(min_x, min_y, min_z),
+            max: azalea_core::position::Vec3::new(max_x, max_y, max_z),
+        })
+        .collect();
 
-    let faces = [
-        (min.x, dir.x, origin.x, Direction::West),
-        (max.x, dir.x, origin.x, Direction::East),
-        (min.y, dir.y, origin.y, Direction::Down),
-        (max.y, dir.y, origin.y, Direction::Up),
-        (min.z, dir.z, origin.z, Direction::North),
-        (max.z, dir.z, origin.z, Direction::South),
-    ];
-
-    for &(plane, d_comp, o_comp, face) in &faces {
-        if d_comp.abs() < 1e-8 {
-            continue;
-        }
-        let t = (plane - o_comp) / d_comp;
-        if t < 0.0 || t >= best_t {
-            continue;
-        }
-        let hit = origin + dir * t;
-        let (c1, c2, c1_min, c1_max, c2_min, c2_max) = match face {
-            Direction::West | Direction::East => (hit.y, hit.z, min.y, max.y, min.z, max.z),
-            Direction::Down | Direction::Up => (hit.x, hit.z, min.x, max.x, min.z, max.z),
-            Direction::North | Direction::South => (hit.x, hit.y, min.x, max.x, min.y, max.y),
-        };
-        if c1 >= c1_min && c1 <= c1_max && c2 >= c2_min && c2 <= c2_max {
-            best_t = t;
-            best_face = face;
-        }
+    let ray = to_v - from_v;
+    let probe = from_v + ray * INSIDE_PROBE_FRACTION;
+    let block_offset = block_pos.to_vec3_floored();
+    let starts_inside = aabbs
+        .iter()
+        .any(|aabb| aabb.move_relative(block_offset).contains(probe));
+    if starts_inside {
+        let looked_at_face = Direction::nearest(ray).opposite();
+        return Some((from, looked_at_face));
     }
 
-    best_face
+    let hit = AzaleaAabb::clip_iterable(&aabbs, from_v, to_v, block_pos)?;
+    let hit_point = DVec3::new(hit.location.x, hit.location.y, hit.location.z);
+    Some((hit_point, hit.direction))
 }
 
 fn send_action(
@@ -1574,6 +1573,7 @@ pub(crate) fn send_swap_offhand(sender: &PacketSender) {
 mod tests {
     use azalea_registry::HolderSet;
     use azalea_registry::identifier::Identifier;
+    use glam::dvec3;
 
     use super::*;
 
@@ -1592,6 +1592,40 @@ mod tests {
         ));
         assert!(!same_item_same_components(Some(&a), None));
         assert!(same_item_same_components(None, None));
+    }
+
+    #[test]
+    fn ray_over_partial_block_misses_but_ray_onto_it_hits() {
+        let slab_height = 0.5;
+        let block = BlockPos::new(0, 0, 0);
+        let bottom_slab: [LocalBox; 1] = [[0.0, 0.0, 0.0, 1.0, slab_height, 1.0]];
+        let origin = dvec3(-1.0, 1.5, 0.5);
+
+        let over_the_slab = origin + dvec3(4.0, -1.4, 0.0);
+        let slab_hit = get_ray_hit_on_boxes(origin, over_the_slab, block, &bottom_slab);
+        assert!(slab_hit.is_none());
+
+        let onto_the_slab = origin + dvec3(3.0, -2.75, 0.0);
+        let (hit_point, face) =
+            get_ray_hit_on_boxes(origin, onto_the_slab, block, &bottom_slab).unwrap();
+        let tolerance = 1e-9;
+        let is_on_slab_surface = (hit_point.y - slab_height).abs() < tolerance;
+        assert!(is_on_slab_surface, "hit {hit_point:?}");
+        assert_eq!(face, Direction::Up);
+    }
+
+    #[test]
+    fn ray_starting_inside_partial_block_hits_immediately() {
+        let slab_height = 0.5;
+        let block = BlockPos::new(0, 0, 0);
+        let bottom_slab: [LocalBox; 1] = [[0.0, 0.0, 0.0, 1.0, slab_height, 1.0]];
+        let inside_the_slab = dvec3(0.5, 0.25, 0.5);
+        let straight_down = inside_the_slab + dvec3(0.0, -4.0, 0.0);
+
+        let (hit_point, face) =
+            get_ray_hit_on_boxes(inside_the_slab, straight_down, block, &bottom_slab).unwrap();
+        assert_eq!(hit_point, inside_the_slab);
+        assert_eq!(face, Direction::Up);
     }
 
     fn rule(blocks: Vec<BlockKind>, speed: Option<f32>, correct: Option<bool>) -> ToolRule {

--- a/pomme-client/src/world/block/mod.rs
+++ b/pomme-client/src/world/block/mod.rs
@@ -7,7 +7,7 @@ use std::sync::OnceLock;
 
 use azalea_block::BlockState;
 
-use crate::physics::block_shape::{LocalBox, compute_shape};
+use crate::physics::block_shape::{LocalBox, compute_outline, compute_shape};
 
 /// Compact per-state property map: `(key, value)` pairs sorted by key. States
 /// have at most ~10 properties, so binary search on a boxed slice beats a
@@ -125,6 +125,9 @@ struct BlockData {
     behavior: BlockBehavior,
     /// Collision shape; see `block_shape::partial_shape` for the encoding.
     shape: Option<Box<[LocalBox]>>,
+    /// Outline shape (vanilla `getShape`) where it differs from `shape`; `None`
+    /// means the two agree and the collision shape doubles as the outline.
+    outline: Option<Box<[LocalBox]>>,
     is_air: bool,
     /// Vanilla `hasCollision` (`BlockBehaviour.Properties.noCollision()`).
     collides: bool,
@@ -389,6 +392,7 @@ fn build_table(data: &str, state_data: &str) -> Vec<BlockData> {
             let properties = PropMap::from_pairs(pairs);
             let fluid = state_fluid(name, &properties);
             let shape = compute_shape(name, &properties).map(Vec::into_boxed_slice);
+            let outline = compute_outline(name, &properties).map(Vec::into_boxed_slice);
             let light = LightProps {
                 emission: state_entry.e.get(offset as usize),
                 dampening: state_entry.d.get(offset as usize),
@@ -402,6 +406,7 @@ fn build_table(data: &str, state_data: &str) -> Vec<BlockData> {
                 properties,
                 behavior,
                 shape,
+                outline,
                 is_air,
                 collides,
                 fluid,
@@ -503,6 +508,7 @@ fn block_data(state: BlockState) -> &'static BlockData {
         properties: PropMap::from_pairs(Vec::new()),
         behavior: DEFAULT_BEHAVIOR,
         shape: None,
+        outline: None,
         is_air: false,
         collides: true,
         fluid: NO_FLUID,
@@ -581,6 +587,14 @@ pub fn fluid(state: BlockState) -> Fluid {
 
 pub(crate) fn block_shape(state: BlockState) -> Option<&'static [LocalBox]> {
     block_data(state).shape.as_deref()
+}
+
+/// Outline shape for interaction raycasts (vanilla `getShape`), falling back to
+/// the collision shape where the two agree. `None` is a full cube; an empty
+/// slice is a block the pick ray passes through.
+pub(crate) fn block_outline(state: BlockState) -> Option<&'static [LocalBox]> {
+    let data = block_data(state);
+    data.outline.as_deref().or(data.shape.as_deref())
 }
 
 /// Baked light properties for a state (vanilla `BlockStateBase` light cache).
@@ -805,6 +819,49 @@ mod tests {
         const NORTH: usize = 2;
         // Side faces of two aligned bottom slabs cover only the lower half.
         assert!(!shape_occludes(bottom, bottom, NORTH));
+    }
+
+    /// Oracles from reference/26.2/decompiled: `SnowLayerBlock` is the only
+    /// shape here whose `getShape` and `getCollisionShape` disagree, and
+    /// `LiquidBlock`/`BubbleColumnBlock` return `Shapes.empty()`.
+    #[test]
+    fn outline_shapes() {
+        setup();
+
+        // One snow layer is 2/16 tall to look at but has no collision at all.
+        let thin = find_state("snow", &[("layers", "1")]);
+        assert_eq!(block_shape(thin), Some(&[][..]));
+        assert_eq!(
+            block_outline(thin),
+            Some(&[[0.0, 0.0, 0.0, 1.0, 2.0 / 16.0, 1.0]][..])
+        );
+        // Eight layers fill the cell visually but collide one layer short.
+        let full = find_state("snow", &[("layers", "8")]);
+        assert_eq!(
+            block_shape(full),
+            Some(&[[0.0, 0.0, 0.0, 1.0, 14.0 / 16.0, 1.0]][..])
+        );
+        assert_eq!(
+            block_outline(full),
+            Some(&[[0.0, 0.0, 0.0, 1.0, 1.0, 1.0]][..])
+        );
+
+        // Fluids are clipped through, not targeted.
+        for id in ["water", "lava"] {
+            assert_eq!(
+                block_outline(find_state(id, &[("level", "0")])),
+                Some(&[][..])
+            );
+        }
+        assert_eq!(
+            block_outline(find_state("bubble_column", &[])),
+            Some(&[][..])
+        );
+
+        // Everywhere else the collision shape doubles as the outline.
+        let slab = find_state("oak_slab", &[("type", "bottom"), ("waterlogged", "false")]);
+        assert_eq!(block_outline(slab), block_shape(slab));
+        assert_eq!(block_outline(find_state("stone", &[])), None);
     }
 
     /// Builds every embedded table so the block/light cross-checks fire for


### PR DESCRIPTION
The block raycast treated every non-air block as a full cube. For any block whose shape does not fill the cell, the empty space above the shape still counted as a hit, so the player could start breaking the block while the crosshair was nowhere near it. Affected blocks:

- snow layers
- carpet
- slabs
- stairs
- dirt path
- farmland

Now the raycast checks the block's actual shape instead of a full cube, so you only hit a block when you are really looking at it. Standing inside a block still hits it right away, same as vanilla.

**Before**
<img width="720" height="406" alt="before" src="https://github.com/user-attachments/assets/072a17b6-d4ad-4d41-995b-6b66b142de71" />



**After**
<img width="720" height="406" alt="after" src="https://github.com/user-attachments/assets/73bf0b53-7b6b-43e1-acce-8fd6c3acfe2b" />

