### PR TITLE
implement vanilla hurt camera feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         # --release reuses the dependency artifacts the clippy step built.
         run: |
           cargo test -p pomme-protocol
-          cargo test -p pomme-client --release -- net::azalea_compat world::block renderer::camera:: ui::menu::
+          cargo test -p pomme-client --release -- net::azalea_compat world::block renderer::camera:: ui::menu:: player::tests::
 
   launcher-frontend:
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ client-pre-pr:
     @cargo clippy -p pomme-client --release --all-targets --all-features -- -D warnings
     @cargo clippy -p pomme-protocol --release --all-targets --all-features -- -D warnings
     @cargo test -p pomme-protocol
-    @cargo test -p pomme-client -- net::azalea_compat world::block renderer::camera:: ui::menu::
+    @cargo test -p pomme-client -- net::azalea_compat world::block renderer::camera:: ui::menu:: player::tests::
 
 # Regenerate a version's packet-id table from the decompiled reference.
 protogen version="26.2":

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -643,7 +643,7 @@ impl AppCore {
                     food,
                     saturation,
                 } => {
-                    game.player.health = health;
+                    game.player.apply_server_health(health);
                     game.player.food = food;
                     game.player.saturation = saturation;
                     if health > 0.0 && game.dead {
@@ -1395,7 +1395,18 @@ impl AppCore {
                     game.entity_store.start_swing(id);
                 }
                 NetworkEvent::EntityDamaged { id } => {
-                    game.entity_store.mark_hurt(id);
+                    if id == game.player.entity_id {
+                        game.player.mark_hurt();
+                    } else {
+                        game.entity_store.mark_hurt(id);
+                    }
+                }
+                NetworkEvent::HurtAnimation { id, yaw } => {
+                    if id == game.player.entity_id {
+                        game.player.animate_hurt(yaw);
+                    } else {
+                        game.entity_store.mark_hurt(id);
+                    }
                 }
                 NetworkEvent::ItemPickedUp {
                     item_id,

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -77,6 +77,18 @@ fn apply_server_block(
     );
 }
 
+/// Starts an entity's hurt animation, with a direction for the packets that
+/// carry one. The local player lives outside the entity store.
+fn hurt_entity(game: &mut GameState, id: i32, dir: Option<f32>) {
+    if id != game.player.entity_id {
+        game.entity_store.mark_hurt(id);
+    } else if let Some(yaw) = dir {
+        game.player.animate_hurt(yaw);
+    } else {
+        game.player.mark_hurt();
+    }
+}
+
 /// Queues a column's packet light for the per-tick apply. Chunk loads enable
 /// the column, standalone light updates are corrections.
 fn queue_light_apply(
@@ -508,6 +520,7 @@ impl AppCore {
                     game.riding_vehicle_id = None;
                     game.player.jump_riding_ticks = 0;
                     game.player.jump_riding_scale = 0.0;
+                    game.player.reset_hurt_state();
 
                     renderer.clear_chunk_meshes();
                     game.mesh_dispatcher =
@@ -1394,20 +1407,8 @@ impl AppCore {
                 NetworkEvent::EntitySwing { id } => {
                     game.entity_store.start_swing(id);
                 }
-                NetworkEvent::EntityDamaged { id } => {
-                    if id == game.player.entity_id {
-                        game.player.mark_hurt();
-                    } else {
-                        game.entity_store.mark_hurt(id);
-                    }
-                }
-                NetworkEvent::HurtAnimation { id, yaw } => {
-                    if id == game.player.entity_id {
-                        game.player.animate_hurt(yaw);
-                    } else {
-                        game.entity_store.mark_hurt(id);
-                    }
-                }
+                NetworkEvent::EntityDamaged { id } => hurt_entity(game, id, None),
+                NetworkEvent::HurtAnimation { id, yaw } => hurt_entity(game, id, Some(yaw)),
                 NetworkEvent::ItemPickedUp {
                     item_id,
                     collector_id,

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -1637,7 +1637,6 @@ pub fn update_game(
     gfx.renderer.set_render_partial_tick(partial_tick);
     gfx.renderer.set_hurt(
         game.player.hurt_time,
-        game.player.hurt_duration,
         game.player.hurt_dir,
         core.menu.damage_tilt_strength,
     );

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -1461,6 +1461,7 @@ pub fn update_game(
     while core.tick_accumulator >= TICK_RATE {
         game.tick_count = game.tick_count.wrapping_add(1);
         core.tick_physics(&mut gfx.renderer, connection, game);
+        game.player.tick_hurt();
         game.player.effects.tick();
         game.item_entity_store.tick(&game.chunk_store);
         game.particle_store.tick(&game.chunk_store);
@@ -1634,6 +1635,12 @@ pub fn update_game(
     );
     // Per-frame FOV interpolation; set before the frustum/view-projection reads.
     gfx.renderer.set_render_partial_tick(partial_tick);
+    gfx.renderer.set_hurt(
+        game.player.hurt_time,
+        game.player.hurt_duration,
+        game.player.hurt_dir,
+        core.menu.damage_tilt_strength,
+    );
     // Plain lerp (vanilla getInterpolatedWalkDistance); the forward-extrapolating
     // camera variant judders across tick boundaries when per-tick speed varies.
     let bob_walk = game

--- a/pomme-client/src/entity/mod.rs
+++ b/pomme-client/src/entity/mod.rs
@@ -94,7 +94,8 @@ fn normalize_player_index_at(kind: EntityKind, index: u8, protocol: i32) -> u8 {
 }
 
 const INTERPOLATION_STEPS: i32 = 3;
-const HURT_DURATION: u8 = 10;
+/// Vanilla `LivingEntity.hurtDuration`, never assigned anything but 10.
+pub const HURT_DURATION: u8 = 10;
 /// Vanilla default arm-swing duration in ticks
 /// (`LivingEntity.getCurrentSwingDuration`).
 const SWING_DURATION: u8 = 6;

--- a/pomme-client/src/net/azalea_compat.rs
+++ b/pomme-client/src/net/azalea_compat.rs
@@ -134,6 +134,18 @@ fn packet_ids_match_azalea() {
         reset_times: true,
     });
     assert_eq!(clear.id(), table_id(Direction::Clientbound, "clear_titles"));
+
+    use azalea_protocol::packets::game::c_hurt_animation;
+
+    let hurt_animation =
+        ClientboundGamePacket::HurtAnimation(c_hurt_animation::ClientboundHurtAnimation {
+            id: MinecraftEntityId(0),
+            yaw: 90.0,
+        });
+    assert_eq!(
+        hurt_animation.id(),
+        table_id(Direction::Clientbound, "hurt_animation")
+    );
 }
 
 /// Round-trip through azalea's `LpVec3` decoder to cross-check the port.

--- a/pomme-client/src/net/handler.rs
+++ b/pomme-client/src/net/handler.rs
@@ -596,6 +596,12 @@ pub fn handle_game_packet(
         ClientboundGamePacket::DamageEvent(p) => {
             let _ = event_tx.try_send(NetworkEvent::EntityDamaged { id: p.entity_id.0 });
         }
+        ClientboundGamePacket::HurtAnimation(p) => {
+            let _ = event_tx.try_send(NetworkEvent::HurtAnimation {
+                id: p.id.0,
+                yaw: p.yaw,
+            });
+        }
         ClientboundGamePacket::RotateHead(p) => {
             let head_y_rot_deg = (p.y_head_rot as f32) * 360.0 / 256.0;
             let _ = event_tx.try_send(NetworkEvent::EntityHeadRotation {

--- a/pomme-client/src/net/mod.rs
+++ b/pomme-client/src/net/mod.rs
@@ -442,6 +442,10 @@ pub enum NetworkEvent {
     EntityDamaged {
         id: i32,
     },
+    HurtAnimation {
+        id: i32,
+        yaw: f32,
+    },
     ItemPickedUp {
         item_id: i32,
         collector_id: i32,

--- a/pomme-client/src/player/mod.rs
+++ b/pomme-client/src/player/mod.rs
@@ -17,6 +17,7 @@ pub const CROUCH_EYE_HEIGHT: f64 = 1.27;
 const DROWN_DAMAGE_THRESHOLD: i32 = -20;
 const DROWN_DAMAGE: f32 = 2.0;
 const AIR_RECOVERY_RATE: i32 = 4;
+const HURT_DURATION: u8 = 10;
 
 // TODO: migrate the remaining raw `game_mode == N` checks to shared constants
 // or an enum.
@@ -49,6 +50,10 @@ pub struct LocalPlayer {
     pub health: f32,
     pub absorption: f32,
     pub max_health: f32,
+    pub hurt_time: u8,
+    pub hurt_duration: u8,
+    pub hurt_dir: f32,
+    flash_on_set_health: bool,
     pub food: u32,
     pub armor: u32,
     pub saturation: f32,
@@ -114,6 +119,10 @@ impl LocalPlayer {
             health: 20.0,
             absorption: 0.0,
             max_health: 20.0,
+            hurt_time: 0,
+            hurt_duration: 0,
+            hurt_dir: 0.0,
+            flash_on_set_health: false,
             food: 20,
             armor: 0,
             saturation: 5.0,
@@ -154,6 +163,30 @@ impl LocalPlayer {
             experience_level: 0,
             experience_progress: 0.0,
             effects: crate::mob_effect::ActiveMobEffects::default(),
+        }
+    }
+
+    pub fn apply_server_health(&mut self, health: f32) {
+        if self.flash_on_set_health && health < self.health {
+            self.mark_hurt();
+        }
+        self.health = health;
+        self.flash_on_set_health = true;
+    }
+
+    pub fn mark_hurt(&mut self) {
+        self.hurt_time = HURT_DURATION;
+        self.hurt_duration = HURT_DURATION;
+    }
+
+    pub fn animate_hurt(&mut self, yaw: f32) {
+        self.mark_hurt();
+        self.hurt_dir = yaw;
+    }
+
+    pub fn tick_hurt(&mut self) {
+        if self.hurt_time > 0 {
+            self.hurt_time -= 1;
         }
     }
 
@@ -333,5 +366,67 @@ impl LocalPlayer {
     pub fn wake_up(&mut self) {
         self.sleeping_pos = None;
         self.sleep_counter = 100;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hurt_state_matches_vanilla_duration_direction_and_expiry() {
+        let mut player = LocalPlayer::new();
+
+        player.apply_server_health(16.0);
+        assert_eq!(
+            player.hurt_time, 0,
+            "first server health sync should not trigger hurt feedback"
+        );
+        player.apply_server_health(18.0);
+        assert_eq!(
+            player.hurt_time, 0,
+            "health increases should not trigger hurt feedback"
+        );
+        player.apply_server_health(17.0);
+        assert_eq!(
+            player.hurt_time, HURT_DURATION,
+            "later health decreases should trigger hurt feedback"
+        );
+        player.hurt_time = 0;
+        player.hurt_duration = 0;
+
+        player.mark_hurt();
+        assert_eq!(
+            player.hurt_time, HURT_DURATION,
+            "damage should start the full hurt timer"
+        );
+        assert_eq!(
+            player.hurt_duration, HURT_DURATION,
+            "damage should refresh the vanilla hurt duration"
+        );
+        assert_eq!(
+            player.hurt_dir, 0.0,
+            "damage events alone must not invent a direction"
+        );
+
+        player.animate_hurt(-37.5);
+        assert_eq!(
+            player.hurt_time, HURT_DURATION,
+            "hurt animation should refresh the timer"
+        );
+        assert_eq!(
+            player.hurt_dir, -37.5,
+            "hurt animation yaw should be preserved exactly"
+        );
+
+        for remaining in (0..HURT_DURATION).rev() {
+            player.tick_hurt();
+            assert_eq!(
+                player.hurt_time, remaining,
+                "hurt timer should decrement once per client tick"
+            );
+        }
+        player.tick_hurt();
+        assert_eq!(player.hurt_time, 0, "expired hurt timer must not underflow");
     }
 }

--- a/pomme-client/src/player/mod.rs
+++ b/pomme-client/src/player/mod.rs
@@ -6,6 +6,7 @@ pub mod tab_list;
 use glam::{dvec2, dvec3};
 use inventory::Inventory;
 
+use crate::entity::HURT_DURATION;
 use crate::entity::components::{LookDirection, Position, Velocity};
 use crate::world::block::{FluidKind, fluid};
 
@@ -17,7 +18,6 @@ pub const CROUCH_EYE_HEIGHT: f64 = 1.27;
 const DROWN_DAMAGE_THRESHOLD: i32 = -20;
 const DROWN_DAMAGE: f32 = 2.0;
 const AIR_RECOVERY_RATE: i32 = 4;
-const HURT_DURATION: u8 = 10;
 
 // TODO: migrate the remaining raw `game_mode == N` checks to shared constants
 // or an enum.
@@ -51,7 +51,6 @@ pub struct LocalPlayer {
     pub absorption: f32,
     pub max_health: f32,
     pub hurt_time: u8,
-    pub hurt_duration: u8,
     pub hurt_dir: f32,
     flash_on_set_health: bool,
     pub food: u32,
@@ -120,7 +119,6 @@ impl LocalPlayer {
             absorption: 0.0,
             max_health: 20.0,
             hurt_time: 0,
-            hurt_duration: 0,
             hurt_dir: 0.0,
             flash_on_set_health: false,
             food: 20,
@@ -176,7 +174,6 @@ impl LocalPlayer {
 
     pub fn mark_hurt(&mut self) {
         self.hurt_time = HURT_DURATION;
-        self.hurt_duration = HURT_DURATION;
     }
 
     pub fn animate_hurt(&mut self, yaw: f32) {
@@ -188,6 +185,14 @@ impl LocalPlayer {
         if self.hurt_time > 0 {
             self.hurt_time -= 1;
         }
+    }
+
+    /// Login and respawn build a fresh vanilla `LocalPlayer`, so hurt state
+    /// does not survive a life.
+    pub fn reset_hurt_state(&mut self) {
+        self.hurt_time = 0;
+        self.hurt_dir = 0.0;
+        self.flash_on_set_health = false;
     }
 
     pub fn height(&self) -> f64 {
@@ -393,16 +398,11 @@ mod tests {
             "later health decreases should trigger hurt feedback"
         );
         player.hurt_time = 0;
-        player.hurt_duration = 0;
 
         player.mark_hurt();
         assert_eq!(
             player.hurt_time, HURT_DURATION,
             "damage should start the full hurt timer"
-        );
-        assert_eq!(
-            player.hurt_duration, HURT_DURATION,
-            "damage should refresh the vanilla hurt duration"
         );
         assert_eq!(
             player.hurt_dir, 0.0,
@@ -428,5 +428,33 @@ mod tests {
         }
         player.tick_hurt();
         assert_eq!(player.hurt_time, 0, "expired hurt timer must not underflow");
+    }
+
+    #[test]
+    fn hurt_state_is_scoped_to_one_life() {
+        let mut player = LocalPlayer::new();
+        player.apply_server_health(20.0);
+        player.animate_hurt(-37.5);
+
+        player.reset_hurt_state();
+        assert_eq!(
+            player.hurt_time, 0,
+            "a new life should clear the hurt timer"
+        );
+        assert_eq!(
+            player.hurt_dir, 0.0,
+            "a new life should clear the hurt direction"
+        );
+
+        player.apply_server_health(6.0);
+        assert_eq!(
+            player.hurt_time, 0,
+            "the first health sync of a new life should not trigger hurt feedback"
+        );
+        player.apply_server_health(5.0);
+        assert_eq!(
+            player.hurt_time, HURT_DURATION,
+            "later decreases in the new life should trigger hurt feedback"
+        );
     }
 }

--- a/pomme-client/src/renderer/camera.rs
+++ b/pomme-client/src/renderer/camera.rs
@@ -2,6 +2,7 @@ use glam::camera::rh::{proj, view};
 use glam::{DVec3, FloatExt, Mat4, Vec3};
 
 use crate::app::input::InputState;
+use crate::entity::HURT_DURATION;
 use crate::entity::components::{LookDirection, Position};
 
 const UP: Vec3 = Vec3::Y;
@@ -110,7 +111,6 @@ pub struct Camera {
     bob_amount: f32,
     bob_enabled: bool,
     hurt_time: u8,
-    hurt_duration: u8,
     hurt_dir: f32,
     damage_tilt_strength: f32,
     /// Projection far plane, scaled with render distance (vanilla
@@ -136,7 +136,6 @@ impl Camera {
             bob_amount: 0.0,
             bob_enabled: false,
             hurt_time: 0,
-            hurt_duration: 0,
             hurt_dir: 0.0,
             damage_tilt_strength: 1.0,
             depth_far: MIN_FAR,
@@ -153,15 +152,8 @@ impl Camera {
         self.bob_enabled = enabled;
     }
 
-    pub fn set_hurt(
-        &mut self,
-        hurt_time: u8,
-        hurt_duration: u8,
-        hurt_dir: f32,
-        damage_tilt_strength: f32,
-    ) {
+    pub fn set_hurt(&mut self, hurt_time: u8, hurt_dir: f32, damage_tilt_strength: f32) {
         self.hurt_time = hurt_time;
-        self.hurt_duration = hurt_duration;
         self.hurt_dir = hurt_dir;
         self.damage_tilt_strength = damage_tilt_strength;
     }
@@ -172,8 +164,12 @@ impl Camera {
         self.hurt_matrix() * self.bob_matrix()
     }
 
+    /// Replicates vanilla `GameRenderer.bobHurt`.
+    ///
+    /// TODO: `bobHurt` also rolls the camera while dying, before this timing
+    /// check; that needs a death-animation timer pomme does not track yet.
     fn hurt_matrix(&self) -> Mat4 {
-        if self.hurt_duration == 0 || self.top_down.is_some() {
+        if self.top_down.is_some() {
             return Mat4::IDENTITY;
         }
         let hurt = self.hurt_time as f32 - self.render_partial_tick;
@@ -181,7 +177,7 @@ impl Camera {
             return Mat4::IDENTITY;
         }
         use std::f32::consts::PI;
-        let hurt = (hurt / self.hurt_duration as f32).powi(4);
+        let hurt = (hurt / HURT_DURATION as f32).powi(4);
         let tilt_deg = -(hurt * PI).sin() * 14.0 * self.damage_tilt_strength;
         let dir = self.hurt_dir.to_radians();
         Mat4::from_rotation_y(-dir)
@@ -547,9 +543,9 @@ mod tests {
     fn hurt_matrix_matches_vanilla_timing_direction_and_damage_tilt() {
         let mut camera = Camera::new(16.0 / 9.0);
         camera.set_render_partial_tick(0.5);
-        camera.set_hurt(6, 10, 90.0, 0.5);
+        camera.set_hurt(6, 90.0, 0.5);
 
-        let hurt = ((6.0_f32 - 0.5) / 10.0).powi(4);
+        let hurt = ((6.0_f32 - 0.5) / HURT_DURATION as f32).powi(4);
         let tilt = -(hurt * std::f32::consts::PI).sin() * 14.0 * 0.5;
         let dir = 90.0_f32.to_radians();
         let expected = Mat4::from_rotation_y(-dir)
@@ -561,14 +557,14 @@ mod tests {
             "directional half-strength hurt transform",
         );
 
-        camera.set_hurt(6, 10, 90.0, 0.0);
+        camera.set_hurt(6, 90.0, 0.0);
         assert_mat4_close(
             camera.hurt_matrix(),
             Mat4::IDENTITY,
             "zero Damage Tilt must disable hurt-camera rotation",
         );
 
-        camera.set_hurt(0, 10, 90.0, 1.0);
+        camera.set_hurt(0, 90.0, 1.0);
         assert_mat4_close(
             camera.hurt_matrix(),
             Mat4::IDENTITY,

--- a/pomme-client/src/renderer/camera.rs
+++ b/pomme-client/src/renderer/camera.rs
@@ -109,6 +109,10 @@ pub struct Camera {
     bob_walk_dist: f32,
     bob_amount: f32,
     bob_enabled: bool,
+    hurt_time: u8,
+    hurt_duration: u8,
+    hurt_dir: f32,
+    damage_tilt_strength: f32,
     /// Projection far plane, scaled with render distance (vanilla
     /// `Camera.depthFar` = render distance in blocks * 4).
     depth_far: f32,
@@ -131,6 +135,10 @@ impl Camera {
             bob_walk_dist: 0.0,
             bob_amount: 0.0,
             bob_enabled: false,
+            hurt_time: 0,
+            hurt_duration: 0,
+            hurt_dir: 0.0,
+            damage_tilt_strength: 1.0,
             depth_far: MIN_FAR,
         }
     }
@@ -145,10 +153,40 @@ impl Camera {
         self.bob_enabled = enabled;
     }
 
-    /// The view-space bob transform, also applied to the first-person arm/held
-    /// item.
-    pub fn view_bob_matrix(&self) -> Mat4 {
-        self.bob_matrix()
+    pub fn set_hurt(
+        &mut self,
+        hurt_time: u8,
+        hurt_duration: u8,
+        hurt_dir: f32,
+        damage_tilt_strength: f32,
+    ) {
+        self.hurt_time = hurt_time;
+        self.hurt_duration = hurt_duration;
+        self.hurt_dir = hurt_dir;
+        self.damage_tilt_strength = damage_tilt_strength;
+    }
+
+    /// The view-space hurt and bob transforms, also applied to the first-person
+    /// arm/held item.
+    pub fn view_effect_matrix(&self) -> Mat4 {
+        self.hurt_matrix() * self.bob_matrix()
+    }
+
+    fn hurt_matrix(&self) -> Mat4 {
+        if self.hurt_duration == 0 || self.top_down.is_some() {
+            return Mat4::IDENTITY;
+        }
+        let hurt = self.hurt_time as f32 - self.render_partial_tick;
+        if hurt < 0.0 {
+            return Mat4::IDENTITY;
+        }
+        use std::f32::consts::PI;
+        let hurt = (hurt / self.hurt_duration as f32).powi(4);
+        let tilt_deg = -(hurt * PI).sin() * 14.0 * self.damage_tilt_strength;
+        let dir = self.hurt_dir.to_radians();
+        Mat4::from_rotation_y(-dir)
+            * Mat4::from_rotation_z(tilt_deg.to_radians())
+            * Mat4::from_rotation_y(dir)
     }
 
     /// Replicates vanilla `GameRenderer.bobView`. Identity when disabled, not
@@ -391,7 +429,7 @@ impl Camera {
     pub fn view_projection_with_fov(&self, fov: f32) -> Mat4 {
         let offset = self.third_person_offset();
         let (forward, up) = self.view_basis();
-        let view = self.bob_matrix() * view::look_to_mat4(offset, forward, up);
+        let view = self.view_effect_matrix() * view::look_to_mat4(offset, forward, up);
         let mut proj = proj::directx::perspective(fov, self.aspect_ratio, NEAR, self.depth_far);
         proj.y_axis.y *= -1.0; // Vulkan NDC has +Y down
         proj * view
@@ -493,6 +531,50 @@ impl CameraUniform {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_mat4_close(actual: Mat4, expected: Mat4, context: &str) {
+        let actual = actual.to_cols_array();
+        let expected = expected.to_cols_array();
+        for (index, (actual, expected)) in actual.into_iter().zip(expected).enumerate() {
+            assert!(
+                (actual - expected).abs() < 1e-6,
+                "{context}: matrix element {index} was {actual}, expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn hurt_matrix_matches_vanilla_timing_direction_and_damage_tilt() {
+        let mut camera = Camera::new(16.0 / 9.0);
+        camera.set_render_partial_tick(0.5);
+        camera.set_hurt(6, 10, 90.0, 0.5);
+
+        let hurt = ((6.0_f32 - 0.5) / 10.0).powi(4);
+        let tilt = -(hurt * std::f32::consts::PI).sin() * 14.0 * 0.5;
+        let dir = 90.0_f32.to_radians();
+        let expected = Mat4::from_rotation_y(-dir)
+            * Mat4::from_rotation_z(tilt.to_radians())
+            * Mat4::from_rotation_y(dir);
+        assert_mat4_close(
+            camera.hurt_matrix(),
+            expected,
+            "directional half-strength hurt transform",
+        );
+
+        camera.set_hurt(6, 10, 90.0, 0.0);
+        assert_mat4_close(
+            camera.hurt_matrix(),
+            Mat4::IDENTITY,
+            "zero Damage Tilt must disable hurt-camera rotation",
+        );
+
+        camera.set_hurt(0, 10, 90.0, 1.0);
+        assert_mat4_close(
+            camera.hurt_matrix(),
+            Mat4::IDENTITY,
+            "expired hurt timing must not rotate the camera",
+        );
+    }
 
     /// The midpoint is the multiplier pomme hardcoded before the slider
     /// existed.

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -775,6 +775,17 @@ impl Renderer {
         self.camera.set_view_bob(walk_dist, bob, enabled);
     }
 
+    pub fn set_hurt(
+        &mut self,
+        hurt_time: u8,
+        hurt_duration: u8,
+        hurt_dir: f32,
+        damage_tilt_strength: f32,
+    ) {
+        self.camera
+            .set_hurt(hurt_time, hurt_duration, hurt_dir, damage_tilt_strength);
+    }
+
     pub fn reset_camera(&mut self, position: Position, look_dir: LookDirection) {
         self.camera.reset(position, look_dir);
     }
@@ -1712,9 +1723,8 @@ impl Renderer {
                     && self.camera.top_down().is_none()
                 {
                     let aspect = sw / sh.max(1.0);
-                    // Same view-bob the world uses, so the arm/item bob in lockstep
-                    // (vanilla applies bobView to the hand pose stack too).
-                    let bob = self.camera.view_bob_matrix();
+                    // Vanilla applies both bobHurt and bobView to the hand pose stack.
+                    let view_effect = self.camera.view_effect_matrix();
                     // Vanilla renderArmWithItem draws the arm only for an empty
                     // hand; a held item renders alone.
                     match held_item {
@@ -1726,14 +1736,14 @@ impl Renderer {
                             *use_anim,
                             item,
                             &self.item_entity_pipeline,
-                            bob,
+                            view_effect,
                         ),
                         None => self.hand_pipeline.update_and_draw(
                             cmd,
                             frame,
                             aspect,
                             *swing_progress,
-                            bob,
+                            view_effect,
                         ),
                     }
                 }

--- a/pomme-client/src/renderer/mod.rs
+++ b/pomme-client/src/renderer/mod.rs
@@ -775,15 +775,9 @@ impl Renderer {
         self.camera.set_view_bob(walk_dist, bob, enabled);
     }
 
-    pub fn set_hurt(
-        &mut self,
-        hurt_time: u8,
-        hurt_duration: u8,
-        hurt_dir: f32,
-        damage_tilt_strength: f32,
-    ) {
+    pub fn set_hurt(&mut self, hurt_time: u8, hurt_dir: f32, damage_tilt_strength: f32) {
         self.camera
-            .set_hurt(hurt_time, hurt_duration, hurt_dir, damage_tilt_strength);
+            .set_hurt(hurt_time, hurt_dir, damage_tilt_strength);
     }
 
     pub fn reset_camera(&mut self, position: Position, look_dir: LookDirection) {

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -31,6 +31,8 @@ struct Settings {
     fov: u32,
     #[serde(default = "default_fov_effect_scale")]
     fov_effect_scale: f32,
+    #[serde(default = "default_damage_tilt_strength")]
+    damage_tilt_strength: f32,
     #[serde(default = "default_sensitivity")]
     sensitivity: f32,
     #[serde(default = "default_true")]
@@ -111,6 +113,14 @@ fn default_fov_effect_scale() -> f32 {
     1.0
 }
 
+fn default_damage_tilt_strength() -> f32 {
+    1.0
+}
+
+fn validated_damage_tilt_strength(value: f32) -> f32 {
+    value.clamp(0.0, 1.0)
+}
+
 fn default_sensitivity() -> f32 {
     0.5
 }
@@ -144,6 +154,7 @@ impl Default for Settings {
             simulation_distance: 12,
             fov: 70,
             fov_effect_scale: 1.0,
+            damage_tilt_strength: 1.0,
             sensitivity: 0.5,
             view_bobbing: true,
             show_subtitles: false,
@@ -432,6 +443,7 @@ pub struct MainMenu {
     pub fov: u32,
     /// FOV Effects slider fraction (0..1); squared by `fov_effect()`.
     pub fov_effect_scale: f32,
+    pub damage_tilt_strength: f32,
     pub sensitivity: f32,
     pub view_bobbing: bool,
     pub show_subtitles: bool,
@@ -541,6 +553,7 @@ impl MainMenu {
             server_render_distance: 0,
             fov: settings.fov,
             fov_effect_scale: settings.fov_effect_scale,
+            damage_tilt_strength: validated_damage_tilt_strength(settings.damage_tilt_strength),
             // Cubed by the look curve, so an out-of-range options.json value
             // reaches infinity and leaves the look direction NaN for good.
             sensitivity: settings.sensitivity.clamp(0.0, 1.0),
@@ -641,6 +654,7 @@ impl MainMenu {
                 simulation_distance: self.simulation_distance,
                 fov: self.fov,
                 fov_effect_scale: self.fov_effect_scale,
+                damage_tilt_strength: self.damage_tilt_strength,
                 sensitivity: self.sensitivity,
                 view_bobbing: self.view_bobbing,
                 show_subtitles: self.show_subtitles,
@@ -915,6 +929,28 @@ impl MainMenu {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn damage_tilt_settings_default_and_validate_to_vanilla_range() {
+        let mut legacy = serde_json::to_value(Settings::default()).unwrap();
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("damage_tilt_strength");
+        let legacy: Settings = serde_json::from_value(legacy).unwrap();
+        assert_eq!(
+            legacy.damage_tilt_strength, 1.0,
+            "legacy settings should default Damage Tilt to vanilla's 100%"
+        );
+
+        for (stored, expected) in [(-0.25, 0.0), (0.35, 0.35), (1.25, 1.0)] {
+            assert_eq!(
+                validated_damage_tilt_strength(stored),
+                expected,
+                "stored Damage Tilt {stored} should validate to {expected}"
+            );
+        }
+    }
 
     #[test]
     fn display_mode_settings_are_backward_compatible_and_round_trip() {

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -117,7 +117,9 @@ fn default_damage_tilt_strength() -> f32 {
     1.0
 }
 
-fn validated_damage_tilt_strength(value: f32) -> f32 {
+/// Vanilla's `OptionInstance.UnitDouble` range, for sliders an out-of-range
+/// options.json would otherwise feed straight into a render or input curve.
+fn unit_range(value: f32) -> f32 {
     value.clamp(0.0, 1.0)
 }
 
@@ -553,10 +555,10 @@ impl MainMenu {
             server_render_distance: 0,
             fov: settings.fov,
             fov_effect_scale: settings.fov_effect_scale,
-            damage_tilt_strength: validated_damage_tilt_strength(settings.damage_tilt_strength),
-            // Cubed by the look curve, so an out-of-range options.json value
-            // reaches infinity and leaves the look direction NaN for good.
-            sensitivity: settings.sensitivity.clamp(0.0, 1.0),
+            damage_tilt_strength: unit_range(settings.damage_tilt_strength),
+            // Cubed by the look curve, so an out-of-range value reaches
+            // infinity and leaves the look direction NaN for good.
+            sensitivity: unit_range(settings.sensitivity),
             view_bobbing: settings.view_bobbing,
             show_subtitles: settings.show_subtitles,
             show_autosave_indicator: settings.show_autosave_indicator,
@@ -931,7 +933,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn damage_tilt_settings_default_and_validate_to_vanilla_range() {
+    fn damage_tilt_defaults_to_full_strength_and_clamps_to_unit_range() {
         let mut legacy = serde_json::to_value(Settings::default()).unwrap();
         legacy
             .as_object_mut()
@@ -945,9 +947,9 @@ mod tests {
 
         for (stored, expected) in [(-0.25, 0.0), (0.35, 0.35), (1.25, 1.0)] {
             assert_eq!(
-                validated_damage_tilt_strength(stored),
+                unit_range(stored),
                 expected,
-                "stored Damage Tilt {stored} should validate to {expected}"
+                "stored slider value {stored} should clamp to {expected}"
             );
         }
     }

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -280,6 +280,14 @@ impl MainMenu {
         } else {
             format!("FOV Effects: {}%", (self.fov_effect() * 100.0).round())
         };
+        let damage_tilt_label = if self.damage_tilt_strength <= 0.0 {
+            "Damage Tilt: OFF".to_string()
+        } else {
+            format!(
+                "Damage Tilt: {}%",
+                (self.damage_tilt_strength * 100.0).round()
+            )
+        };
         let rows: Vec<OptRow> = vec![
             OptRow::Pair("Narrator: OFF", self.show_subtitles_label()),
             OptRow::Pair("High Contrast: OFF", "Menu Background Blur: 50%"),
@@ -291,14 +299,17 @@ impl MainMenu {
             OptRow::Pair("Chat Delay: None", "Notification Time: 10.0s"),
             OptRow::Pair(self.view_bobbing_label(), "Distortion Effects: 100%"),
             OptRow::Pair(&fov_effect_label, "Darkness Pulsing: 100%"),
-            OptRow::Pair("Damage Tilt: 100%", "Glint Speed: 100%"),
+            OptRow::Pair(&damage_tilt_label, "Glint Speed: 100%"),
             OptRow::Pair("Glint Strength: 100%", "Hide Lightning Flashes: OFF"),
             OptRow::Pair("Dark Loading Screen: OFF", "Panorama Scroll Speed: 100%"),
             OptRow::Pair("Hide Splash Texts: OFF", "Narrator Hotkey: ON"),
             OptRow::Pair("Rotate with Minecart: OFF", "High Contrast Outlines: OFF"),
         ];
         let back = self.settings_back.clone_screen();
-        let sliders: &[(&str, f32)] = &[("FOV Effects:", self.fov_effect_scale)];
+        let sliders: &[(&str, f32)] = &[
+            ("FOV Effects:", self.fov_effect_scale),
+            ("Damage Tilt:", self.damage_tilt_strength),
+        ];
         self.build_options_grid(
             sw,
             sh,
@@ -839,6 +850,7 @@ impl MainMenu {
                 }
                 "FOV:" => self.fov = (30.0 + v * 80.0).round() as u32,
                 "FOV Effects:" => self.fov_effect_scale = v,
+                "Damage Tilt:" => self.damage_tilt_strength = v,
                 "Sensitivity:" => self.sensitivity = v,
                 "Master Volume:" => self.master_volume = v,
                 "Music:" => self.music_volume = v,

--- a/pomme-protocol/src/packets.rs
+++ b/pomme-protocol/src/packets.rs
@@ -239,6 +239,10 @@ mod tests {
             Some(47)
         );
         assert_eq!(
+            t.id(Phase::Game, Direction::Clientbound, "hurt_animation"),
+            Some(42)
+        );
+        assert_eq!(
             t.id(Phase::Game, Direction::Clientbound, "remove_mob_effect"),
             Some(0x4E)
         );


### PR DESCRIPTION
## Summary

* add vanilla 26.2 hurt camera timing and directional tilt for the local player
* apply the hurt transform to both the world camera and first-person hand/item rendering
* make Accessibility's Damage Tilt option functional, persisted, and able to scale or disable the effect
* add focused tests for hurt state, camera transforms, and Damage Tilt persistence/validation

## Testing

* `just client-pre-pr`
* manually verified directional hurt feedback, held-item movement, view-bob composition, Damage Tilt at 100%/50%/OFF, persistence, and healing.

Closes #529