### PR TITLE
implement credits and attribution screen

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -291,6 +291,8 @@ impl AppCore {
             tab: self.input.tab_pressed(),
             f5: self.input.f5_pressed(),
             scroll_delta: self.input.consume_menu_scroll(),
+            up_held: self.input.key_pressed(KeyCode::ArrowUp),
+            space_held: self.input.key_pressed(KeyCode::Space),
         }
     }
 

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -25,7 +25,9 @@ use crate::physics::movement;
 use crate::player::LocalPlayer;
 use crate::renderer::Renderer;
 use crate::resource_pack::ResourcePackManager;
-use crate::ui::menu::{MainMenu, MenuInput};
+use crate::ui::menu::{
+    CREDITS_KEY_CTRL_L, CREDITS_KEY_CTRL_R, CREDITS_KEY_SPACE, CREDITS_KEY_UP, MainMenu, MenuInput,
+};
 use crate::user::UserData;
 use crate::world::chunk::ChunkStore;
 
@@ -225,6 +227,23 @@ pub struct AppCore {
     player_faces_dirty: bool,
 }
 
+/// Folds the credits roll's keys into a `CREDITS_KEY_*` mask. Both control
+/// keys count separately in vanilla's `speedupModifiers`, so this can't go
+/// through `InputState::ctrl_held`, which folds them into one winit modifier
+/// bit.
+fn credits_key_mask(mut is_set: impl FnMut(KeyCode) -> bool) -> u8 {
+    [
+        (KeyCode::ArrowUp, CREDITS_KEY_UP),
+        (KeyCode::Space, CREDITS_KEY_SPACE),
+        (KeyCode::ControlLeft, CREDITS_KEY_CTRL_L),
+        (KeyCode::ControlRight, CREDITS_KEY_CTRL_R),
+    ]
+    .into_iter()
+    .filter(|&(code, _)| is_set(code))
+    .map(|(_, bit)| bit)
+    .sum()
+}
+
 impl AppCore {
     pub fn new(
         version: String,
@@ -279,7 +298,9 @@ impl AppCore {
         }
     }
 
-    pub fn build_menu_input(&mut self) -> MenuInput {
+    pub fn build_menu_input(&mut self, dt: f32) -> MenuInput {
+        let credits_keys_down = credits_key_mask(|code| self.input.key_pressed(code));
+        let credits_keys_pressed = credits_key_mask(|code| self.input.key_just_pressed(code));
         MenuInput {
             cursor: self.input.cursor_pos(),
             clicked: self.input.left_just_pressed(),
@@ -291,8 +312,9 @@ impl AppCore {
             tab: self.input.tab_pressed(),
             f5: self.input.f5_pressed(),
             scroll_delta: self.input.consume_menu_scroll(),
-            up_held: self.input.key_pressed(KeyCode::ArrowUp),
-            space_held: self.input.key_pressed(KeyCode::Space),
+            dt,
+            credits_keys_down,
+            credits_keys_pressed,
         }
     }
 

--- a/pomme-client/src/app/mod.rs
+++ b/pomme-client/src/app/mod.rs
@@ -154,9 +154,8 @@ impl ApplicationHandler for App {
                 mut pending_skin_uuid,
             } => {
                 let window_icon = {
-                    let png =
-                        include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icon.png"));
-                    let img = image::load_from_memory(png).expect("failed to decode icon");
+                    let img = image::load_from_memory(crate::assets::POMME_ICON_PNG)
+                        .expect("failed to decode icon");
                     let rgba = img.to_rgba8();
                     let (w, h) = (rgba.width(), rgba.height());
                     winit::window::Icon::from_rgba(rgba.into_raw(), w, h).ok()

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -2207,7 +2207,7 @@ pub fn update_game(
 
     if game.options_from_game {
         core.menu.server_render_distance = game.server_render_distance;
-        let mut menu_input = core.build_menu_input();
+        let mut menu_input = core.build_menu_input(dt);
         // Chat consumed the enter/tab latches earlier this frame; hand them on.
         menu_input.enter = enter;
         menu_input.tab = tab;

--- a/pomme-client/src/app/phases/in_menu.rs
+++ b/pomme-client/src/app/phases/in_menu.rs
@@ -31,7 +31,7 @@ pub fn update_menu(
         }
     }
 
-    let menu_input = core.build_menu_input();
+    let menu_input = core.build_menu_input(dt);
 
     let result = core.menu.build(sw, sh, &menu_input, |t, s| {
         gfx.renderer.menu_text_width(t, s)

--- a/pomme-client/src/assets.rs
+++ b/pomme-client/src/assets.rs
@@ -3,6 +3,11 @@ use std::path::{Path, PathBuf};
 
 use crate::resource_pack::ResourcePackManager;
 
+/// Pomme's brand mark, embedded rather than resolved from the vanilla asset
+/// tree: the window icon and the credits roll's logo both come from it.
+pub const POMME_ICON_PNG: &[u8] =
+    include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/icon.png"));
+
 pub fn load_image(path: &Path) -> Result<image::DynamicImage, image::ImageError> {
     image::open(path).or_else(|_| {
         let data = std::fs::read(path).map_err(image::ImageError::IoError)?;

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -1952,6 +1952,7 @@ pub enum SpriteId {
     Incompatible,
     Unreachable,
     SteveHead,
+    PommeLogo,
     FriendsBackground,
     FriendsTab,
     FriendsTabDisabled,
@@ -3019,6 +3020,28 @@ fn build_sprite_atlas(
                 }
             }
         }
+    }
+
+    // Downscaled 4:1 with a nearest filter so the pixel art stays crisp and the
+    // 512px source doesn't dominate the atlas.
+    const POMME_LOGO_SIZE: u32 = 128;
+    match image::load_from_memory(crate::assets::POMME_ICON_PNG) {
+        Ok(img) => {
+            let scaled = image::imageops::resize(
+                &img.to_rgba8(),
+                POMME_LOGO_SIZE,
+                POMME_LOGO_SIZE,
+                image::imageops::FilterType::Nearest,
+            );
+            images.push((
+                SpriteId::PommeLogo,
+                scaled.into_raw(),
+                POMME_LOGO_SIZE,
+                POMME_LOGO_SIZE,
+                0.0,
+            ));
+        }
+        Err(e) => tracing::warn!("Failed to load pomme logo: {e}"),
     }
 
     // Shelf packing gives every sprite in a row the height of the tallest one

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -3021,7 +3021,17 @@ fn build_sprite_atlas(
         }
     }
 
-    let atlas_size = 1024u32;
+    // Shelf packing gives every sprite in a row the height of the tallest one
+    // in it, so a short sprite landing after a tall one strands the difference.
+    // Packing tallest-first keeps each row's members close in height; left
+    // unsorted, the tail of the list overflowed and was dropped.
+    images.sort_by_key(|sprite| std::cmp::Reverse(sprite.3));
+
+    // Sprites are sampled with NEAREST, so a quad edge landing a hair past its
+    // region reads the neighbour. Keep a 1px gutter, as the font atlas does.
+    const PAD: u32 = 1;
+
+    let atlas_size = 2048u32;
     let mut pixels = vec![0u8; (atlas_size * atlas_size * 4) as usize];
     let mut regions = HashMap::new();
     let mut cursor_x = 0u32;
@@ -3029,13 +3039,13 @@ fn build_sprite_atlas(
     let mut row_height = 0u32;
 
     for (id, data, w, h, border) in &images {
-        if cursor_x + w > atlas_size {
+        if cursor_x + w + PAD > atlas_size {
             cursor_x = 0;
-            cursor_y += row_height;
+            cursor_y += row_height + PAD;
             row_height = 0;
         }
-        if cursor_y + h > atlas_size {
-            tracing::warn!("Sprite atlas overflow, skipping {:?}", id);
+        if cursor_y + h + PAD > atlas_size {
+            tracing::error!("Sprite atlas overflow, skipping {:?}", id);
             continue;
         }
 
@@ -3064,7 +3074,7 @@ fn build_sprite_atlas(
             },
         );
 
-        cursor_x += w;
+        cursor_x += w + PAD;
         row_height = row_height.max(*h);
     }
 
@@ -3529,8 +3539,7 @@ fn push_nine_slice(
     let bu = (tex_border / region.src_w) * uv_w;
     let bv = (tex_border / region.src_h) * uv_h;
 
-    // Snap to integer pixels; fractional edges let NEAREST sampling bleed into
-    // the neighbouring atlas sprite (no gutter between sprites).
+    // Snap to integer pixels so NEAREST sampling stays inside the region.
     let x0 = x.round();
     let y0 = y.round();
     let x1 = (x + w).round();

--- a/pomme-client/src/renderer/pipelines/menu_overlay.rs
+++ b/pomme-client/src/renderer/pipelines/menu_overlay.rs
@@ -2031,6 +2031,46 @@ struct SpriteAtlas {
 const INV_TEX_W: u32 = 176;
 const INV_TEX_H: u32 = 166;
 
+/// Downscales a straight-alpha sprite, filtering it premultiplied so the
+/// transparent border's black stays out of the edge texels' colour. The atlas
+/// stores straight alpha and the shader premultiplies at sample time, so a
+/// naive filter would darken every anti-aliased edge twice over.
+fn downscale_straight_alpha(src: &image::RgbaImage, size: u32) -> image::RgbaImage {
+    let mut premul = image::Rgba32FImage::new(src.width(), src.height());
+    for (dst, src) in premul.pixels_mut().zip(src.pixels()) {
+        let a = f32::from(src[3]) / 255.0;
+        *dst = image::Rgba([
+            f32::from(src[0]) / 255.0 * a,
+            f32::from(src[1]) / 255.0 * a,
+            f32::from(src[2]) / 255.0 * a,
+            a,
+        ]);
+    }
+
+    // Lanczos rings and the resize clamps each channel on its own, so colour
+    // can land above its own alpha; undo the premultiply against that clamp.
+    let scaled =
+        image::imageops::resize(&premul, size, size, image::imageops::FilterType::Lanczos3);
+    let mut out = image::RgbaImage::new(size, size);
+    for (dst, src) in out.pixels_mut().zip(scaled.pixels()) {
+        let a = src[3].clamp(0.0, 1.0);
+        let straight = |c: f32| {
+            if a == 0.0 {
+                0
+            } else {
+                ((c / a).clamp(0.0, 1.0) * 255.0).round() as u8
+            }
+        };
+        *dst = image::Rgba([
+            straight(src[0]),
+            straight(src[1]),
+            straight(src[2]),
+            (a * 255.0).round() as u8,
+        ]);
+    }
+    out
+}
+
 fn build_sprite_atlas(
     device: &vk::Device,
     queue: vk::Queue,
@@ -3022,20 +3062,16 @@ fn build_sprite_atlas(
         }
     }
 
-    // Downscaled 4:1 with a nearest filter so the pixel art stays crisp and the
-    // 512px source doesn't dominate the atlas.
-    const POMME_LOGO_SIZE: u32 = 128;
+    // The credits roll draws the mark at 44 GUI units, so 44 * gui_scale px:
+    // 176 at 1080p, 264 at 1440p, 396 at 4K on the default auto scale. The
+    // atlas sampler is NEAREST, so 256 is the size that straddles that range
+    // with the least resampling either way.
+    const POMME_LOGO_SIZE: u32 = 256;
     match image::load_from_memory(crate::assets::POMME_ICON_PNG) {
         Ok(img) => {
-            let scaled = image::imageops::resize(
-                &img.to_rgba8(),
-                POMME_LOGO_SIZE,
-                POMME_LOGO_SIZE,
-                image::imageops::FilterType::Nearest,
-            );
             images.push((
                 SpriteId::PommeLogo,
-                scaled.into_raw(),
+                downscale_straight_alpha(&img.to_rgba8(), POMME_LOGO_SIZE).into_raw(),
                 POMME_LOGO_SIZE,
                 POMME_LOGO_SIZE,
                 0.0,
@@ -3989,4 +4025,29 @@ fn create_pipeline(
     device.destroy_shader_module(frag_module, None);
 
     pipeline
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn downscale_keeps_colour_out_of_the_transparent_border() {
+        // Opaque white against the transparent black an anti-aliased sprite
+        // sits on; filtering straight alpha would leave the edge texels grey.
+        let mut src = image::RgbaImage::new(16, 16);
+        for (x, _, px) in src.enumerate_pixels_mut() {
+            *px = if x < 8 {
+                image::Rgba([255, 255, 255, 255])
+            } else {
+                image::Rgba([0, 0, 0, 0])
+            };
+        }
+
+        let out = downscale_straight_alpha(&src, 4);
+        assert!(out.pixels().any(|px| px[3] > 0 && px[3] < 255));
+        for px in out.pixels().filter(|px| px[3] > 0) {
+            assert_eq!([px[0], px[1], px[2]], [255, 255, 255], "alpha {}", px[3]);
+        }
+    }
 }

--- a/pomme-client/src/ui/menu/credits.json
+++ b/pomme-client/src/ui/menu/credits.json
@@ -1,0 +1,77 @@
+[
+  {
+    "section": "",
+    "disciplines": [
+      {
+        "discipline": "",
+        "titles": [
+          {
+            "title": "Created By",
+            "names": ["Purdze"]
+          },
+          {
+            "title": "Contributors",
+            "names": [
+              "arse09",
+              "colonthreeing",
+              "Sqrilizz",
+              "uri singer",
+              "Bjorn Beishline",
+              "Matvei",
+              "Spencer0187",
+              "ChocoDev",
+              "Collin Budrick",
+              "Maksas Gornostajus"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "section": "Built With",
+    "disciplines": [
+      {
+        "discipline": "",
+        "titles": [
+          {
+            "title": "Networking",
+            "names": ["azalea", "simdnbt"]
+          },
+          {
+            "title": "Rendering",
+            "names": [
+              "ash",
+              "gpu-allocator",
+              "binary-greedy-meshing",
+              "glam",
+              "fontdue"
+            ]
+          },
+          {
+            "title": "Platform",
+            "names": ["winit", "rodio", "tokio"]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "section": "Minecraft",
+    "disciplines": [
+      {
+        "discipline": "",
+        "titles": [
+          {
+            "title": "Original Game By",
+            "names": ["Mojang Studios"]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "section": "Thank You For Playing",
+    "disciplines": []
+  }
+]

--- a/pomme-client/src/ui/menu/credits.rs
+++ b/pomme-client/src/ui/menu/credits.rs
@@ -21,6 +21,7 @@ const LINE_H: f32 = 12.0;
 const SCROLL_SPEED: f32 = 0.75;
 const SPEEDUP_FACTOR: f32 = 5.0;
 const SPEEDUP_FACTOR_FAST: f32 = 15.0;
+const CREDITS_KEY_CTRL: u8 = CREDITS_KEY_CTRL_L | CREDITS_KEY_CTRL_R;
 
 /// How far below the screen vanilla parks the logo, and the first line below
 /// that. The roll starts already scrolled past the first, since vanilla sizes
@@ -131,6 +132,24 @@ fn credits() -> &'static [Line] {
     )
 }
 
+/// `WinScreen` latches its key state from `keyPressed` / `keyReleased`, which
+/// OS key repeats also reach. So a key held from before the roll opened starts
+/// counting only once its repeat arrives, and any release clears it.
+fn latch_keys(state: &mut u8, down: u8, pressed: u8) -> u8 {
+    *state = (*state | pressed) & down;
+    *state
+}
+
+/// `WinScreen.calculateScrollSpeed`, without its direction term; the control
+/// keys count only while Space is down.
+fn scroll_speed(keys: u8) -> f32 {
+    if keys & CREDITS_KEY_SPACE == 0 {
+        return SCROLL_SPEED;
+    }
+    let modifiers = (keys & CREDITS_KEY_CTRL).count_ones() as f32;
+    SCROLL_SPEED * (SPEEDUP_FACTOR + modifiers * SPEEDUP_FACTOR_FAST)
+}
+
 impl MainMenu {
     /// Vanilla `CreditsAndAttributionScreen`: three 210-wide buttons spaced 8
     /// apart, under a title header, over a 200-wide Done footer.
@@ -194,20 +213,14 @@ impl MainMenu {
             }
         }
 
-        let done_w = 200.0 * gs;
-        if push_button_f(
+        if push_done_button(
             &mut elements,
             &mut ctx,
             &mut any_hovered,
-            input.cursor,
-            input.clicked,
-            cx - done_w / 2.0,
-            chrome.done_y,
-            done_w,
-            btn_h,
+            input,
+            &chrome,
+            cx,
             gs,
-            "Done",
-            true,
         ) {
             self.set_screen(Screen::Options);
         }
@@ -222,15 +235,17 @@ impl MainMenu {
         }
     }
 
+    /// The roll's only entry, so it can clear the key latch the way a fresh
+    /// `WinScreen` starts with nothing held.
     fn open_credits_roll(&mut self) {
         self.set_screen(Screen::CreditsRoll);
         self.credits_scroll = LOGO_LEAD_IN;
-        self.credits_last_frame = None;
+        self.credits_keys = 0;
     }
 
     /// Vanilla `WinScreen` with `poem = false`: the roll scrolls up from below
-    /// the screen, Up reverses it, Space and Shift speed it up, and it returns
-    /// to the credits page once the last line has passed.
+    /// the screen, Up reverses it, Space and Control speed it up, and it
+    /// returns to the credits page once the last line has passed.
     pub(super) fn build_credits_roll(
         &mut self,
         sw: f32,
@@ -247,23 +262,20 @@ impl MainMenu {
         let gs = crate::ui::hud::gui_scale(sw, sh, self.gui_scale_setting);
         let fs = common::FONT_SIZE * gs;
 
-        // `WinScreen.calculateScrollSpeed`, in ticks; vanilla advances by
-        // partial ticks per frame, so scale the frame delta by 20 tps.
-        let direction = if input.up_held { -1.0 } else { 1.0 };
-        let speed = if input.space_held {
-            let modifiers = if input.shift { 1.0 } else { 0.0 };
-            SCROLL_SPEED * (SPEEDUP_FACTOR + modifiers * SPEEDUP_FACTOR_FAST)
+        let keys = latch_keys(
+            &mut self.credits_keys,
+            input.credits_keys_down,
+            input.credits_keys_pressed,
+        );
+        let direction = if keys & CREDITS_KEY_UP != 0 {
+            -1.0
         } else {
-            SCROLL_SPEED
+            1.0
         };
-        let now = Instant::now();
-        let dt = self
-            .credits_last_frame
-            .map_or(0.0, |last| now.duration_since(last).as_secs_f32());
-        self.credits_last_frame = Some(now);
-        // Vanilla floors the rewind at 0, its own start; ours is the lead-in.
-        self.credits_scroll =
-            (self.credits_scroll + dt * 20.0 * speed * direction).max(LOGO_LEAD_IN);
+        // Vanilla advances by partial ticks, so scale the delta by 20 tps, and
+        // floors the rewind at its own start of 0; ours is the lead-in.
+        let step = input.dt * 20.0 * scroll_speed(keys) * direction;
+        self.credits_scroll = (self.credits_scroll + step).max(LOGO_LEAD_IN);
 
         let sh_units = sh / gs;
         let total_scroll_length = lines.len() as f32 * LINE_H;
@@ -384,5 +396,32 @@ mod tests {
             lines[1].text,
             format!("{NAME_PREFIX}{}", first_title.names[0])
         );
+    }
+
+    #[test]
+    fn held_key_counts_only_from_its_next_press() {
+        // Space activated the button on the previous screen, so the roll opens
+        // with it down but unpressed; only its repeat starts the speed-up.
+        let mut state = 0;
+        assert_eq!(latch_keys(&mut state, CREDITS_KEY_SPACE, 0), 0);
+        assert_eq!(
+            latch_keys(&mut state, CREDITS_KEY_SPACE, CREDITS_KEY_SPACE),
+            CREDITS_KEY_SPACE
+        );
+        assert_eq!(
+            latch_keys(&mut state, CREDITS_KEY_SPACE, 0),
+            CREDITS_KEY_SPACE
+        );
+        assert_eq!(latch_keys(&mut state, 0, 0), 0);
+    }
+
+    #[test]
+    fn scroll_speed_matches_calculate_scroll_speed() {
+        // `speedupModifiers` is only consulted while `speedupActive`.
+        assert_eq!(scroll_speed(0), 0.75);
+        assert_eq!(scroll_speed(CREDITS_KEY_UP | CREDITS_KEY_CTRL), 0.75);
+        assert_eq!(scroll_speed(CREDITS_KEY_SPACE), 3.75);
+        assert_eq!(scroll_speed(CREDITS_KEY_SPACE | CREDITS_KEY_CTRL_L), 15.0);
+        assert_eq!(scroll_speed(CREDITS_KEY_SPACE | CREDITS_KEY_CTRL), 26.25);
     }
 }

--- a/pomme-client/src/ui/menu/credits.rs
+++ b/pomme-client/src/ui/menu/credits.rs
@@ -1,0 +1,388 @@
+//! Credits & Attribution page and the scrolling credits roll, ported from
+//! vanilla `CreditsAndAttributionScreen` and `WinScreen` (`poem = false`).
+
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+use super::*;
+
+/// Mojang's attribution page; pomme ships vanilla assets, so this stays theirs.
+const ATTRIBUTION_URL: &str = "https://aka.ms/MinecraftJavaAttribution";
+const LICENSES_URL: &str = "https://github.com/PommeMC/Client/blob/master/THIRD_PARTY_LICENSES.md";
+
+const CREDITS_JSON: &str = include_str!("credits.json");
+
+/// `WinScreen.NAME_PREFIX`: names indent under their title.
+const NAME_PREFIX: &str = "           ";
+const SECTION_HEADING: &str = "============";
+/// `WinScreen` line pitch and scroll speeds, for `poem = false`.
+const LINE_H: f32 = 12.0;
+const SCROLL_SPEED: f32 = 0.75;
+const SPEEDUP_FACTOR: f32 = 5.0;
+const SPEEDUP_FACTOR_FAST: f32 = 15.0;
+
+/// How far below the screen vanilla parks the logo, and the first line below
+/// that. The roll starts already scrolled past the first, since vanilla sizes
+/// this lead-in for a several-hundred-line credits file and pomme's is short
+/// enough that it would just be a blank screen. The second is wider than
+/// vanilla's 100 to leave the lockup room to breathe.
+const LOGO_LEAD_IN: f32 = 50.0;
+const LOGO_TO_TEXT: f32 = 130.0;
+/// The brand mark set beside the wordmark, together standing in for vanilla's
+/// 256x44 logo, which is why the mark carries its height.
+const LOGO_SIZE: f32 = 44.0;
+const LOGO_GAP: f32 = 8.0;
+const WORDMARK_SIZE: f32 = 40.0;
+/// Left edge of the text column: vanilla lays lines against `logoX`, half its
+/// 256-wide logo left of centre.
+const TEXT_INSET: f32 = 128.0;
+
+const COL_YELLOW: [f32; 4] = common::rgb(0xFFFF55);
+const COL_GRAY: [f32; 4] = common::rgb(0xAAAAAA);
+
+#[derive(Deserialize)]
+struct Section {
+    section: String,
+    disciplines: Vec<Discipline>,
+}
+
+#[derive(Deserialize)]
+struct Discipline {
+    discipline: String,
+    titles: Vec<Title>,
+}
+
+#[derive(Deserialize)]
+struct Title {
+    title: String,
+    names: Vec<String>,
+}
+
+/// One rendered credits line.
+struct Line {
+    text: String,
+    centered: bool,
+    color: [f32; 4],
+}
+
+impl Line {
+    fn new(text: impl Into<String>, centered: bool, color: [f32; 4]) -> Self {
+        Self {
+            text: text.into(),
+            centered,
+            color,
+        }
+    }
+
+    fn blank() -> Self {
+        Self::new("", false, WHITE)
+    }
+}
+
+/// `WinScreen` skips anything scrolled past the top or not yet risen into view.
+fn visible(top: f32, h: f32, sh: f32) -> bool {
+    top + h > 0.0 && top < sh
+}
+
+/// Vanilla ends every heading and title block with two `addEmptyLine()` calls.
+fn push_gap(lines: &mut Vec<Line>) {
+    lines.extend([Line::blank(), Line::blank()]);
+}
+
+/// `WinScreen.addCreditsFile`: sections expand to heading/name/heading, then
+/// each discipline's titles with their indented names.
+fn build_lines(sections: &[Section]) -> Vec<Line> {
+    let mut lines = Vec::new();
+    for section in sections {
+        if !section.section.is_empty() {
+            lines.push(Line::new(SECTION_HEADING, true, WHITE));
+            lines.push(Line::new(&section.section, true, COL_YELLOW));
+            lines.push(Line::new(SECTION_HEADING, true, WHITE));
+            push_gap(&mut lines);
+        }
+        for discipline in &section.disciplines {
+            if !discipline.discipline.is_empty() {
+                lines.push(Line::new(&discipline.discipline, true, COL_YELLOW));
+                push_gap(&mut lines);
+            }
+            for title in &discipline.titles {
+                lines.push(Line::new(&title.title, false, COL_GRAY));
+                for name in &title.names {
+                    lines.push(Line::new(format!("{NAME_PREFIX}{name}"), false, WHITE));
+                }
+                push_gap(&mut lines);
+            }
+        }
+    }
+    lines
+}
+
+fn credits() -> &'static [Line] {
+    static LINES: OnceLock<Vec<Line>> = OnceLock::new();
+    LINES.get_or_init(
+        || match serde_json::from_str::<Vec<Section>>(CREDITS_JSON) {
+            Ok(sections) => build_lines(&sections),
+            Err(e) => {
+                tracing::error!("couldn't load credits: {e}");
+                Vec::new()
+            }
+        },
+    )
+}
+
+impl MainMenu {
+    /// Vanilla `CreditsAndAttributionScreen`: three 210-wide buttons spaced 8
+    /// apart, under a title header, over a 200-wide Done footer.
+    pub(super) fn build_options_credits(
+        &mut self,
+        sw: f32,
+        sh: f32,
+        input: &MenuInput,
+    ) -> MainMenuResult {
+        if input.escape {
+            self.set_screen(Screen::Options);
+            return empty_result(2.0);
+        }
+
+        let gs = crate::ui::hud::gui_scale(sw, sh, self.gui_scale_setting);
+        let btn_h = common::BTN_H * gs;
+        let cx = sw / 2.0;
+
+        let mut elements = Vec::new();
+        let mut any_hovered = false;
+
+        let chrome = push_screen_chrome(&mut elements, sw, sh, gs, "Credits and Attribution");
+
+        // `HeaderAndFooterLayout.arrangeElements`: content sits 30 below the
+        // header unless that would push it through the footer.
+        let btn_w = 210.0 * gs;
+        let spacing = 8.0 * gs;
+        let block_h = 3.0 * btn_h + 2.0 * spacing;
+        let block_top = (chrome.header_h + 30.0 * gs).min(chrome.content_bottom - block_h);
+
+        self.focus_advance(input);
+        let mut ctx = self.make_focus_ctx(input);
+
+        let buttons: [(&str, Option<&str>); 3] = [
+            ("Credits", None),
+            ("Attribution", Some(ATTRIBUTION_URL)),
+            ("Licenses", Some(LICENSES_URL)),
+        ];
+        for (i, (label, url)) in buttons.iter().enumerate() {
+            let y = block_top + i as f32 * (btn_h + spacing);
+            if push_button_f(
+                &mut elements,
+                &mut ctx,
+                &mut any_hovered,
+                input.cursor,
+                input.clicked,
+                cx - btn_w / 2.0,
+                y,
+                btn_w,
+                btn_h,
+                gs,
+                label,
+                true,
+            ) {
+                match url {
+                    Some(url) => {
+                        let _ = open::that(url);
+                    }
+                    None => self.open_credits_roll(),
+                }
+            }
+        }
+
+        let done_w = 200.0 * gs;
+        if push_button_f(
+            &mut elements,
+            &mut ctx,
+            &mut any_hovered,
+            input.cursor,
+            input.clicked,
+            cx - done_w / 2.0,
+            chrome.done_y,
+            done_w,
+            btn_h,
+            gs,
+            "Done",
+            true,
+        ) {
+            self.set_screen(Screen::Options);
+        }
+        self.finish_focus(&ctx);
+
+        MainMenuResult {
+            elements,
+            action: MenuAction::None,
+            cursor_pointer: any_hovered,
+            blur: 2.0,
+            clicked_button: ctx.fired,
+        }
+    }
+
+    fn open_credits_roll(&mut self) {
+        self.set_screen(Screen::CreditsRoll);
+        self.credits_scroll = LOGO_LEAD_IN;
+        self.credits_last_frame = None;
+    }
+
+    /// Vanilla `WinScreen` with `poem = false`: the roll scrolls up from below
+    /// the screen, Up reverses it, Space and Shift speed it up, and it returns
+    /// to the credits page once the last line has passed.
+    pub(super) fn build_credits_roll(
+        &mut self,
+        sw: f32,
+        sh: f32,
+        input: &MenuInput,
+        text_width_fn: common::TextWidthFn,
+    ) -> MainMenuResult {
+        let lines = credits();
+        if input.escape || lines.is_empty() {
+            self.set_screen(Screen::OptionsCredits);
+            return empty_result(2.0);
+        }
+
+        let gs = crate::ui::hud::gui_scale(sw, sh, self.gui_scale_setting);
+        let fs = common::FONT_SIZE * gs;
+
+        // `WinScreen.calculateScrollSpeed`, in ticks; vanilla advances by
+        // partial ticks per frame, so scale the frame delta by 20 tps.
+        let direction = if input.up_held { -1.0 } else { 1.0 };
+        let speed = if input.space_held {
+            let modifiers = if input.shift { 1.0 } else { 0.0 };
+            SCROLL_SPEED * (SPEEDUP_FACTOR + modifiers * SPEEDUP_FACTOR_FAST)
+        } else {
+            SCROLL_SPEED
+        };
+        let now = Instant::now();
+        let dt = self
+            .credits_last_frame
+            .map_or(0.0, |last| now.duration_since(last).as_secs_f32());
+        self.credits_last_frame = Some(now);
+        // Vanilla floors the rewind at 0, its own start; ours is the lead-in.
+        self.credits_scroll =
+            (self.credits_scroll + dt * 20.0 * speed * direction).max(LOGO_LEAD_IN);
+
+        let sh_units = sh / gs;
+        let total_scroll_length = lines.len() as f32 * LINE_H;
+        if self.credits_scroll > total_scroll_length + 2.0 * sh_units + 24.0 {
+            self.set_screen(Screen::OptionsCredits);
+            return empty_result(2.0);
+        }
+
+        let mut elements = Vec::new();
+
+        // `WinScreen.extractMenuBackground` scrolls the tiling at half speed.
+        // `TiledImage` has no UV offset, so shift the quad by one tile instead.
+        let tile = MENU_BG_TILE * gs;
+        let bg_offset = (self.credits_scroll * 0.5 * gs) % tile;
+        elements.push(MenuElement::ScissorPush {
+            x: 0.0,
+            y: 0.0,
+            w: sw,
+            h: sh,
+        });
+        // TODO: vanilla also draws textures/misc/credits_vignette.png over this
+        // with the VIGNETTE multiply blend; pomme has no matching pipeline yet.
+        push_menu_backdrop(&mut elements, 0.0, -bg_offset, sw, sh + tile, gs);
+
+        let cx = sw / 2.0;
+        let left_x = cx - TEXT_INSET * gs;
+        let y_offs = -self.credits_scroll * gs;
+        let logo_y = sh + LOGO_LEAD_IN * gs;
+        let first_line_y = logo_y + LOGO_TO_TEXT * gs;
+
+        // Mark and wordmark are centered together as one lockup.
+        let logo_top = logo_y + y_offs;
+        let logo_size = LOGO_SIZE * gs;
+        let wordmark_size = WORDMARK_SIZE * gs;
+        if visible(logo_top, logo_size, sh) {
+            let wordmark_w = text_width_fn("Pomme", wordmark_size);
+            let lockup_w = logo_size + LOGO_GAP * gs + wordmark_w;
+            let logo_x = cx - lockup_w / 2.0;
+            elements.push(MenuElement::Image {
+                x: logo_x,
+                y: logo_top,
+                w: logo_size,
+                h: logo_size,
+                sprite: SpriteId::PommeLogo,
+                tint: WHITE,
+            });
+            elements.push(MenuElement::Text {
+                x: logo_x + logo_size + LOGO_GAP * gs,
+                y: logo_top + (logo_size - wordmark_size) / 2.0,
+                text: "Pomme".into(),
+                scale: wordmark_size,
+                color: COL_WORDMARK,
+                centered: false,
+            });
+        }
+
+        for (i, line) in lines.iter().enumerate() {
+            let y = first_line_y + i as f32 * LINE_H * gs + y_offs;
+            // Vanilla parks only the final line at mid-screen, and still culls
+            // it on its unparked position, so it leaves once that scrolls out.
+            let draw_y = if i == lines.len() - 1 {
+                y - (y - (sh / 2.0 - LINE_H / 2.0 * gs)).min(0.0)
+            } else {
+                y
+            };
+            if line.text.is_empty() || !visible(y, (LINE_H + 8.0) * gs, sh) {
+                continue;
+            }
+            elements.push(MenuElement::Text {
+                x: if line.centered { cx } else { left_x },
+                y: draw_y,
+                text: line.text.clone(),
+                scale: fs,
+                color: line.color,
+                centered: line.centered,
+            });
+        }
+        elements.push(MenuElement::ScissorPop);
+
+        MainMenuResult {
+            elements,
+            action: MenuAction::None,
+            cursor_pointer: false,
+            blur: 2.0,
+            clicked_button: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_credits_parse_into_vanilla_shaped_lines() {
+        let sections: Vec<Section> = serde_json::from_str(CREDITS_JSON).unwrap();
+        assert!(!sections.is_empty());
+
+        let lines = build_lines(&sections);
+        let first_title = &sections[0].disciplines[0].titles[0];
+
+        // An unnamed section skips its heading; the logo announces that one.
+        assert!(sections[0].section.is_empty());
+        assert_eq!(lines[0].text, first_title.title);
+
+        // A named section still gets vanilla's heading/name/heading block.
+        let named = sections.iter().find(|s| !s.section.is_empty()).unwrap();
+        let at = lines.iter().position(|l| l.text == named.section).unwrap();
+        assert_eq!(lines[at - 1].text, SECTION_HEADING);
+        assert_eq!(lines[at + 1].text, SECTION_HEADING);
+        assert!(lines[at].centered);
+        assert_eq!(lines[at].color, COL_YELLOW);
+
+        // Names indent under their title, which is left-aligned and gray.
+        assert!(!lines[0].centered);
+        assert_eq!(lines[0].color, COL_GRAY);
+        assert_eq!(
+            lines[1].text,
+            format!("{NAME_PREFIX}{}", first_title.names[0])
+        );
+    }
+}

--- a/pomme-client/src/ui/menu/friends_screen.rs
+++ b/pomme-client/src/ui/menu/friends_screen.rs
@@ -90,22 +90,9 @@ impl MainMenu {
         let incoming_count = lists.as_ref().map(|l| l.incoming.len()).unwrap_or(0);
 
         // Vanilla renders Friends as a dialog over the previous screen. Re-draw
-        // the title screen as a static backdrop (neutral input → visuals only,
-        // no hover/click/actions); the renderer blurs it behind the panel.
-        let backdrop_input = MenuInput {
-            cursor: (-1.0, -1.0),
-            clicked: false,
-            mouse_held: false,
-            events: Vec::new(),
-            shift: false,
-            enter: false,
-            escape: false,
-            tab: false,
-            f5: false,
-            scroll_delta: 0.0,
-            up_held: false,
-            space_held: false,
-        };
+        // the title screen as a static backdrop; the renderer blurs it behind
+        // the panel.
+        let backdrop_input = MenuInput::backdrop();
         let mut elements = self
             .build_main(screen_w, screen_h, &backdrop_input, text_width_fn)
             .elements;

--- a/pomme-client/src/ui/menu/friends_screen.rs
+++ b/pomme-client/src/ui/menu/friends_screen.rs
@@ -103,6 +103,8 @@ impl MainMenu {
             tab: false,
             f5: false,
             scroll_delta: 0.0,
+            up_held: false,
+            space_held: false,
         };
         let mut elements = self
             .build_main(screen_w, screen_h, &backdrop_input, text_width_fn)

--- a/pomme-client/src/ui/menu/helpers.rs
+++ b/pomme-client/src/ui/menu/helpers.rs
@@ -812,3 +812,30 @@ pub(super) fn push_screen_chrome(
         done_y: sh - footer_h + (footer_h - common::BTN_H * gs) / 2.0,
     }
 }
+
+/// The 200-wide Done button vanilla centres in a header/footer screen's footer.
+pub(super) fn push_done_button(
+    elements: &mut Vec<MenuElement>,
+    ctx: &mut FocusCtx,
+    any_hovered: &mut bool,
+    input: &MenuInput,
+    chrome: &ChromeLayout,
+    cx: f32,
+    gs: f32,
+) -> bool {
+    let w = 200.0 * gs;
+    push_button_f(
+        elements,
+        ctx,
+        any_hovered,
+        input.cursor,
+        input.clicked,
+        cx - w / 2.0,
+        chrome.done_y,
+        w,
+        common::BTN_H * gs,
+        gs,
+        "Done",
+        true,
+    )
+}

--- a/pomme-client/src/ui/menu/helpers.rs
+++ b/pomme-client/src/ui/menu/helpers.rs
@@ -716,3 +716,99 @@ pub(super) fn emit_transition_strips(
         });
     }
 }
+
+/// Tile pitch of the menu backdrop, in GUI units.
+pub(super) const MENU_BG_TILE: f32 = 32.0;
+
+/// The dimmed tiled backdrop drawn behind menu content regions.
+pub(super) fn push_menu_backdrop(
+    elements: &mut Vec<MenuElement>,
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+    gs: f32,
+) {
+    elements.push(MenuElement::TiledImage {
+        x,
+        y,
+        w,
+        h,
+        sprite: SpriteId::MenuBackground,
+        tile_size: MENU_BG_TILE * gs,
+        tint: [0.25, 0.25, 0.25, 1.0],
+    });
+    elements.push(MenuElement::Rect {
+        x,
+        y,
+        w,
+        h,
+        corner_radius: 0.0,
+        color: [0.0, 0.0, 0.0, 0.3],
+    });
+}
+
+/// Vertical bounds of a header/footer screen, in framebuffer pixels.
+pub(super) struct ChromeLayout {
+    pub header_h: f32,
+    pub content_top: f32,
+    pub content_bottom: f32,
+    pub done_y: f32,
+}
+
+/// Draws the shared header/footer frame: a dimmed tiled background between two
+/// separators, with the title centered in the header.
+pub(super) fn push_screen_chrome(
+    elements: &mut Vec<MenuElement>,
+    sw: f32,
+    sh: f32,
+    gs: f32,
+    title: &str,
+) -> ChromeLayout {
+    let fs = common::FONT_SIZE * gs;
+    let cx = sw / 2.0;
+    let header_h = HEADER_FOOTER_H * gs;
+    let footer_h = HEADER_FOOTER_H * gs;
+    let sep_h = 2.0 * gs;
+    let content_top = header_h + sep_h;
+    let content_bottom = sh - footer_h - sep_h;
+
+    push_menu_backdrop(
+        elements,
+        0.0,
+        content_top,
+        sw,
+        content_bottom - content_top,
+        gs,
+    );
+    elements.push(MenuElement::Text {
+        x: cx,
+        y: (header_h - fs) / 2.0,
+        text: title.into(),
+        scale: fs,
+        color: WHITE,
+        centered: true,
+    });
+    elements.push(MenuElement::Image {
+        x: 0.0,
+        y: header_h,
+        w: sw,
+        h: sep_h,
+        sprite: SpriteId::HeaderSeparator,
+        tint: WHITE,
+    });
+    elements.push(MenuElement::Image {
+        x: 0.0,
+        y: content_bottom,
+        w: sw,
+        h: sep_h,
+        sprite: SpriteId::FooterSeparator,
+        tint: WHITE,
+    });
+    ChromeLayout {
+        header_h,
+        content_top,
+        content_bottom,
+        done_y: sh - footer_h + (footer_h - common::BTN_H * gs) / 2.0,
+    }
+}

--- a/pomme-client/src/ui/menu/main_screen.rs
+++ b/pomme-client/src/ui/menu/main_screen.rs
@@ -117,7 +117,7 @@ impl MainMenu {
             y: cy,
             text: "Pomme".into(),
             scale: title_size,
-            color: [0.94, 0.96, 0.99, 0.95],
+            color: COL_WORDMARK,
             centered: false,
         });
 

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -1,3 +1,4 @@
+mod credits;
 mod friends_screen;
 mod helpers;
 mod main_screen;
@@ -264,6 +265,10 @@ pub struct MenuInput {
     pub tab: bool,
     pub f5: bool,
     pub scroll_delta: f32,
+    /// Up / Space held this frame, driving the credits roll's reverse and
+    /// speed-up (vanilla `WinScreen` tracks these as held keys, not presses).
+    pub up_held: bool,
+    pub space_held: bool,
 }
 
 impl MenuInput {
@@ -281,7 +286,8 @@ impl MenuInput {
     }
 }
 
-const HEADER_H: f32 = 33.0;
+/// Vanilla `HeaderAndFooterLayout.DEFAULT_HEADER_AND_FOOTER_HEIGHT`.
+const HEADER_FOOTER_H: f32 = 33.0;
 const ENTRY_H: f32 = 36.0;
 /// Inset (GUI units) keeping server-list entry content off the raw row edges.
 const SERVER_ENTRY_PAD: f32 = 2.0;
@@ -297,6 +303,8 @@ const COL_DIM: [f32; 4] = [0.55, 0.57, 0.69, 1.0];
 const COL_DARK_DIM: [f32; 4] = [0.4, 0.42, 0.52, 1.0];
 const COL_RED: [f32; 4] = [0.88, 0.25, 0.32, 1.0];
 const COL_SEP: [f32; 4] = [1.0, 1.0, 1.0, 0.07];
+/// Tint of the "Pomme" wordmark, on the title screen and in the credits roll.
+const COL_WORDMARK: [f32; 4] = [0.94, 0.96, 0.99, 0.95];
 
 const FIELD_BG: [f32; 4] = [0.06, 0.07, 0.14, 0.8];
 const FIELD_BORDER: [f32; 4] = [1.0, 1.0, 1.0, 0.08];
@@ -326,6 +334,7 @@ enum Screen {
     OptionsAccessibility,
     OptionsTelemetry,
     OptionsCredits,
+    CreditsRoll,
 }
 
 impl Screen {
@@ -346,6 +355,7 @@ impl Screen {
             Self::OptionsAccessibility => Self::OptionsAccessibility,
             Self::OptionsTelemetry => Self::OptionsTelemetry,
             Self::OptionsCredits => Self::OptionsCredits,
+            Self::CreditsRoll => Self::CreditsRoll,
             Self::ServerList => Self::ServerList,
             Self::DirectConnect => Self::DirectConnect,
             Self::AddServer => Self::AddServer,
@@ -419,6 +429,10 @@ pub struct MainMenu {
     last_click_time: Instant,
     /// Steady clock for label scroll animation.
     created: Instant,
+    /// Credits roll position, in unscaled GUI units, and the frame it last
+    /// advanced on.
+    credits_scroll: f32,
+    credits_last_frame: Option<Instant>,
     last_click_index: Option<usize>,
     pub gui_scale_setting: u32,
     pub render_distance: u32,
@@ -533,6 +547,8 @@ impl MainMenu {
             focusable_count: 0,
             last_click_time: Instant::now(),
             created: Instant::now(),
+            credits_scroll: 0.0,
+            credits_last_frame: None,
             last_click_index: None,
             gui_scale_setting: settings.gui_scale,
             render_distance: settings.render_distance,
@@ -718,6 +734,7 @@ impl MainMenu {
                 | Screen::OptionsAccessibility
                 | Screen::OptionsTelemetry
                 | Screen::OptionsCredits
+                | Screen::CreditsRoll
         )
     }
 
@@ -893,13 +910,10 @@ impl MainMenu {
                 "Telemetry Data",
                 Screen::Options,
             ),
-            Screen::OptionsCredits => self.build_options_stub(
-                screen_w,
-                screen_h,
-                input,
-                "Credits & Attribution",
-                Screen::Options,
-            ),
+            Screen::OptionsCredits => self.build_options_credits(screen_w, screen_h, input),
+            Screen::CreditsRoll => {
+                self.build_credits_roll(screen_w, screen_h, input, &text_width_fn)
+            }
         }
     }
 

--- a/pomme-client/src/ui/menu/mod.rs
+++ b/pomme-client/src/ui/menu/mod.rs
@@ -265,13 +265,46 @@ pub struct MenuInput {
     pub tab: bool,
     pub f5: bool,
     pub scroll_delta: f32,
-    /// Up / Space held this frame, driving the credits roll's reverse and
-    /// speed-up (vanilla `WinScreen` tracks these as held keys, not presses).
-    pub up_held: bool,
-    pub space_held: bool,
+    /// Seconds since the last frame, clamped against stalls by the app loop.
+    /// Only the credits roll accumulates a delta; the other menu animations
+    /// time off an anchor `Instant`.
+    pub dt: f32,
+    /// `CREDITS_KEY_*` masks of the roll's keys. `pressed` carries OS key
+    /// repeats, as vanilla's `KeyboardHandler` routes those to `keyPressed`.
+    pub credits_keys_down: u8,
+    pub credits_keys_pressed: u8,
 }
 
+/// `WinScreen.direction`.
+pub const CREDITS_KEY_UP: u8 = 1 << 0;
+/// `WinScreen.speedupActive`.
+pub const CREDITS_KEY_SPACE: u8 = 1 << 1;
+/// `WinScreen.speedupModifiers` holds keys 341 / 345, the two Control keys,
+/// and counts them.
+pub const CREDITS_KEY_CTRL_L: u8 = 1 << 2;
+pub const CREDITS_KEY_CTRL_R: u8 = 1 << 3;
+
 impl MenuInput {
+    /// Neutral input: builds a screen for its visuals only, with no hover,
+    /// click or key state.
+    pub fn backdrop() -> Self {
+        Self {
+            cursor: (-1.0, -1.0),
+            clicked: false,
+            mouse_held: false,
+            events: Vec::new(),
+            shift: false,
+            enter: false,
+            escape: false,
+            tab: false,
+            f5: false,
+            scroll_delta: 0.0,
+            dt: 0.0,
+            credits_keys_down: 0,
+            credits_keys_pressed: 0,
+        }
+    }
+
     /// `InputWithModifiers.isSelection`: Enter / NumpadEnter (folded into
     /// `enter`) or Space with no modifiers activates the focused widget.
     pub fn activate(&self) -> bool {
@@ -429,10 +462,10 @@ pub struct MainMenu {
     last_click_time: Instant,
     /// Steady clock for label scroll animation.
     created: Instant,
-    /// Credits roll position, in unscaled GUI units, and the frame it last
-    /// advanced on.
+    /// Credits roll position in unscaled GUI units, and the `CREDITS_KEY_*`
+    /// mask latched from presses and releases the way `WinScreen` latches its.
     credits_scroll: f32,
-    credits_last_frame: Option<Instant>,
+    credits_keys: u8,
     last_click_index: Option<usize>,
     pub gui_scale_setting: u32,
     pub render_distance: u32,
@@ -548,7 +581,7 @@ impl MainMenu {
             last_click_time: Instant::now(),
             created: Instant::now(),
             credits_scroll: 0.0,
-            credits_last_frame: None,
+            credits_keys: 0,
             last_click_index: None,
             gui_scale_setting: settings.gui_scale,
             render_distance: settings.render_distance,

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -1231,7 +1231,6 @@ impl MainMenu {
         }
 
         let gs = crate::ui::hud::gui_scale(sw, sh, self.gui_scale_setting);
-        let btn_h = common::BTN_H * gs;
         let cx = sw / 2.0;
 
         let mut elements = Vec::new();
@@ -1249,22 +1248,16 @@ impl MainMenu {
             centered: true,
         });
 
-        let done_w = 200.0 * gs;
         self.focus_advance(input);
         let mut ctx = self.make_focus_ctx(input);
-        if push_button_f(
+        if push_done_button(
             &mut elements,
             &mut ctx,
             &mut any_hovered,
-            input.cursor,
-            input.clicked,
-            cx - done_w / 2.0,
-            chrome.done_y,
-            done_w,
-            btn_h,
+            input,
+            &chrome,
+            cx,
             gs,
-            "Done",
-            true,
         ) {
             self.set_screen(back);
         }

--- a/pomme-client/src/ui/menu/options.rs
+++ b/pomme-client/src/ui/menu/options.rs
@@ -538,30 +538,21 @@ impl MainMenu {
         let (content_top, content_bottom, done_y);
 
         if header_footer {
-            let header_h = 33.0 * gs;
-            let footer_h = 33.0 * gs;
+            let header_h = HEADER_FOOTER_H * gs;
+            let footer_h = HEADER_FOOTER_H * gs;
             let sep_h = 2.0 * gs;
             content_top = header_h + sep_h;
             content_bottom = sh - footer_h - sep_h;
             done_y = sh - footer_h + (footer_h - btn_h) / 2.0;
 
-            elements.push(MenuElement::TiledImage {
-                x: 0.0,
-                y: content_top,
-                w: sw,
-                h: content_bottom - content_top,
-                sprite: SpriteId::MenuBackground,
-                tile_size: 32.0 * gs,
-                tint: [0.25, 0.25, 0.25, 1.0],
-            });
-            elements.push(MenuElement::Rect {
-                x: 0.0,
-                y: content_top,
-                w: sw,
-                h: content_bottom - content_top,
-                corner_radius: 0.0,
-                color: [0.0, 0.0, 0.0, 0.3],
-            });
+            push_menu_backdrop(
+                &mut elements,
+                0.0,
+                content_top,
+                sw,
+                content_bottom - content_top,
+                gs,
+            );
 
             elements.push(MenuElement::Text {
                 x: cx,
@@ -1019,7 +1010,7 @@ impl MainMenu {
         header_y += field_h + pad;
 
         let content_top = header_y;
-        let footer_h = 33.0 * gs;
+        let footer_h = HEADER_FOOTER_H * gs;
         let content_bottom = sh - footer_h;
         let done_y = sh - footer_h + (footer_h - btn_h) / 2.0;
 
@@ -1240,67 +1231,18 @@ impl MainMenu {
         }
 
         let gs = crate::ui::hud::gui_scale(sw, sh, self.gui_scale_setting);
-        let fs = common::FONT_SIZE * gs;
         let btn_h = common::BTN_H * gs;
         let cx = sw / 2.0;
-
-        let header_h = 33.0 * gs;
-        let footer_h = 33.0 * gs;
-        let sep_h = 2.0 * gs;
-        let content_top = header_h + sep_h;
-        let content_bottom = sh - footer_h - sep_h;
-        let done_y = sh - footer_h + (footer_h - btn_h) / 2.0;
 
         let mut elements = Vec::new();
         let mut any_hovered = false;
 
-        elements.push(MenuElement::TiledImage {
-            x: 0.0,
-            y: content_top,
-            w: sw,
-            h: content_bottom - content_top,
-            sprite: SpriteId::MenuBackground,
-            tile_size: 32.0 * gs,
-            tint: [0.25, 0.25, 0.25, 1.0],
-        });
-        elements.push(MenuElement::Rect {
-            x: 0.0,
-            y: content_top,
-            w: sw,
-            h: content_bottom - content_top,
-            corner_radius: 0.0,
-            color: [0.0, 0.0, 0.0, 0.3],
-        });
-
-        elements.push(MenuElement::Text {
-            x: cx,
-            y: (header_h - fs) / 2.0,
-            text: title.into(),
-            scale: fs,
-            color: WHITE,
-            centered: true,
-        });
-        elements.push(MenuElement::Image {
-            x: 0.0,
-            y: header_h,
-            w: sw,
-            h: sep_h,
-            sprite: SpriteId::HeaderSeparator,
-            tint: WHITE,
-        });
-        elements.push(MenuElement::Image {
-            x: 0.0,
-            y: content_bottom,
-            w: sw,
-            h: sep_h,
-            sprite: SpriteId::FooterSeparator,
-            tint: WHITE,
-        });
+        let chrome = push_screen_chrome(&mut elements, sw, sh, gs, title);
 
         let body_fs = 10.0 * gs;
         elements.push(MenuElement::Text {
             x: cx,
-            y: (content_top + content_bottom) / 2.0 - body_fs / 2.0,
+            y: (chrome.content_top + chrome.content_bottom) / 2.0 - body_fs / 2.0,
             text: "Coming soon".into(),
             scale: body_fs,
             color: COL_DIM,
@@ -1317,7 +1259,7 @@ impl MainMenu {
             input.cursor,
             input.clicked,
             cx - done_w / 2.0,
-            done_y,
+            chrome.done_y,
             done_w,
             btn_h,
             gs,

--- a/pomme-client/src/ui/menu/servers.rs
+++ b/pomme-client/src/ui/menu/servers.rs
@@ -9,7 +9,7 @@ impl MainMenu {
         text_width_fn: &dyn Fn(&str, f32) -> f32,
     ) -> MainMenuResult {
         let gs = crate::ui::hud::gui_scale(screen_w, screen_h, self.gui_scale_setting);
-        let header_h = HEADER_H * gs;
+        let header_h = HEADER_FOOTER_H * gs;
         let sep_h = SEP_H * gs;
         let entry_h = ENTRY_H * gs;
         let row_w = ROW_W * gs;
@@ -53,23 +53,7 @@ impl MainMenu {
             centered: true,
         });
 
-        elements.push(MenuElement::TiledImage {
-            x: 0.0,
-            y: list_top,
-            w: screen_w,
-            h: list_h,
-            sprite: SpriteId::MenuBackground,
-            tile_size: 32.0 * gs,
-            tint: [0.25, 0.25, 0.25, 1.0],
-        });
-        elements.push(MenuElement::Rect {
-            x: 0.0,
-            y: list_top,
-            w: screen_w,
-            h: list_h,
-            corner_radius: 0.0,
-            color: [0.0, 0.0, 0.0, 0.3],
-        });
+        push_menu_backdrop(&mut elements, 0.0, list_top, screen_w, list_h, gs);
 
         push_separator(&mut elements, 0.0, list_top - sep_h, screen_w, sep_h);
         push_separator(&mut elements, 0.0, list_bottom, screen_w, sep_h);


### PR DESCRIPTION
Replaces the Credits & Attribution stub with the real screen: Credits opens a scrolling roll, Attribution and Licenses open links. Stacked on #533, which the logo sprite needs.