### PR TITLE
fix chat on 1.20.4 and 1.20.3 servers

### DIFF
--- a/pomme-client/src/net/azalea_compat.rs
+++ b/pomme-client/src/net/azalea_compat.rs
@@ -1247,12 +1247,14 @@ fn translate_chunk_769() {
     assert_eq!(p.chunk_data.data[..], [0, 1, 0, 0, 0, 5, 0, 0]);
 }
 
-/// 1.21.5 prepended `globalIndex` to `player_chat`; the shim synthesizes
-/// zero ahead of an otherwise identical body.
-#[test]
-fn translate_player_chat_769() {
+/// A `player_chat` frame with everything but the chat type fixed: 765 sends a
+/// direct registry id where 769 already sends a holder.
+fn player_chat_frame(protocol: i32, chat_type: u32) -> Vec<u8> {
     let mut old = Vec::new();
-    wire::write_varint(&mut old, old_id(769, Direction::Clientbound, "player_chat"));
+    wire::write_varint(
+        &mut old,
+        old_id(protocol, Direction::Clientbound, "player_chat"),
+    );
     old.extend_from_slice(&[7; 16]); // sender uuid
     wire::write_varint(&mut old, 3); // index
     old.push(0); // no signature
@@ -1262,11 +1264,63 @@ fn translate_player_chat_769() {
     old.push(0); // no last-seen entries
     old.push(0); // no unsigned content
     old.push(0); // filter: pass-through
-    wire::write_varint(&mut old, 1); // chat type holder: registry id 0
+    wire::write_varint(&mut old, chat_type);
+    old.extend_from_slice(&[8, 0, 1, b'n']); // name: NBT string
+    old.push(0); // no target
+    old
+}
+
+/// Pre-1.20.5 sends the chat type as a direct registry id where 26.2 wants a
+/// holder. Id 0 (`chat`, the ordinary message) is the holder's "inline value
+/// follows" sentinel, so leaving it alone makes normal chat undecodable.
+#[test]
+fn translate_player_chat_765() {
+    let ClientboundGamePacket::PlayerChat(p) = translate_and_decode(765, player_chat_frame(765, 0))
+    else {
+        panic!("wrong packet");
+    };
+    assert_eq!(p.global_index, 0);
+    assert_eq!(p.index, 3);
+    assert_eq!(p.body.content, "hi");
+    assert_eq!(chat_kind(&p.chat_type), 0);
+}
+
+/// `disguised_chat` carries the same `ChatType.Bound` tail, after the message
+/// component rather than a signed body.
+#[test]
+fn translate_disguised_chat_765() {
+    let mut old = Vec::new();
+    wire::write_varint(
+        &mut old,
+        old_id(765, Direction::Clientbound, "disguised_chat"),
+    );
+    old.extend_from_slice(&[8, 0, 2, b'h', b'i']); // message: NBT string
+    wire::write_varint(&mut old, 0); // chat type: direct registry id
     old.extend_from_slice(&[8, 0, 1, b'n']); // name: NBT string
     old.push(0); // no target
 
-    let ClientboundGamePacket::PlayerChat(p) = translate_and_decode(769, old) else {
+    let ClientboundGamePacket::DisguisedChat(p) = translate_and_decode(765, old) else {
+        panic!("wrong packet");
+    };
+    assert_eq!(chat_kind(&p.chat_type), 0);
+}
+
+/// The registry id behind a decoded chat-type holder; a direct (inline) one
+/// means the holder bump was missed.
+fn chat_kind(bound: &azalea_protocol::packets::game::c_player_chat::ChatTypeBound) -> u32 {
+    use azalea_registry::{Holder, Registry};
+    match &bound.chat_type {
+        Holder::Reference(kind) => kind.to_u32(),
+        Holder::Direct(_) => panic!("chat type decoded as an inline value"),
+    }
+}
+
+/// 1.21.5 prepended `globalIndex` to `player_chat`; the shim synthesizes
+/// zero ahead of an otherwise identical body.
+#[test]
+fn translate_player_chat_769() {
+    let ClientboundGamePacket::PlayerChat(p) = translate_and_decode(769, player_chat_frame(769, 1))
+    else {
         panic!("wrong packet");
     };
     assert_eq!(p.global_index, 0);

--- a/pomme-client/src/net/translate.rs
+++ b/pomme-client/src/net/translate.rs
@@ -200,6 +200,8 @@
 //!   always the signed form (empty signatures appended)
 //! - `update_advancements` drops (old-form icons nested in display data);
 //!   serializer ids from `particles` (18) up shift
+//! - `player_chat`/`disguised_chat` carry a direct chat-type registry id where
+//!   1.20.5 put a holder (bumped by one on the way through)
 //!
 //! Known limitation (accepted): an inbound item stack carrying a data
 //! component at/after the first id the versions number differently (26.1:

--- a/pomme-client/src/net/translate.rs
+++ b/pomme-client/src/net/translate.rs
@@ -392,6 +392,10 @@ struct Ids765 {
     /// display NBT the walker can't rewrite.
     /// TODO: rewrite the icons bare so 765 advancement toasts show.
     update_advancements_id: u32,
+    /// Pre-1.20.5 chat packets carry a direct chat-type registry id where
+    /// 1.20.5 put a holder (id + 1).
+    player_chat_id: u32,
+    disguised_chat_id: u32,
     /// The wire version's registry names, for the attribute-key lookup.
     registry: &'static RegistryTable,
     /// Serverbound: latest + wire ids for the item-form rewrites.
@@ -406,6 +410,10 @@ struct Ids765 {
 impl Ids765 {
     fn rewrite(&self, id: u32) -> Option<FrameRewrite> {
         Some(match id {
+            // These two shadow 769's player_chat arm; the globalIndex
+            // prepend is folded into the chat-type holder rewrite.
+            i if i == self.player_chat_id => translate_player_chat_765,
+            i if i == self.disguised_chat_id => translate_disguised_chat_765,
             i if i == self.container_set_content_id => translate_container_set_content_765,
             i if i == self.set_equipment_id => translate_set_equipment_765,
             i if i == self.merchant_offers_id => translate_merchant_offers_765,
@@ -1067,6 +1075,8 @@ impl GameIds {
                 container_set_slot_id: id(Clientbound, "container_set_slot"),
                 respawn_id: id(Clientbound, "respawn"),
                 update_advancements_id: id(Clientbound, "update_advancements"),
+                player_chat_id: id(Clientbound, "player_chat"),
+                disguised_chat_id: id(Clientbound, "disguised_chat"),
                 registry: RegistryTable::for_protocol(protocol).expect("embedded registry table"),
                 container_click_id: id(Serverbound, "container_click"),
                 container_click_old_id: required_id(
@@ -2471,6 +2481,101 @@ fn skip_utf(cur: &mut Cursor<&[u8]>) -> Option<()> {
 fn skip_nbt(cur: &mut Cursor<&[u8]>) -> Option<()> {
     let tag = read_u8(cur)?;
     skip_nbt_payload(cur, tag, 0)
+}
+
+/// Rewrites `player_chat` for 1.20.4, whose trailing `ChatType.Bound` needs
+/// the holder bump; the 1.21.5 globalIndex prepend folds in, since this arm
+/// shadows 769's.
+fn translate_player_chat_765(id: u32, payload: &[u8]) -> Option<Vec<u8>> {
+    let mut cur = Cursor::new(payload);
+    let mut out = Vec::with_capacity(payload.len() + 4);
+    wire::write_varint(&mut out, id);
+    wire::write_varint(&mut out, 0); // globalIndex, 1.21.5+
+    player_chat_head(&mut cur, &mut out)?;
+    chat_type_holder(&mut cur, &mut out, payload).map(|()| out)
+}
+
+/// Rewrites `disguised_chat` for 1.20.4: the same holder bump, after the
+/// message component rather than a signed body.
+fn translate_disguised_chat_765(id: u32, payload: &[u8]) -> Option<Vec<u8>> {
+    let mut cur = Cursor::new(payload);
+    skip_nbt(&mut cur)?; // message
+
+    let mut out = Vec::with_capacity(payload.len() + 2);
+    wire::write_varint(&mut out, id);
+    out.extend_from_slice(&payload[..cur.position() as usize]);
+    chat_type_holder(&mut cur, &mut out, payload).map(|()| out)
+}
+
+/// Writes the direct chat-type registry id as the holder 1.20.5 replaced it
+/// with (id + 1, 0 being reserved for an inline value), then the rest of the
+/// frame. The id is synced-registry order either way, so it needs no remap.
+fn chat_type_holder(cur: &mut Cursor<&[u8]>, out: &mut Vec<u8>, payload: &[u8]) -> Option<()> {
+    let chat_type = u32::azalea_read_var(cur).ok()?;
+    wire::write_varint(out, chat_type + 1);
+    out.extend_from_slice(&payload[cur.position() as usize..]);
+    Some(())
+}
+
+/// Copies `player_chat`'s body up to the trailing `ChatType.Bound`.
+fn player_chat_head(cur: &mut Cursor<&[u8]>, out: &mut Vec<u8>) -> Option<()> {
+    copy_bytes(cur, out, 16)?; // sender uuid
+    copy_varint(cur, out)?; // index
+    copy_optional(cur, out, |c, o| copy_bytes(c, o, 256))?; // signature
+    copy_utf(cur, out)?; // content
+    copy_bytes(cur, out, 16)?; // timestamp, salt
+    let last_seen = copy_varint(cur, out)?;
+    for _ in 0..last_seen {
+        // A zero id carries a full signature instead of a cache reference.
+        if copy_varint(cur, out)? == 0 {
+            copy_bytes(cur, out, 256)?;
+        }
+    }
+    copy_optional(cur, out, copy_nbt)?; // unsigned content
+    if copy_varint(cur, out)? == 2 {
+        let longs = copy_varint(cur, out)?; // partially-filtered bit set
+        copy_bytes(cur, out, longs as usize * 8)?;
+    }
+    Some(())
+}
+
+fn copy_bytes(cur: &mut Cursor<&[u8]>, out: &mut Vec<u8>, n: usize) -> Option<()> {
+    let at = cur.position() as usize;
+    advance(cur, n)?;
+    out.extend_from_slice(&cur.get_ref()[at..at + n]);
+    Some(())
+}
+
+fn copy_varint(cur: &mut Cursor<&[u8]>, out: &mut Vec<u8>) -> Option<u32> {
+    let at = cur.position() as usize;
+    let v = u32::azalea_read_var(cur).ok()?;
+    out.extend_from_slice(&cur.get_ref()[at..cur.position() as usize]);
+    Some(v)
+}
+
+fn copy_utf(cur: &mut Cursor<&[u8]>, out: &mut Vec<u8>) -> Option<()> {
+    let len = copy_varint(cur, out)?;
+    copy_bytes(cur, out, len as usize)
+}
+
+fn copy_nbt(cur: &mut Cursor<&[u8]>, out: &mut Vec<u8>) -> Option<()> {
+    let span = nbt_span(cur)?;
+    out.extend_from_slice(&cur.get_ref()[span]);
+    Some(())
+}
+
+fn copy_optional(
+    cur: &mut Cursor<&[u8]>,
+    out: &mut Vec<u8>,
+    inner: impl FnOnce(&mut Cursor<&[u8]>, &mut Vec<u8>) -> Option<()>,
+) -> Option<()> {
+    let present = read_u8(cur)?;
+    out.push(present);
+    if present != 0 {
+        inner(cur, out)
+    } else {
+        Some(())
+    }
 }
 
 fn skip_optional(


### PR DESCRIPTION
chat type was sent as a raw registry id where a holder was expected, so normal chat never decoded and other chat types rendered one slot off