### PR TITLE
fix fullscreen option runtime updates and persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         # --release reuses the dependency artifacts the clippy step built.
         run: |
           cargo test -p pomme-protocol
-          cargo test -p pomme-client --release -- net::azalea_compat world::block renderer::camera::
+          cargo test -p pomme-client --release -- net::azalea_compat world::block renderer::camera:: ui::menu::
 
   launcher-frontend:
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ client-pre-pr:
     @cargo clippy -p pomme-client --release --all-targets --all-features -- -D warnings
     @cargo clippy -p pomme-protocol --release --all-targets --all-features -- -D warnings
     @cargo test -p pomme-protocol
-    @cargo test -p pomme-client -- net::azalea_compat world::block renderer::camera::
+    @cargo test -p pomme-client -- net::azalea_compat world::block renderer::camera:: ui::menu::
 
 # Regenerate a version's packet-id table from the decompiled reference.
 protogen version="26.2":

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -149,6 +149,22 @@ impl DisplayMode {
             Self::Fullscreen => Self::Windowed,
         }
     }
+
+    pub fn to_u8(self) -> u8 {
+        match self {
+            Self::Windowed => 0,
+            Self::Borderless => 1,
+            Self::Fullscreen => 2,
+        }
+    }
+
+    pub fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Borderless,
+            2 => Self::Fullscreen,
+            _ => Self::Windowed,
+        }
+    }
 }
 
 #[derive(Default, PartialEq)]
@@ -207,6 +223,8 @@ impl AppCore {
             user.access_token.clone(),
         );
 
+        let display_mode = menu.display_mode;
+
         let asset_index =
             AssetIndex::load(&data_dirs.indexes_dir, &data_dirs.objects_dir, &version);
 
@@ -220,7 +238,7 @@ impl AppCore {
         Self {
             user,
             presence,
-            display_mode: DisplayMode::Windowed,
+            display_mode,
             input: InputState::new(),
             menu,
             tokio_rt,
@@ -253,6 +271,13 @@ impl AppCore {
             tab: self.input.tab_pressed(),
             f5: self.input.f5_pressed(),
             scroll_delta: self.input.consume_menu_scroll(),
+        }
+    }
+
+    pub fn sync_display_mode(&mut self, window: &Window) {
+        if self.menu.display_mode != self.display_mode {
+            self.display_mode = self.menu.display_mode;
+            self.apply_display_mode(window);
         }
     }
 

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -8,7 +8,8 @@ use azalea_protocol::packets::game::{
 };
 use glam::{FloatExt, dvec3};
 use winit::keyboard::KeyCode;
-use winit::window::{CursorGrabMode, Window};
+use winit::monitor::MonitorHandle;
+use winit::window::{CursorGrabMode, Fullscreen, Window};
 
 use crate::app::input::{Action, InputState, STICK_MOVEMENT_THRESHOLD};
 use crate::app::phases::ConnectionPhase;
@@ -134,7 +135,7 @@ fn dirty_sections_for_block(
     }
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum DisplayMode {
     Windowed,
     Borderless,
@@ -163,6 +164,25 @@ impl DisplayMode {
             1 => Self::Borderless,
             2 => Self::Fullscreen,
             _ => Self::Windowed,
+        }
+    }
+
+    /// Shared by window creation and the runtime switch so the two can't drift.
+    pub fn fullscreen_for(self, monitor: Option<MonitorHandle>) -> Option<Fullscreen> {
+        match self {
+            Self::Windowed => None,
+            Self::Borderless => Some(Fullscreen::Borderless(None)),
+            Self::Fullscreen => {
+                let video_mode = monitor.and_then(|m| {
+                    m.video_modes().max_by_key(|v| {
+                        (v.refresh_rate_millihertz(), v.size().width, v.size().height)
+                    })
+                });
+                Some(match video_mode {
+                    Some(mode) => Fullscreen::Exclusive(mode),
+                    None => Fullscreen::Borderless(None),
+                })
+            }
         }
     }
 }
