### PR TITLE
disable unimplemented menu controls

### DIFF
--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -2424,12 +2424,12 @@ fn build_sprite_atlas(
         (
             SpriteId::SliderTrack,
             "minecraft/textures/gui/sprites/widget/slider.png",
-            3.0,
+            1.0,
         ),
         (
             SpriteId::SliderTrackHover,
             "minecraft/textures/gui/sprites/widget/slider_highlighted.png",
-            3.0,
+            1.0,
         ),
         (
             SpriteId::SliderHandle,

--- a/pomme-client/src/ui/common.rs
+++ b/pomme-client/src/ui/common.rs
@@ -603,15 +603,14 @@ pub fn push_slider(
         None
     };
 
-    let track_sprite = SpriteId::SliderTrack;
     elements.push(MenuElement::NineSlice {
         x,
         y,
         w,
         h,
-        sprite: track_sprite,
+        sprite: SpriteId::SliderTrack,
         border: BTN_BORDER * gs,
-        tint: if enabled { WHITE } else { COL_DISABLED },
+        tint: WHITE,
     });
 
     let handle_sprite = if actively_dragging || start_drag || hovered {
@@ -625,7 +624,7 @@ pub fn push_slider(
         w: handle_w,
         h,
         sprite: handle_sprite,
-        tint: if enabled { WHITE } else { COL_DISABLED },
+        tint: WHITE,
     });
 
     let text_col = if enabled { WHITE } else { COL_DISABLED };

--- a/pomme-client/src/ui/common.rs
+++ b/pomme-client/src/ui/common.rs
@@ -584,15 +584,16 @@ pub fn push_slider(
     fs: f32,
     label: &str,
     value: f32,
+    enabled: bool,
     dragging: bool,
     scroll: &LabelScroll<'_>,
 ) -> SliderResult {
-    let hovered = hit_test(cursor, [x, y, w, h]);
+    let hovered = enabled && hit_test(cursor, [x, y, w, h]);
     let handle_w = 8.0 * gs;
     let track_w = w - handle_w;
     let handle_x = x + value.clamp(0.0, 1.0) * track_w;
 
-    let actively_dragging = dragging && mouse_held;
+    let actively_dragging = enabled && dragging && mouse_held;
     let start_drag = hovered && mouse_held && !dragging;
 
     let new_value = if actively_dragging || start_drag {
@@ -610,7 +611,7 @@ pub fn push_slider(
         h,
         sprite: track_sprite,
         border: BTN_BORDER * gs,
-        tint: WHITE,
+        tint: if enabled { WHITE } else { COL_DISABLED },
     });
 
     let handle_sprite = if actively_dragging || start_drag || hovered {
@@ -624,10 +625,11 @@ pub fn push_slider(
         w: handle_w,
         h,
         sprite: handle_sprite,
-        tint: WHITE,
+        tint: if enabled { WHITE } else { COL_DISABLED },
     });
 
-    push_widget_label(elements, x, y, w, h, gs, fs, label, WHITE, Some(scroll));
+    let text_col = if enabled { WHITE } else { COL_DISABLED };
+    push_widget_label(elements, x, y, w, h, gs, fs, label, text_col, Some(scroll));
 
     SliderResult {
         hovered,

--- a/pomme-client/src/ui/common.rs
+++ b/pomme-client/src/ui/common.rs
@@ -9,7 +9,9 @@ use crate::ui::text_edit::TextFieldRenderInfo;
 pub const WHITE: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
 pub const FONT_SIZE: f32 = 8.0;
 pub const BTN_H: f32 = 20.0;
-pub const COL_DISABLED: [f32; 4] = [0.35, 0.36, 0.45, 1.0];
+/// Vanilla's inactive-widget text colour, `0xA0A0A0`
+/// (`AbstractWidget.WithInactiveMessage.defaultInactiveMessage`).
+pub const COL_DISABLED: [f32; 4] = [0.627, 0.627, 0.627, 1.0];
 pub const SLOT_SIZE: f32 = 16.0;
 pub const SLOT_STRIDE: f32 = 18.0;
 pub const SLOT_LABEL_COLOR: [f32; 4] = [0.25, 0.25, 0.25, 1.0];
@@ -609,7 +611,8 @@ pub fn push_slider(
         w,
         h,
         sprite: SpriteId::SliderTrack,
-        border: BTN_BORDER * gs,
+        // `widget/slider.png.mcmeta` declares a 1px border, not the button's 3.
+        border: 1.0 * gs,
         tint: WHITE,
     });
 

--- a/pomme-client/src/ui/menu/main_screen.rs
+++ b/pomme-client/src/ui/menu/main_screen.rs
@@ -297,7 +297,7 @@ impl MainMenu {
                     icon,
                     scale: icon_scale,
                     color: if !enabled {
-                        [0.45, 0.47, 0.58, 0.35]
+                        text_disabled
                     } else if hovered {
                         text_bright
                     } else {

--- a/pomme-client/src/ui/menu/main_screen.rs
+++ b/pomme-client/src/ui/menu/main_screen.rs
@@ -31,24 +31,29 @@ impl MainMenu {
         let text_col: [f32; 4] = [0.89, 0.90, 0.96, 0.85];
         let text_bright: [f32; 4] = [0.94, 0.95, 0.98, 1.0];
         let text_dim: [f32; 4] = [0.53, 0.56, 0.69, 0.6];
+        let text_disabled: [f32; 4] = [0.45, 0.47, 0.58, 0.35];
         let border: [f32; 4] = [1.0, 1.0, 1.0, 0.05];
 
         struct BtnDef {
             label: &'static str,
             id: u8,
+            enabled: bool,
         }
         let buttons = [
             BtnDef {
                 label: "Singleplayer",
                 id: 0,
+                enabled: false,
             },
             BtnDef {
                 label: "Multiplayer",
                 id: 1,
+                enabled: true,
             },
             BtnDef {
                 label: "Quit Game",
                 id: 2,
+                enabled: true,
             },
         ];
 
@@ -198,8 +203,8 @@ impl MainMenu {
         for (i, def) in buttons.iter().enumerate() {
             let by = cy + i as f32 * (btn_h + btn_gap);
             let rect = [btn_x, by, content_w, btn_h];
-            let focused = ctx.focused(true);
-            let hovered = common::hit_test(cursor, rect);
+            let focused = ctx.focused(def.enabled);
+            let hovered = def.enabled && common::hit_test(cursor, rect);
             any_hovered |= hovered;
             // Keyboard focus shows the same highlight as hover (vanilla).
             let active = hovered || focused;
@@ -224,7 +229,13 @@ impl MainMenu {
                     accent[0],
                     accent[1],
                     accent[2],
-                    if active { 0.9 } else { 0.12 },
+                    if !def.enabled {
+                        0.04
+                    } else if active {
+                        0.9
+                    } else {
+                        0.12
+                    },
                 ],
             });
 
@@ -233,7 +244,13 @@ impl MainMenu {
                 y: rect[1] + (rect[3] - font_size) / 2.0,
                 text: def.label.into(),
                 scale: font_size,
-                color: if active { text_bright } else { text_col },
+                color: if !def.enabled {
+                    text_disabled
+                } else if active {
+                    text_bright
+                } else {
+                    text_col
+                },
                 centered: false,
             });
 
@@ -290,21 +307,22 @@ impl MainMenu {
                 hovered
             };
 
-        let bottom_icons: [(f32, char); 4] = [
-            (btn_x, ICON_USER),
-            (btn_x + icon_size + icon_gap, ICON_LINK),
-            (btn_x + content_w - icon_size, ICON_GEAR),
+        let bottom_icons: [(f32, char, bool); 4] = [
+            (btn_x, ICON_USER, false),
+            (btn_x + icon_size + icon_gap, ICON_LINK, true),
+            (btn_x + content_w - icon_size, ICON_GEAR, true),
             (
                 btn_x + content_w - icon_size * 2.0 - icon_gap,
                 ICON_PAINTBRUSH,
+                true,
             ),
         ];
 
-        for &(bx, icon) in &bottom_icons {
-            let hovered = icon_btn(&mut elements, bx, icon_area_y, icon, true);
-            any_hovered |= hovered;
+        for &(bx, icon, enabled) in &bottom_icons {
+            let hovered = icon_btn(&mut elements, bx, icon_area_y, icon, enabled);
+            any_hovered |= enabled && hovered;
 
-            if clicked && hovered {
+            if enabled && clicked && hovered {
                 any_clicked = true;
                 match icon {
                     ICON_LINK => {
@@ -342,7 +360,7 @@ impl MainMenu {
             (
                 new_x0 + icon_size + icon_gap,
                 ICON_LANGUAGE,
-                true,
+                false,
                 "Language",
             ),
             (

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -243,11 +243,14 @@ pub enum MenuAction {
 pub struct MainMenuResult {
     pub elements: Vec<MenuElement>,
     pub action: MenuAction,
+    // TODO: vanilla `AbstractWidget.handleCursor` wants NOT_ALLOWED over a
+    // hovered inactive widget; one bool only says pointer or arrow.
     pub cursor_pointer: bool,
     pub blur: f32,
     pub clicked_button: bool,
 }
 
+#[derive(Default)]
 pub struct MenuInput {
     pub cursor: (f32, f32),
     pub clicked: bool,

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -10,6 +10,10 @@ pub(super) enum OptRow<'a> {
     PairLeft(&'a str),
 }
 
+fn option_enabled(label: &str, disabled: &[&str]) -> bool {
+    !disabled.iter().any(|prefix| label.starts_with(prefix))
+}
+
 fn compat_label(compat: PackCompat) -> (&'static str, [f32; 4]) {
     match compat {
         PackCompat::Compatible => ("Compatible", [0.33, 0.87, 0.33, 1.0]),
@@ -62,6 +66,13 @@ impl MainMenu {
 
         let fov_frac = (self.fov as f32 - 30.0) / 80.0;
         let sliders: &[(&str, f32)] = &[("FOV:", fov_frac)];
+        let disabled = &[
+            "Online...",
+            "Language...",
+            "Chat Settings...",
+            "Telemetry Data...",
+            "Credits & Attribution...",
+        ];
         self.build_options_grid(
             sw,
             sh,
@@ -71,6 +82,7 @@ impl MainMenu {
             &rows,
             nav,
             sliders,
+            disabled,
             false,
             &[],
             text_width_fn,
@@ -183,6 +195,30 @@ impl MainMenu {
             ("Simulation Distance:", sd_frac),
             ("Max Framerate:", mf_frac),
         ];
+        let disabled = &[
+            "Fullscreen Resolution:",
+            "Inactivity FPS Limit:",
+            "Exclusive Fullscreen:",
+            "Brightness:",
+            "Graphics Backend:",
+            "Graphics:",
+            "Biome Blend:",
+            "Prioritize Chunk Updates:",
+            "Simulation Distance:",
+            "Smooth Lighting:",
+            "Particles:",
+            "Mipmap Levels:",
+            "Entity Shadows:",
+            "Entity Distance:",
+            "Menu Background Blur:",
+            "Cloud Range:",
+            "Cutout Leaves:",
+            "Improved Transparency:",
+            "Texture Filtering:",
+            "Max Anisotropy:",
+            "Weather Radius:",
+            "Chunk Fade-in:",
+        ];
         self.build_options_grid(
             sw,
             sh,
@@ -192,6 +228,7 @@ impl MainMenu {
             &rows,
             &[],
             sliders,
+            disabled,
             true,
             &[],
             text_width_fn,
@@ -220,6 +257,15 @@ impl MainMenu {
         ];
         let nav: &[(&str, Screen)] = &[("Key Binds...", Screen::OptionsKeybinds)];
         let sliders: &[(&str, f32)] = &[("Sensitivity:", self.sensitivity)];
+        let disabled = &[
+            "Invert Mouse:",
+            "Auto-Jump:",
+            "Operator Items Tab:",
+            "Key Binds...",
+            "Mouse Settings...",
+            "Sneak:",
+            "Sprint:",
+        ];
         self.build_options_grid(
             sw,
             sh,
@@ -229,6 +275,7 @@ impl MainMenu {
             &rows,
             nav,
             sliders,
+            disabled,
             true,
             &[],
             text_width_fn,
@@ -253,6 +300,26 @@ impl MainMenu {
             OptRow::Pair("Hide Matched Names: ON", "Reduced Debug Info: OFF"),
             OptRow::Pair("Only Show Secure Chat: OFF", "Save Chat Drafts: OFF"),
         ];
+        let disabled = &[
+            "Chat:",
+            "Chat Colors:",
+            "Web Links:",
+            "Prompt on Links:",
+            "Chat Text Opacity:",
+            "Text Background Opacity:",
+            "Chat Text Size:",
+            "Line Spacing:",
+            "Chat Delay:",
+            "Chat Width:",
+            "Focused Height:",
+            "Unfocused Height:",
+            "Narrator:",
+            "Command Suggestions:",
+            "Hide Matched Names:",
+            "Reduced Debug Info:",
+            "Only Show Secure Chat:",
+            "Save Chat Drafts:",
+        ];
         self.build_options_grid(
             sw,
             sh,
@@ -262,6 +329,7 @@ impl MainMenu {
             &rows,
             &[],
             &[],
+            disabled,
             true,
             &[],
             text_width_fn,
@@ -299,6 +367,29 @@ impl MainMenu {
         ];
         let back = self.settings_back.clone_screen();
         let sliders: &[(&str, f32)] = &[("FOV Effects:", self.fov_effect_scale)];
+        let disabled = &[
+            "Narrator:",
+            "High Contrast:",
+            "Menu Background Blur:",
+            "Text Background Opacity:",
+            "Background for Chat Only:",
+            "Chat Text Opacity:",
+            "Line Spacing:",
+            "Chat Delay:",
+            "Notification Time:",
+            "Distortion Effects:",
+            "Darkness Pulsing:",
+            "Damage Tilt:",
+            "Glint Speed:",
+            "Glint Strength:",
+            "Hide Lightning Flashes:",
+            "Dark Loading Screen:",
+            "Panorama Scroll Speed:",
+            "Hide Splash Texts:",
+            "Narrator Hotkey:",
+            "Rotate with Minecart:",
+            "High Contrast Outlines:",
+        ];
         self.build_options_grid(
             sw,
             sh,
@@ -308,6 +399,7 @@ impl MainMenu {
             &rows,
             &[],
             sliders,
+            disabled,
             true,
             &[],
             text_width_fn,
@@ -364,6 +456,13 @@ impl MainMenu {
             ("Voice/Speech:", self.voice_volume),
             ("UI:", self.ui_volume),
         ];
+        let disabled = &[
+            "UI:",
+            "Device:",
+            "Directional Audio:",
+            "Music Frequency:",
+            "Music Toast:",
+        ];
         self.build_options_grid(
             sw,
             sh,
@@ -373,6 +472,7 @@ impl MainMenu {
             &rows,
             &[],
             sliders,
+            disabled,
             true,
             &[],
             text_width_fn,
@@ -428,6 +528,15 @@ impl MainMenu {
             OptRow::Pair(left_pants, right_pants),
             OptRow::Pair(hat, main_hand),
         ];
+        let disabled = &[
+            "Cape:",
+            "Jacket:",
+            "Left Sleeve:",
+            "Right Sleeve:",
+            "Left Pants Leg:",
+            "Right Pants Leg:",
+            "Hat:",
+        ];
         self.build_options_grid(
             sw,
             sh,
@@ -437,6 +546,7 @@ impl MainMenu {
             &rows,
             &[],
             &[],
+            disabled,
             true,
             &[],
             text_width_fn,
@@ -482,6 +592,12 @@ impl MainMenu {
                 "Allow friends to see which server you're on",
             ),
         ];
+        let disabled = &[
+            "Realms Notifications:",
+            "Allow Server Listings:",
+            "Show Online Status:",
+            "Show Current Server:",
+        ];
         self.build_options_grid(
             sw,
             sh,
@@ -491,6 +607,7 @@ impl MainMenu {
             &rows,
             &[],
             &[],
+            disabled,
             true,
             tooltips,
             text_width_fn,
@@ -508,6 +625,7 @@ impl MainMenu {
         rows: &[OptRow],
         nav: &[(&str, Screen)],
         sliders: &[(&'static str, f32)],
+        disabled: &[&str],
         header_footer: bool,
         tooltips: &[(&str, &str)],
         text_width_fn: common::TextWidthFn,
@@ -680,6 +798,7 @@ impl MainMenu {
                 OptRow::PairLeft(a) => widgets.push((*a, left_x, small_w)),
             }
             for (label, bx, bw) in widgets {
+                let enabled = option_enabled(label, disabled);
                 if let Some((prefix, value)) = sliders.iter().find(|(p, _)| label.starts_with(p)) {
                     let is_active = self.active_slider == Some(*prefix);
                     let result = common::push_slider(
@@ -694,6 +813,7 @@ impl MainMenu {
                         fs,
                         label,
                         *value,
+                        enabled,
                         is_active,
                         &label_scroll,
                     );
@@ -710,8 +830,8 @@ impl MainMenu {
                     continue;
                 }
 
-                let focused = ctx.focused(true);
-                let h = common::hit_test(cursor, [bx, by, bw, btn_h]);
+                let focused = ctx.focused(enabled);
+                let h = enabled && common::hit_test(cursor, [bx, by, bw, btn_h]);
                 let draw_cursor = helpers::focus_cursor(focused, h, bx, by, bw, btn_h, cursor);
                 common::push_button_scrolling(
                     &mut elements,
@@ -723,7 +843,7 @@ impl MainMenu {
                     gs,
                     fs,
                     label,
-                    true,
+                    enabled,
                     &label_scroll,
                 );
                 any_hovered |= h;
@@ -1335,5 +1455,51 @@ impl MainMenu {
             blur: 2.0,
             clicked_button: ctx.fired,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_prefixes_match_dynamic_option_labels() {
+        let disabled = &["Simulation Distance:", "Graphics:"];
+
+        assert!(!option_enabled("Simulation Distance: 12 chunks", disabled));
+        assert!(!option_enabled("Graphics: Fancy", disabled));
+        assert!(option_enabled("Render Distance: 12 chunks", disabled));
+        assert!(option_enabled("Graphics Backend: Default", disabled));
+    }
+
+    #[test]
+    fn disabled_slider_cannot_hover_or_drag() {
+        let mut elements = Vec::new();
+        let text_width = |_: &str, _: f32| 0.0;
+        let scroll = common::LabelScroll {
+            text_width_fn: &text_width,
+            time_secs: 0.0,
+        };
+
+        let result = common::push_slider(
+            &mut elements,
+            (50.0, 10.0),
+            true,
+            0.0,
+            0.0,
+            100.0,
+            20.0,
+            1.0,
+            common::FONT_SIZE,
+            "Simulation Distance: 12 chunks",
+            0.5,
+            false,
+            true,
+            &scroll,
+        );
+
+        assert!(!result.hovered);
+        assert!(!result.dragging);
+        assert_eq!(result.new_value, None);
     }
 }

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -464,8 +464,6 @@ impl MainMenu {
             ("UI:", self.ui_volume),
         ];
         let disabled = &[
-            // TODO: drop once `SoundCategory::Ui` exists.
-            "UI:",
             "Device:",
             "Directional Audio:",
             "Music Frequency:",

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -14,6 +14,17 @@ fn option_enabled(label: &str, disabled: &[&str]) -> bool {
     !disabled.iter().any(|prefix| label.starts_with(prefix))
 }
 
+/// Widget labels a row builds; `Header` rows are text, not widgets. Only the
+/// disable-list guard needs this, so it is debug-only.
+#[cfg(debug_assertions)]
+fn row_labels<'a>(row: &OptRow<'a>) -> Vec<&'a str> {
+    match row {
+        OptRow::Header(_) => Vec::new(),
+        OptRow::Big(a) | OptRow::PairLeft(a) => vec![*a],
+        OptRow::Pair(a, b) => vec![*a, *b],
+    }
+}
+
 fn compat_label(compat: PackCompat) -> (&'static str, [f32; 4]) {
     match compat {
         PackCompat::Compatible => ("Compatible", [0.33, 0.87, 0.33, 1.0]),
@@ -66,13 +77,9 @@ impl MainMenu {
 
         let fov_frac = (self.fov as f32 - 30.0) / 80.0;
         let sliders: &[(&str, f32)] = &[("FOV:", fov_frac)];
-        let disabled = &[
-            "Online...",
-            "Language...",
-            "Chat Settings...",
-            "Telemetry Data...",
-            "Credits & Attribution...",
-        ];
+        // Nav rows are disabled only where the target is a `build_options_stub`
+        // page; screens with real (if inert) controls stay reachable.
+        let disabled = &["Language...", "Telemetry Data..."];
         self.build_options_grid(
             sw,
             sh,
@@ -457,6 +464,7 @@ impl MainMenu {
             ("UI:", self.ui_volume),
         ];
         let disabled = &[
+            // TODO: drop once `SoundCategory::Ui` exists.
             "UI:",
             "Device:",
             "Directional Audio:",
@@ -528,6 +536,8 @@ impl MainMenu {
             OptRow::Pair(left_pants, right_pants),
             OptRow::Pair(hat, main_hand),
         ];
+        // "Main Hand:" stays enabled: it moves the attack indicator client-side.
+        // The model toggles do nothing; `client_information` hardcodes them.
         let disabled = &[
             "Cape:",
             "Jacket:",
@@ -771,6 +781,18 @@ impl MainMenu {
             });
         }
 
+        // Rewording a label would silently re-enable its control, so catch a
+        // prefix that no longer matches anything.
+        #[cfg(debug_assertions)]
+        {
+            for p in disabled {
+                debug_assert!(
+                    rows.iter().flat_map(row_labels).any(|l| l.starts_with(p)),
+                    "{title}: disabled prefix {p:?} matches no row",
+                );
+            }
+        }
+
         self.focus_advance(input);
         let mut ctx = self.make_focus_ctx(input);
 
@@ -831,7 +853,8 @@ impl MainMenu {
                 }
 
                 let focused = ctx.focused(enabled);
-                let h = enabled && common::hit_test(cursor, [bx, by, bw, btn_h]);
+                let hit = common::hit_test(cursor, [bx, by, bw, btn_h]);
+                let h = enabled && hit;
                 let draw_cursor = helpers::focus_cursor(focused, h, bx, by, bw, btn_h, cursor);
                 common::push_button_scrolling(
                     &mut elements,
@@ -847,7 +870,9 @@ impl MainMenu {
                     &label_scroll,
                 );
                 any_hovered |= h;
-                if h && let Some((_, tip)) = tooltips.iter().find(|(p, _)| label.starts_with(p)) {
+                // Vanilla keys tooltips off `isHovered`, which ignores `active`
+                // (`AbstractWidget.extractTooltipForNextRenderPass`).
+                if hit && let Some((_, tip)) = tooltips.iter().find(|(p, _)| label.starts_with(p)) {
                     common::push_tooltip(&mut elements, cursor, sw, sh, gs, tip);
                 }
                 if (clicked && h) || (focused && ctx.activate) {
@@ -1501,5 +1526,38 @@ mod tests {
         assert!(!result.hovered);
         assert!(!result.dragging);
         assert_eq!(result.new_value, None);
+    }
+
+    /// Drives every options screen so `build_options_grid`'s debug assertion
+    /// checks each screen's rows against its disabled list.
+    #[test]
+    fn disabled_prefixes_cover_every_options_screen() {
+        let rt = std::sync::Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("current-thread runtime"),
+        );
+        // Nonexistent dir: settings and the server list fall back to defaults,
+        // and nothing writes without a click.
+        let mut menu = MainMenu::new(
+            std::path::Path::new("pomme-options-coverage-test"),
+            rt,
+            "tester".into(),
+            "26.2".into(),
+            None,
+        );
+        let input = MenuInput::default();
+        let text_width = |_: &str, _: f32| 0.0;
+        let tw: common::TextWidthFn = &text_width;
+        let (sw, sh) = (1920.0, 1080.0);
+
+        menu.build_options(sw, sh, &input, tw);
+        menu.build_options_video(sw, sh, &input, tw);
+        menu.build_options_controls(sw, sh, &input, tw);
+        menu.build_options_chat(sw, sh, &input, tw);
+        menu.build_options_accessibility(sw, sh, &input, tw);
+        menu.build_options_music(sw, sh, &input, tw);
+        menu.build_options_skin(sw, sh, &input, tw);
+        menu.build_options_online(sw, sh, &input, tw);
     }
 }


### PR DESCRIPTION
## Summary

- render currently unimplemented menu controls using the existing disabled button style
- prevent disabled buttons and sliders from receiving hover, focus, click, or drag input
- disable placeholder controls across the title screen and options pages while leaving implemented settings interactive
- add focused tests for disabled option matching and slider interaction

## Testing

- `just client-pre-pr`
- manually verified disabled styling/interaction across the title screen and options pages

Closes #527