### PR TITLE
implement controls sensitivity slider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         # --release reuses the dependency artifacts the clippy step built.
         run: |
           cargo test -p pomme-protocol
-          cargo test -p pomme-client --release -- net::azalea_compat world::block
+          cargo test -p pomme-client --release -- net::azalea_compat world::block renderer::camera::
 
   launcher-frontend:
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ client-pre-pr:
     @cargo clippy -p pomme-client --release --all-targets --all-features -- -D warnings
     @cargo clippy -p pomme-protocol --release --all-targets --all-features -- -D warnings
     @cargo test -p pomme-protocol
-    @cargo test -p pomme-client -- net::azalea_compat world::block
+    @cargo test -p pomme-client -- net::azalea_compat world::block renderer::camera::
 
 # Regenerate a version's packet-id table from the decompiled reference.
 protogen version="26.2":

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -1452,7 +1452,8 @@ pub fn update_game(
     }
 
     if game.input_live() && game.chunk_load_bench.is_none() {
-        gfx.renderer.update_camera(&mut core.input, dt);
+        gfx.renderer
+            .update_camera(&mut core.input, dt, core.menu.sensitivity);
     }
 
     // Menus never pause the simulation; tick_physics substitutes neutral input.

--- a/pomme-client/src/renderer/camera.rs
+++ b/pomme-client/src/renderer/camera.rs
@@ -14,9 +14,15 @@ const NEAR: f32 = 0.1;
 /// Floor of the dynamic far plane (vanilla floors at `cloudRange * 16`
 /// instead; pomme's fixed-reach clouds derive their fade from this).
 pub(crate) const MIN_FAR: f32 = 1000.0;
-const MOUSE_SENSITIVITY: f32 = 0.15;
 /// Controller look speed in degrees per second, scaled by frame delta.
 const CONTROLLER_SENSITIVITY: f32 = 150.0;
+
+/// Vanilla mouse sensitivity curve from `MouseHandler.turnPlayer`, including
+/// the 0.15 turn scale applied by `Entity.turn`.
+fn mouse_sensitivity_multiplier(sensitivity: f32) -> f32 {
+    let scaled = sensitivity * 0.6 + 0.2;
+    scaled * scaled * scaled * 8.0 * 0.15
+}
 pub const THIRD_PERSON_DISTANCE: f32 = 4.0;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -165,7 +171,7 @@ impl Camera {
             * Mat4::from_rotation_x(pitch_deg.to_radians())
     }
 