@@ -282,27 +302,9 @@ impl AppCore {
     }
 
     pub fn apply_display_mode(&mut self, window: &Window) {
-        match self.display_mode {
-            DisplayMode::Windowed => {
-                window.set_fullscreen(None);
-                window.set_decorations(true);
-            }
-            DisplayMode::Borderless => {
-                window.set_fullscreen(Some(winit::window::Fullscreen::Borderless(None)));
-            }
-            DisplayMode::Fullscreen => {
-                let monitor = window.current_monitor();
-                let video_mode = monitor.and_then(|m| {
-                    m.video_modes().max_by_key(|v| {
-                        (v.refresh_rate_millihertz(), v.size().width, v.size().height)
-                    })
-                });
-                if let Some(mode) = video_mode {
-                    window.set_fullscreen(Some(winit::window::Fullscreen::Exclusive(mode)));
-                } else {
-                    window.set_fullscreen(Some(winit::window::Fullscreen::Borderless(None)));
-                }
-            }
+        window.set_fullscreen(self.display_mode.fullscreen_for(window.current_monitor()));
+        if self.display_mode == DisplayMode::Windowed {
+            window.set_decorations(true);
         }
     }
 

--- a/pomme-client/src/app/mod.rs
+++ b/pomme-client/src/app/mod.rs
@@ -179,6 +179,7 @@ impl ApplicationHandler for App {
                         };
                     }
                 };
+                self.core.apply_display_mode(&window);
 
                 let mut renderer = match Renderer::new(
                     Arc::clone(&window),
@@ -290,9 +291,9 @@ impl ApplicationHandler for App {
                         && !self.core.input.key_pressed(KeyCode::F3)
                         && let PhysicalKey::Code(KeyCode::F11) = event.physical_key
                     {
-                        self.core.display_mode = self.core.display_mode.cycle();
-                        self.core.menu.display_mode = self.core.display_mode;
-                        self.core.apply_display_mode(window);
+                        let display_mode = self.core.display_mode.cycle();
+                        self.core.menu.set_display_mode(display_mode);
+                        self.core.sync_display_mode(window);
                     }
                     // F2 screenshot works in every phase, like vanilla.
                     // TODO: Ctrl+F2 panoramic screenshot

--- a/pomme-client/src/app/mod.rs
+++ b/pomme-client/src/app/mod.rs
@@ -162,9 +162,16 @@ impl ApplicationHandler for App {
                     winit::window::Icon::from_rgba(rgba.into_raw(), w, h).ok()
                 };
 
+                // Born in the persisted mode: the swapchain is sized from
+                // `inner_size()` before the window is shown, so switching after
+                // creation would leave it built for the windowed size.
+                let monitor = event_loop
+                    .primary_monitor()
+                    .or_else(|| event_loop.available_monitors().next());
                 let window_attrs = Window::default_attributes()
                     .with_title("Pomme")
                     .with_inner_size(winit::dpi::LogicalSize::new(854, 480))
+                    .with_fullscreen(self.core.display_mode.fullscreen_for(monitor))
                     .with_visible(false)
                     .with_window_icon(window_icon);
 
@@ -179,7 +186,6 @@ impl ApplicationHandler for App {
                         };
                     }
                 };