-    pub fn update_look(&mut self, input: &mut InputState, dt: f32) {
+    pub fn update_look(&mut self, input: &mut InputState, dt: f32, sensitivity: f32) {
         if let Some(look_vec) = input.get_gamepad_right_analog() {
             let step = CONTROLLER_SENSITIVITY * dt;
             let y_rot_deg =
@@ -176,10 +182,11 @@ impl Camera {
 
         if input.is_cursor_captured() {
             let (dx, dy) = input.consume_mouse_delta();
-            let y_rot_deg = ((self.look_dir.y_rot_deg() + dx as f32 * MOUSE_SENSITIVITY) + 180.0)
+            let mouse_sensitivity = mouse_sensitivity_multiplier(sensitivity);
+            let y_rot_deg = ((self.look_dir.y_rot_deg() + dx as f32 * mouse_sensitivity) + 180.0)
                 .rem_euclid(360.0)
                 - 180.0;
-            let x_rot_deg = self.look_dir.x_rot_deg() + dy as f32 * MOUSE_SENSITIVITY;
+            let x_rot_deg = self.look_dir.x_rot_deg() + dy as f32 * mouse_sensitivity;
             self.look_dir = LookDirection::new(y_rot_deg, x_rot_deg);
         }
     }
@@ -477,5 +484,15 @@ impl CameraUniform {
             camera_block: [0; 4],
             fog_env: [f32::MAX, f32::MAX, 0.0, 0.0],
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vanilla_default_mouse_sensitivity_is_point_fifteen() {
+        assert!((mouse_sensitivity_multiplier(0.5) - 0.15).abs() < 1e-6);
     }
 }

--- a/pomme-client/src/renderer/camera.rs
+++ b/pomme-client/src/renderer/camera.rs
@@ -16,14 +16,17 @@ const NEAR: f32 = 0.1;
 pub(crate) const MIN_FAR: f32 = 1000.0;
 /// Controller look speed in degrees per second, scaled by frame delta.
 const CONTROLLER_SENSITIVITY: f32 = 150.0;
+pub const THIRD_PERSON_DISTANCE: f32 = 4.0;
 
 /// Vanilla mouse sensitivity curve from `MouseHandler.turnPlayer`, including
 /// the 0.15 turn scale applied by `Entity.turn`.
+///
+/// TODO: `turnPlayer`'s other branches are unmodelled — `smoothCamera`,
+/// scoping (`sensitivityMod` without the `* 8.0`), and `invertMouseX`/`Y`.
 fn mouse_sensitivity_multiplier(sensitivity: f32) -> f32 {
     let scaled = sensitivity * 0.6 + 0.2;
     scaled * scaled * scaled * 8.0 * 0.15
 }
-pub const THIRD_PERSON_DISTANCE: f32 = 4.0;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum CameraMode {
@@ -491,8 +494,12 @@ impl CameraUniform {
 mod tests {
     use super::*;
 
+    /// The midpoint is the multiplier pomme hardcoded before the slider
+    /// existed.
     #[test]
-    fn vanilla_default_mouse_sensitivity_is_point_fifteen() {
-        assert!((mouse_sensitivity_multiplier(0.5) - 0.15).abs() < 1e-6);
+    fn mouse_sensitivity_curve_matches_vanilla() {
+        for (sensitivity, expected) in [(0.0, 0.0096), (0.5, 0.15), (1.0, 0.6144)] {
+            assert!((mouse_sensitivity_multiplier(sensitivity) - expected).abs() < 1e-6);
+        }
     }
 }

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -763,8 +763,8 @@ impl Renderer {
         &self.last_timings
     }
 
-    pub fn update_camera(&mut self, input: &mut InputState, dt: f32) {
-        self.camera.update_look(input, dt);
+    pub fn update_camera(&mut self, input: &mut InputState, dt: f32, sensitivity: f32) {
+        self.camera.update_look(input, dt, sensitivity);
     }
 
     pub fn sync_camera_pos(&mut self, position: Position) {

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -538,7 +538,9 @@ impl MainMenu {
             server_render_distance: 0,
             fov: settings.fov,
             fov_effect_scale: settings.fov_effect_scale,
-            sensitivity: settings.sensitivity,
+            // Cubed by the look curve, so an out-of-range options.json value
+            // reaches infinity and leaves the look direction NaN for good.
+            sensitivity: settings.sensitivity.clamp(0.0, 1.0),
             view_bobbing: settings.view_bobbing,
             show_subtitles: settings.show_subtitles,
             show_autosave_indicator: settings.show_autosave_indicator,

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -31,6 +31,8 @@ struct Settings {
     fov: u32,
     #[serde(default = "default_fov_effect_scale")]
     fov_effect_scale: f32,
+    #[serde(default = "default_sensitivity")]
+    sensitivity: f32,
     #[serde(default = "default_true")]
     view_bobbing: bool,
     #[serde(default)]
@@ -107,6 +109,10 @@ fn default_fov_effect_scale() -> f32 {
     1.0
 }
 
+fn default_sensitivity() -> f32 {
+    0.5
+}
+
 fn default_cloud_mode() -> u8 {
     2
 }
@@ -136,6 +142,7 @@ impl Default for Settings {
             simulation_distance: 12,
             fov: 70,
             fov_effect_scale: 1.0,
+            sensitivity: 0.5,
             view_bobbing: true,
             show_subtitles: false,
             show_autosave_indicator: true,
@@ -422,6 +429,7 @@ pub struct MainMenu {
     pub fov: u32,
     /// FOV Effects slider fraction (0..1); squared by `fov_effect()`.
     pub fov_effect_scale: f32,
+    pub sensitivity: f32,
     pub view_bobbing: bool,
     pub show_subtitles: bool,
     pub show_autosave_indicator: bool,
@@ -530,6 +538,7 @@ impl MainMenu {
             server_render_distance: 0,
             fov: settings.fov,
             fov_effect_scale: settings.fov_effect_scale,
+            sensitivity: settings.sensitivity,
             view_bobbing: settings.view_bobbing,
             show_subtitles: settings.show_subtitles,
             show_autosave_indicator: settings.show_autosave_indicator,
@@ -627,6 +636,7 @@ impl MainMenu {
                 simulation_distance: self.simulation_distance,
                 fov: self.fov,
                 fov_effect_scale: self.fov_effect_scale,
+                sensitivity: self.sensitivity,
                 view_bobbing: self.view_bobbing,
                 show_subtitles: self.show_subtitles,
                 show_autosave_indicator: self.show_autosave_indicator,

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -205,13 +205,21 @@ impl MainMenu {
         input: &MenuInput,
         text_width_fn: common::TextWidthFn,
     ) -> MainMenuResult {
+        let sensitivity_label = if self.sensitivity <= 0.0 {
+            "Sensitivity: *yawn*".to_string()
+        } else if self.sensitivity >= 1.0 {
+            "Sensitivity: HYPERSPEED!!!".to_string()
+        } else {
+            format!("Sensitivity: {}%", (self.sensitivity * 200.0) as u32)
+        };
         let rows: Vec<OptRow> = vec![
-            OptRow::Pair("Sensitivity: 100%", "Invert Mouse: OFF"),
+            OptRow::Pair(&sensitivity_label, "Invert Mouse: OFF"),
             OptRow::Pair("Auto-Jump: ON", "Operator Items Tab: OFF"),
             OptRow::Pair("Key Binds...", "Mouse Settings..."),
             OptRow::Pair("Sneak: Toggle", "Sprint: Hold"),
         ];
         let nav: &[(&str, Screen)] = &[("Key Binds...", Screen::OptionsKeybinds)];
+        let sliders: &[(&str, f32)] = &[("Sensitivity:", self.sensitivity)];
         self.build_options_grid(
             sw,
             sh,
@@ -220,7 +228,7 @@ impl MainMenu {
             Screen::Options,
             &rows,
             nav,
-            &[],
+            sliders,
             true,
             &[],
             text_width_fn,
@@ -831,6 +839,7 @@ impl MainMenu {
                 }
                 "FOV:" => self.fov = (30.0 + v * 80.0).round() as u32,
                 "FOV Effects:" => self.fov_effect_scale = v,
+                "Sensitivity:" => self.sensitivity = v,
                 "Master Volume:" => self.master_volume = v,
                 "Music:" => self.music_volume = v,
                 "Jukebox/Note Blocks:" => self.jukebox_volume = v,


### PR DESCRIPTION
## Summary

- Turn the Controls sensitivity option into a functional slider
- Persist the sensitivity setting with vanilla's 100% default
- Apply the vanilla 26.2 mouse sensitivity scaling curve to mouse-look input

The previous hard-coded `0.15` mouse multiplier corresponds to vanilla's default 100% sensitivity.

## Testing

- `just client-pre-pr`
- Manually verified sensitivity changes mouse-look behavior in-game

Closes #520