-                self.core.apply_display_mode(&window);
 
                 let mut renderer = match Renderer::new(
                     Arc::clone(&window),

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -2216,6 +2216,7 @@ pub fn update_game(
             .build(sw, sh, &menu_input, |t, s| r.menu_text_width(t, s));
         elements.extend(result.elements);
         core.input.clear_just_pressed_actions();
+        core.sync_display_mode(&gfx.window);
     } else if game.dead {
         let cursor = core.input.cursor_pos();
         let clicked = core.input.left_just_pressed() && !game.respawn_sent;

--- a/pomme-client/src/app/phases/in_menu.rs
+++ b/pomme-client/src/app/phases/in_menu.rs
@@ -75,10 +75,7 @@ pub fn update_menu(
 
     core.input.clear_just_pressed_actions();
 
-    if core.menu.display_mode != core.display_mode {
-        core.display_mode = core.menu.display_mode;
-        core.apply_display_mode(&gfx.window);
-    }
+    core.sync_display_mode(&gfx.window);
 
     gfx.renderer.set_vsync(core.menu.vsync);
 

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -89,6 +89,8 @@ struct Settings {
     cloud_mode: u8,
     #[serde(default = "default_attack_indicator")]
     attack_indicator: u8,
+    #[serde(default)]
+    display_mode: u8,
 }
 
 fn default_fov() -> u32 {
@@ -165,6 +167,7 @@ impl Default for Settings {
             ui_volume: 1.0,
             cloud_mode: 2,
             attack_indicator: 1,
+            display_mode: 0,
         }
     }
 }
@@ -557,7 +560,7 @@ impl MainMenu {
             skin_right_pants: settings.skin_right_pants,
             skin_hat: settings.skin_hat,
             skin_main_hand_right: settings.skin_main_hand_right,
-            display_mode: DisplayMode::Windowed,
+            display_mode: DisplayMode::from_u8(settings.display_mode),
             cloud_mode: CloudMode::from_u8(settings.cloud_mode),
             attack_indicator: crate::ui::hud::AttackIndicatorMode::from_u8(
                 settings.attack_indicator,
@@ -656,8 +659,14 @@ impl MainMenu {
                 skin_main_hand_right: self.skin_main_hand_right,
                 cloud_mode: self.cloud_mode.to_u8(),
                 attack_indicator: self.attack_indicator.to_u8(),
+                display_mode: self.display_mode.to_u8(),
             },
         );
+    }
+
+    pub fn set_display_mode(&mut self, display_mode: DisplayMode) {
+        self.display_mode = display_mode;
+        self.save_settings();
     }
 
     pub fn main_hand_right(&self) -> bool {
@@ -888,5 +897,32 @@ impl MainMenu {
         self.ping_generation
             .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
         self.ping_results.write().clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_mode_settings_are_backward_compatible_and_round_trip() {
+        let mut legacy = serde_json::to_value(Settings::default()).unwrap();
+        legacy.as_object_mut().unwrap().remove("display_mode");
+        let legacy: Settings = serde_json::from_value(legacy).unwrap();
+        assert_eq!(legacy.display_mode, 0);
+
+        for mode in [
+            DisplayMode::Windowed,
+            DisplayMode::Borderless,
+            DisplayMode::Fullscreen,
+        ] {
+            let settings = Settings {
+                display_mode: mode.to_u8(),
+                ..Settings::default()
+            };
+            let json = serde_json::to_string(&settings).unwrap();
+            let loaded: Settings = serde_json::from_str(&json).unwrap();
+            assert!(DisplayMode::from_u8(loaded.display_mode) == mode);
+        }
     }
 }

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -934,7 +934,7 @@ mod tests {
             };
             let json = serde_json::to_string(&settings).unwrap();
             let loaded: Settings = serde_json::from_str(&json).unwrap();
-            assert!(DisplayMode::from_u8(loaded.display_mode) == mode);
+            assert_eq!(DisplayMode::from_u8(loaded.display_mode), mode);
         }
     }
 }

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -740,7 +740,7 @@ impl MainMenu {
                         self.save_settings();
                     }
                     if label.starts_with("Fullscreen:") {
-                        self.display_mode = self.display_mode.cycle();
+                        self.set_display_mode(self.display_mode.cycle());
                     }
                     if label.starts_with("Clouds:") {
                         self.cloud_mode = self.cloud_mode.cycle();


### PR DESCRIPTION
## Summary

- apply Video Settings display-mode changes immediately while in-game as well as in menus
- persist the selected display mode and restore it on launch
- keep F11 display-mode changes in sync with persisted settings
- add a regression test for backward-compatible display-mode persistence

## Testing

- `just client-pre-pr`
- manually verified in-game display-mode changes, restart persistence, main-menu toggling, and F11 persistence

Closes #525