### PR TITLE
replace rodio audio backend with openal soft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         # --release reuses the dependency artifacts the clippy step built.
         run: |
           cargo test -p pomme-protocol
-          cargo test -p pomme-client --release -- net::azalea_compat world::block renderer::camera:: ui::menu:: player::tests:: audio::
+          cargo test -p pomme-client --release -- net::azalea_compat world::block renderer::camera:: ui::menu:: player::tests:: audio:: net::handler::
 
   launcher-frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         # --release reuses the dependency artifacts the clippy step built.
         run: |
           cargo test -p pomme-protocol
-          cargo test -p pomme-client --release -- net::azalea_compat world::block renderer::camera:: ui::menu:: player::tests::
+          cargo test -p pomme-client --release -- net::azalea_compat world::block renderer::camera:: ui::menu:: player::tests:: audio::
 
   launcher-frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -15,7 +15,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   MC_VERSION: "26.2"
-  LWJGL_OPENAL_VERSION: "3.4.1"
 
 permissions:
   contents: write
@@ -58,25 +57,16 @@ jobs:
             artifact: pomme-client.exe
             name: pomme-client-windows-x64
             openal_classifier: natives-windows
-            openal_member: windows/x64/org/lwjgl/openal/OpenAL.dll
-            openal_name: OpenAL.dll
-            openal_sha256: 28d4065b9c6be68454eb4d7c0da665bd4bc7cc77d854c1f67afbd2f38ff730a3
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact: pomme-client
             name: pomme-client-linux-x64-gnu
             openal_classifier: natives-linux
-            openal_member: linux/x64/org/lwjgl/openal/libopenal.so
-            openal_name: libopenal.so
-            openal_sha256: c3be36ffda26c46b77bfa359586424a95d7620be11427897c7a454abb16c0994
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: pomme-client
             name: pomme-client-macos-arm64
             openal_classifier: natives-macos-arm64
-            openal_member: macos/arm64/org/lwjgl/openal/libopenal.dylib
-            openal_name: libopenal.dylib
-            openal_sha256: 704365e5bfc028c006d2fe54862742d661295bd4b960824a0d2fbe5a9c7b8ffd
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -103,40 +93,21 @@ jobs:
       - name: Build
         run: cargo build -p pomme-client --release --target ${{ matrix.target }}
 
-      - name: Stage Minecraft OpenAL Soft 1.25.1
-        shell: bash
-        env:
-          OPENAL_CLASSIFIER: ${{ matrix.openal_classifier }}
-          OPENAL_MEMBER: ${{ matrix.openal_member }}
-          OPENAL_NAME: ${{ matrix.openal_name }}
-          OPENAL_SHA256: ${{ matrix.openal_sha256 }}
-        run: |
-          python - <<'PY'
-          import hashlib
-          import os
-          from pathlib import Path
-          import urllib.request
-          import zipfile
+      # The runner images disagree on whether `python` or `python3` is on PATH,
+      # and the `--require` staging below fails the release rather than degrade.
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
 
-          version = os.environ["LWJGL_OPENAL_VERSION"]
-          classifier = os.environ["OPENAL_CLASSIFIER"]
-          member = os.environ["OPENAL_MEMBER"]
-          expected = os.environ["OPENAL_SHA256"]
-          url = (
-              "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/"
-              f"{version}/lwjgl-openal-{version}-{classifier}.jar"
-          )
-          jar = Path("openal-native.jar")
-          urllib.request.urlretrieve(url, jar)
-          actual = hashlib.sha256(jar.read_bytes()).hexdigest()
-          if actual != expected:
-              raise SystemExit(f"OpenAL native jar hash mismatch: {actual} != {expected}")
-          out = Path("openal-native") / os.environ["OPENAL_NAME"]
-          out.parent.mkdir(parents=True, exist_ok=True)
-          with zipfile.ZipFile(jar) as archive:
-              out.write_bytes(archive.read(member))
-          print(f"staged {out} from {url} ({actual})")
-          PY
+      # Version, jar member and checksum come from
+      # pomme-client/third-party/openal-natives.txt, which `just openal` also
+      # reads, so a release and a dev build never diverge.
+      - name: Stage Minecraft's OpenAL Soft native
+        shell: bash
+        run: |
+          mkdir -p bundle
+          python tools/fetch_openal.py bundle \
+            --classifier "${{ matrix.openal_classifier }}" --require
 
       - name: Package (Unix)
         if: matrix.os != 'windows-latest'
@@ -144,7 +115,6 @@ jobs:
         run: |
           mkdir -p dist bundle
           cp "target/${{ matrix.target }}/release/${{ matrix.artifact }}" bundle/
-          cp "openal-native/${{ matrix.openal_name }}" bundle/
           cp pomme-client/third-party/OpenAL-Soft-LICENSE.txt bundle/
           cp pomme-client/third-party/OpenAL-Soft-NOTICE.txt bundle/
 
@@ -172,7 +142,6 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force dist, bundle | Out-Null
           Copy-Item "target/${{ matrix.target }}/release/${{ matrix.artifact }}" bundle/
-          Copy-Item "openal-native/${{ matrix.openal_name }}" bundle/
           Copy-Item "pomme-client/third-party/OpenAL-Soft-LICENSE.txt" bundle/
           Copy-Item "pomme-client/third-party/OpenAL-Soft-NOTICE.txt" bundle/
           Compress-Archive -Path "bundle/*" -DestinationPath "dist/${{ matrix.name }}.zip"

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -15,6 +15,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   MC_VERSION: "26.2"
+  LWJGL_OPENAL_VERSION: "3.4.1"
 
 permissions:
   contents: write
@@ -56,14 +57,26 @@ jobs:
             target: x86_64-pc-windows-msvc
             artifact: pomme-client.exe
             name: pomme-client-windows-x64
+            openal_classifier: natives-windows
+            openal_member: windows/x64/org/lwjgl/openal/OpenAL.dll
+            openal_name: OpenAL.dll
+            openal_sha256: 28d4065b9c6be68454eb4d7c0da665bd4bc7cc77d854c1f67afbd2f38ff730a3
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact: pomme-client
             name: pomme-client-linux-x64-gnu
+            openal_classifier: natives-linux
+            openal_member: linux/x64/org/lwjgl/openal/libopenal.so
+            openal_name: libopenal.so
+            openal_sha256: c3be36ffda26c46b77bfa359586424a95d7620be11427897c7a454abb16c0994
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: pomme-client
             name: pomme-client-macos-arm64
+            openal_classifier: natives-macos-arm64
+            openal_member: macos/arm64/org/lwjgl/openal/libopenal.dylib
+            openal_name: libopenal.dylib
+            openal_sha256: 704365e5bfc028c006d2fe54862742d661295bd4b960824a0d2fbe5a9c7b8ffd
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -90,12 +103,50 @@ jobs:
       - name: Build
         run: cargo build -p pomme-client --release --target ${{ matrix.target }}
 
+      - name: Stage Minecraft OpenAL Soft 1.25.1
+        shell: bash
+        env:
+          OPENAL_CLASSIFIER: ${{ matrix.openal_classifier }}
+          OPENAL_MEMBER: ${{ matrix.openal_member }}
+          OPENAL_NAME: ${{ matrix.openal_name }}
+          OPENAL_SHA256: ${{ matrix.openal_sha256 }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import os
+          from pathlib import Path
+          import urllib.request
+          import zipfile
+
+          version = os.environ["LWJGL_OPENAL_VERSION"]
+          classifier = os.environ["OPENAL_CLASSIFIER"]
+          member = os.environ["OPENAL_MEMBER"]
+          expected = os.environ["OPENAL_SHA256"]
+          url = (
+              "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/"
+              f"{version}/lwjgl-openal-{version}-{classifier}.jar"
+          )
+          jar = Path("openal-native.jar")
+          urllib.request.urlretrieve(url, jar)
+          actual = hashlib.sha256(jar.read_bytes()).hexdigest()
+          if actual != expected:
+              raise SystemExit(f"OpenAL native jar hash mismatch: {actual} != {expected}")
+          out = Path("openal-native") / os.environ["OPENAL_NAME"]
+          out.parent.mkdir(parents=True, exist_ok=True)
+          with zipfile.ZipFile(jar) as archive:
+              out.write_bytes(archive.read(member))
+          print(f"staged {out} from {url} ({actual})")
+          PY
+
       - name: Package (Unix)
         if: matrix.os != 'windows-latest'
         shell: bash
         run: |
           mkdir -p dist bundle
           cp "target/${{ matrix.target }}/release/${{ matrix.artifact }}" bundle/
+          cp "openal-native/${{ matrix.openal_name }}" bundle/
+          cp pomme-client/third-party/OpenAL-Soft-LICENSE.txt bundle/
+          cp pomme-client/third-party/OpenAL-Soft-NOTICE.txt bundle/
 
           # macOS has no system Vulkan, so ship the loader + MoltenVK + ICD next
           # to the binary (build.rs gives it an @executable_path rpath).
@@ -119,8 +170,12 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force dist | Out-Null
-          Compress-Archive -Path "target/${{ matrix.target }}/release/${{ matrix.artifact }}" -DestinationPath "dist/${{ matrix.name }}.zip"
+          New-Item -ItemType Directory -Force dist, bundle | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/${{ matrix.artifact }}" bundle/
+          Copy-Item "openal-native/${{ matrix.openal_name }}" bundle/
+          Copy-Item "pomme-client/third-party/OpenAL-Soft-LICENSE.txt" bundle/
+          Copy-Item "pomme-client/third-party/OpenAL-Soft-NOTICE.txt" bundle/
+          Compress-Archive -Path "bundle/*" -DestinationPath "dist/${{ matrix.name }}.zip"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,28 +114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alsa"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
-dependencies = [
- "alsa-sys",
- "bitflags 2.11.1",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "alsa-sys"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
-dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "android-activity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,50 +1493,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "coreaudio-rs"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
- "objc2-audio-toolbox",
- "objc2-core-audio",
- "objc2-core-audio-types",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "cpal"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
-dependencies = [
- "alsa",
- "coreaudio-rs",
- "dasp_sample",
- "jni 0.21.1",
- "js-sys",
- "libc",
- "mach2",
- "ndk",
- "ndk-context",
- "num-derive",
- "num-traits",
- "objc2 0.6.4",
- "objc2-audio-toolbox",
- "objc2-avf-audio",
- "objc2-core-audio",
- "objc2-core-audio-types",
- "objc2-core-foundation",
- "objc2-foundation 0.3.2",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "windows",
-]
-
-[[package]]
 name = "cpubits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,12 +1720,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "dasp_sample"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
@@ -2332,12 +2260,6 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
-
-[[package]]
-name = "extended"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fastrand"
@@ -3935,15 +3857,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "mach2"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4292,7 +4205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -4383,31 +4295,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-audio-toolbox"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
- "objc2 0.6.4",
- "objc2-core-audio",
- "objc2-core-audio-types",
- "objc2-core-foundation",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
-name = "objc2-avf-audio"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
-dependencies = [
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
 name = "objc2-cloud-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4443,29 +4330,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-audio"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
-dependencies = [
- "dispatch2",
- "objc2 0.6.4",
- "objc2-core-audio-types",
- "objc2-core-foundation",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
-name = "objc2-core-audio-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
-dependencies = [
- "bitflags 2.11.1",
- "objc2 0.6.4",
-]
-
-[[package]]
 name = "objc2-core-data"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4494,9 +4358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
- "block2 0.6.2",
  "dispatch2",
- "libc",
  "objc2 0.6.4",
 ]
 
@@ -5166,6 +5028,7 @@ dependencies = [
  "gilrs",
  "glam",
  "image",
+ "libloading 0.8.9",
  "mimalloc",
  "open",
  "parking_lot",
@@ -5175,13 +5038,13 @@ dependencies = [
  "pyronyx",
  "raw-window-handle",
  "reqwest",
- "rodio",
  "scopeguard",
  "serde",
  "serde_json",
  "sha1_smol",
  "shaderc",
  "simdnbt",
+ "symphonia",
  "thiserror 2.0.20",
  "time",
  "tokio",
@@ -5602,16 +5465,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rand_distr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
-dependencies = [
- "num-traits",
- "rand 0.10.2",
-]
-
-[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5882,22 +5735,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rodio"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a536bb79db59098ef71a4dd4246c02eb87b316deceb1b68e0cde7167ec01eb"
-dependencies = [
- "cpal",
- "dasp_sample",
- "num-rational",
- "rand 0.10.2",
- "rand_distr",
- "rtrb",
- "symphonia",
- "thiserror 2.0.20",
-]
-
-[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5932,12 +5769,6 @@ dependencies = [
  "rand 0.8.6",
  "simple_asn1",
 ]
-
-[[package]]
-name = "rtrb"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ade083ccbb4bf536df69d1f6432cc23deb7acccff86b183f3923a6fd56a1153"
 
 [[package]]
 name = "rustc-hash"
@@ -6886,61 +6717,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
 dependencies = [
  "lazy_static",
- "symphonia-bundle-flac",
- "symphonia-bundle-mp3",
- "symphonia-codec-aac",
- "symphonia-codec-pcm",
  "symphonia-codec-vorbis",
  "symphonia-core",
- "symphonia-format-isomp4",
  "symphonia-format-ogg",
- "symphonia-format-riff",
  "symphonia-metadata",
-]
-
-[[package]]
-name = "symphonia-bundle-flac"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
-dependencies = [
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-bundle-mp3"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
-dependencies = [
- "lazy_static",
- "log",
- "symphonia-core",
- "symphonia-metadata",
-]
-
-[[package]]
-name = "symphonia-codec-aac"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
-dependencies = [
- "lazy_static",
- "log",
- "symphonia-core",
-]
-
-[[package]]
-name = "symphonia-codec-pcm"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
-dependencies = [
- "log",
- "symphonia-core",
 ]
 
 [[package]]
@@ -6968,19 +6748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "symphonia-format-isomp4"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
-dependencies = [
- "encoding_rs",
- "log",
- "symphonia-core",
- "symphonia-metadata",
- "symphonia-utils-xiph",
-]
-
-[[package]]
 name = "symphonia-format-ogg"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6990,18 +6757,6 @@ dependencies = [
  "symphonia-core",
  "symphonia-metadata",
  "symphonia-utils-xiph",
-]
-
-[[package]]
-name = "symphonia-format-riff"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
-dependencies = [
- "extended",
- "log",
- "symphonia-core",
- "symphonia-metadata",
 ]
 
 [[package]]

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ client-pre-pr:
     @cargo clippy -p pomme-client --release --all-targets --all-features -- -D warnings
     @cargo clippy -p pomme-protocol --release --all-targets --all-features -- -D warnings
     @cargo test -p pomme-protocol
-    @cargo test -p pomme-client -- net::azalea_compat world::block renderer::camera:: ui::menu:: player::tests::
+    @cargo test -p pomme-client -- net::azalea_compat world::block renderer::camera:: ui::menu:: player::tests:: audio::
 
 # Regenerate a version's packet-id table from the decompiled reference.
 protogen version="26.2":

--- a/justfile
+++ b/justfile
@@ -12,15 +12,24 @@ launcher-pre-pr:
     @cargo clippy -p pomme-launcher --release --all-targets --all-features -- -D warnings
     @pnpm --filter pomme-launcher pre-pr
 
-client-dev *args:
+# Stage Minecraft's OpenAL Soft next to the dev binaries, as the release job does.
+openal:
+    #!/usr/bin/env bash
+    python=$(command -v python3 || command -v python) || {
+        echo "warning: no python on PATH, skipping OpenAL staging (audio will be disabled)" >&2
+        exit 0
+    }
+    "$python" tools/fetch_openal.py target/debug target/release
+
+client-dev *args: openal
     @cargo run -p pomme-client {{ args }}
 
 # Optimized release client for accurate benchmarking (supplies the launch token the guard needs).
-client-release *args:
+client-release *args: openal
     #!/usr/bin/env bash
     cargo run --release -p pomme-client -- --launch-token "$(mktemp)" {{ args }}
 
-client-build *args:
+client-build *args: openal
     @cargo build -p pomme-client {{ args }}
 
 client-pre-pr:
@@ -29,7 +38,7 @@ client-pre-pr:
     @cargo clippy -p pomme-client --release --all-targets --all-features -- -D warnings
     @cargo clippy -p pomme-protocol --release --all-targets --all-features -- -D warnings
     @cargo test -p pomme-protocol
-    @cargo test -p pomme-client -- net::azalea_compat world::block renderer::camera:: ui::menu:: player::tests:: audio::
+    @cargo test -p pomme-client -- net::azalea_compat world::block renderer::camera:: ui::menu:: player::tests:: audio:: net::handler::
 
 # Regenerate a version's packet-id table from the decompiled reference.
 protogen version="26.2":

--- a/pomme-client/Cargo.toml
+++ b/pomme-client/Cargo.toml
@@ -57,6 +57,7 @@ simdnbt = "0.10"
 discord-rich-presence = "1.1"
 arboard = { version = "3", features = ["wayland-data-control"] }
 scopeguard = "1.2"
-rodio = "0.22"
+libloading = "0.8"
+symphonia = { version = "0.5.5", default-features = false, features = ["ogg", "vorbis"] }
 fastrand = "2"
 gilrs = "0.11.2"

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -485,9 +485,17 @@ impl AppCore {
     }
 
     pub fn clear_server_resource_packs(&mut self, renderer: &mut Renderer) {
-        if !self.resource_packs.clear_server_packs() {
-            return;
+        if self.resource_packs.clear_server_packs() {
+            self.reload_pack_assets(renderer);
         }
+    }
+
+    /// Rebuilds every asset a pack can override. Only call this once the
+    /// active stack has really changed: it waits for device idle, drops the
+    /// block cache and rebuilds the texture atlas. Clearing
+    /// `menu.reload_assets` is safe here because the pending local-pack toggle
+    /// it stands for is covered by the reload we just did.
+    fn reload_pack_assets(&mut self, renderer: &mut Renderer) {
         self.menu.active_packs = self.resource_packs.active_pack_info();
         renderer.reload_assets(&self.data_dirs.game_dir, &self.resource_packs);
         self.audio.reload_assets(&self.resource_packs);
@@ -1569,15 +1577,14 @@ impl AppCore {
                     });
                 }
                 NetworkEvent::ResourcePackPop { id } => {
-                    if let Some(id) = id {
-                        self.resource_packs.remove_server_pack(&id);
-                    } else {
-                        self.resource_packs.clear_server_packs();
+                    // A server may pop an id it already popped, or never pushed.
+                    let removed = match id {
+                        Some(id) => self.resource_packs.remove_server_pack(&id),
+                        None => self.resource_packs.clear_server_packs(),
+                    };
+                    if removed {
+                        self.reload_pack_assets(renderer);
                     }
-                    self.menu.active_packs = self.resource_packs.active_pack_info();
-                    renderer.reload_assets(&self.data_dirs.game_dir, &self.resource_packs);
-                    self.audio.reload_assets(&self.resource_packs);
-                    self.menu.reload_assets = false;
                 }
                 NetworkEvent::Reconfiguring => {
                     tracing::info!("Server re-entered configuration");
@@ -1650,9 +1657,8 @@ impl AppCore {
                     self.resource_packs
                         .apply_server_pack(pending.id, &pending.hash);
                     tracing::info!("Resource pack {} loaded successfully", pending.id);
-                    renderer.reload_assets(&self.data_dirs.game_dir, &self.resource_packs);
-                    self.audio.reload_assets(&self.resource_packs);
-                    self.menu.reload_assets = false;
+                    // `apply_server_pack` always changes the stack.
+                    self.reload_pack_assets(renderer);
                     s_resource_pack::Action::SuccessfullyLoaded
                 }
             };

--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -282,6 +282,7 @@ impl AppCore {
         let audio = crate::audio::AudioEngine::new(
             &data_dirs.jar_assets_dir,
             asset_index.clone(),
+            &resource_packs,
             menu.category_volumes(),
         );
         let (player_skin_tx, player_skin_rx) = crossbeam_channel::unbounded();
@@ -481,6 +482,16 @@ impl AppCore {
         self.player_faces.clear();
         self.player_faces_dirty = false;
         renderer.clear_player_entity_skins();
+    }
+
+    pub fn clear_server_resource_packs(&mut self, renderer: &mut Renderer) {
+        if !self.resource_packs.clear_server_packs() {
+            return;
+        }
+        self.menu.active_packs = self.resource_packs.active_pack_info();
+        renderer.reload_assets(&self.data_dirs.game_dir, &self.resource_packs);
+        self.audio.reload_assets(&self.resource_packs);
+        self.menu.reload_assets = false;
     }
 
     pub fn drain_network_events(
@@ -1066,14 +1077,26 @@ impl AppCore {
                     pitch,
                     seed,
                 } => {
+                    if game.silent_entities.contains(&entity_id) {
+                        continue;
+                    }
                     let pos = (entity_id == game.player.entity_id)
-                        .then_some(game.player.position + dvec3(0.0, 1.0, 0.0))
-                        .or_else(|| game.entity_store.living.get(&entity_id).map(|e| e.position));
+                        .then_some(game.player.position)
+                        .or_else(|| game.entity_positions.get(&entity_id).copied());
 
                     if let Some(pos) = pos {
-                        self.audio
-                            .play_world_sound(&sound, category, pos, volume, pitch, seed);
+                        self.audio.play_entity_sound(
+                            &sound,
+                            category,
+                            crate::audio::EntitySoundTarget { id: entity_id, pos },
+                            volume,
+                            pitch,
+                            seed,
+                        );
                     }
+                }
+                NetworkEvent::StopSound { sound_id, category } => {
+                    self.audio.stop_sounds(sound_id.as_deref(), category);
                 }
                 NetworkEvent::GameModeChanged {
                     game_mode,
@@ -1197,6 +1220,8 @@ impl AppCore {
                     x_rot_deg,
                     head_y_rot_deg,
                 } => {
+                    game.entity_positions.insert(id, position);
+                    game.silent_entities.remove(&id);
                     if crate::entity::is_living_mob(&entity_type) {
                         let player_uuid = (entity_type
                             == azalea_registry::builtin::EntityKind::Player)
@@ -1232,6 +1257,10 @@ impl AppCore {
                     game.entity_store
                         .move_living_delta(id, dx, dy, dz, on_ground);
                     game.item_entity_store.move_delta(id, dx, dy, dz, on_ground);
+                    if let Some(pos) = game.entity_positions.get_mut(&id) {
+                        *pos += dvec3(dx, dy, dz);
+                        self.audio.update_entity_sound_position(id, *pos);
+                    }
                 }
                 NetworkEvent::EntityMovedRotated {
                     id,
@@ -1247,6 +1276,10 @@ impl AppCore {
                     game.entity_store
                         .rotate_living(id, y_rot_deg, x_rot_deg, on_ground);
                     game.item_entity_store.move_delta(id, dx, dy, dz, on_ground);
+                    if let Some(pos) = game.entity_positions.get_mut(&id) {
+                        *pos += dvec3(dx, dy, dz);
+                        self.audio.update_entity_sound_position(id, *pos);
+                    }
                 }
                 NetworkEvent::EntityRotated {
                     id,
@@ -1277,6 +1310,8 @@ impl AppCore {
                     }
                     game.item_entity_store
                         .teleport(id, position, velocity, on_ground);
+                    game.entity_positions.insert(id, position);
+                    self.audio.update_entity_sound_position(id, position);
                 }
                 NetworkEvent::LevelEvent {
                     event_type,
@@ -1330,6 +1365,9 @@ impl AppCore {
                         {
                             self.remove_player_skin(renderer, &uuid);
                         }
+                        game.entity_positions.remove(id);
+                        game.silent_entities.remove(id);
+                        self.audio.stop_entity_sounds(*id);
                     }
                     game.item_entity_store.remove(&ids);
                     if game.controlled_vehicle_id.is_some_and(|v| ids.contains(&v)) {
@@ -1364,6 +1402,16 @@ impl AppCore {
                     );
                 }
                 NetworkEvent::EntityData { id, index, value } => {
+                    if index == 4
+                        && let crate::entity::MetaValue::Bool(silent) = &value
+                    {
+                        if *silent {
+                            game.silent_entities.insert(id);
+                            self.audio.stop_entity_sounds(id);
+                        } else {
+                            game.silent_entities.remove(&id);
+                        }
+                    }
                     game.entity_store.apply_entity_data(id, index, value);
                 }
                 NetworkEvent::EntityPose { id, is_crouching } => {
@@ -1455,7 +1503,7 @@ impl AppCore {
                     {
                         // Vanilla plays this client-side in handleTakeItemEntity.
                         self.audio.play_world_sound(
-                            &crate::audio::SoundRef::Event("entity.item.pickup".to_string()),
+                            &crate::audio::SoundRef::event("entity.item.pickup"),
                             crate::audio::CATEGORY_PLAYERS,
                             item_pos,
                             0.2,
@@ -1527,12 +1575,17 @@ impl AppCore {
                         self.resource_packs.clear_server_packs();
                     }
                     self.menu.active_packs = self.resource_packs.active_pack_info();
-                    self.menu.reload_assets = true;
+                    renderer.reload_assets(&self.data_dirs.game_dir, &self.resource_packs);
+                    self.audio.reload_assets(&self.resource_packs);
+                    self.menu.reload_assets = false;
                 }
                 NetworkEvent::Reconfiguring => {
                     tracing::info!("Server re-entered configuration");
+                    self.audio.stop_all_sounds();
                     game.entity_store = crate::entity::EntityStore::new();
                     game.item_entity_store = crate::entity::ItemEntityStore::new();
+                    game.entity_positions.clear();
+                    game.silent_entities.clear();
                     game.action_bar = None;
                     game.waypoints = crate::world::waypoints::WaypointMap::default();
                     self.clear_server_ui(game, renderer);
@@ -1597,7 +1650,9 @@ impl AppCore {
                     self.resource_packs
                         .apply_server_pack(pending.id, &pending.hash);
                     tracing::info!("Resource pack {} loaded successfully", pending.id);
-                    self.menu.reload_assets = true;
+                    renderer.reload_assets(&self.data_dirs.game_dir, &self.resource_packs);
+                    self.audio.reload_assets(&self.resource_packs);
+                    self.menu.reload_assets = false;
                     s_resource_pack::Action::SuccessfullyLoaded
                 }
             };

--- a/pomme-client/src/app/mod.rs
+++ b/pomme-client/src/app/mod.rs
@@ -622,6 +622,7 @@ impl ApplicationHandler for App {
                                 game,
                             },
                             ConnectingUpdateResult::ManualDisconnect => {
+                                core.clear_server_resource_packs(&mut gfx.renderer);
                                 gfx.renderer.clear_chunk_meshes();
 
                                 if let Some(p) = &mut core.presence {
@@ -632,6 +633,7 @@ impl ApplicationHandler for App {
                                 AppPhase::InMenu { gfx, panorama }
                             }
                             ConnectingUpdateResult::Disconnected { reason } => {
+                                core.clear_server_resource_packs(&mut gfx.renderer);
                                 gfx.renderer.clear_chunk_meshes();
                                 core.menu.show_disconnect(reason);
 
@@ -674,6 +676,8 @@ impl ApplicationHandler for App {
                                 game,
                             },
                             GameUpdateResult::ManualDisconnect => {
+                                core.audio.stop_all_sounds();
+                                core.clear_server_resource_packs(&mut gfx.renderer);
                                 gfx.renderer.clear_chunk_meshes();
 
                                 if let Some(p) = &mut core.presence {
@@ -687,6 +691,8 @@ impl ApplicationHandler for App {
                                 }
                             }
                             GameUpdateResult::Disconnected { reason } => {
+                                core.audio.stop_all_sounds();
+                                core.clear_server_resource_packs(&mut gfx.renderer);
                                 gfx.renderer.clear_chunk_meshes();
                                 core.menu.show_disconnect(reason);
 

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -105,6 +105,12 @@ pub struct GameState {
     /// dirty; consumed by the visibility refresh as its new-loads signal.
     pub pending_load_rescan: bool,
     pub entity_store: EntityStore,
+    /// Last server position for every spawned entity, including entity kinds
+    /// Pomme does not otherwise render. Used by packet-driven entity-bound
+    /// sounds.
+    pub entity_positions: HashMap<i32, Position>,
+    /// Entity ids whose shared `DATA_SILENT` flag is currently true.
+    pub silent_entities: HashSet<i32>,
     pub position_set: bool,
     pub player_loaded_sent: bool,
     pub player: LocalPlayer,
@@ -302,6 +308,8 @@ impl GameState {
             pending_load_rescan: false,
             chunk_store,
             entity_store: EntityStore::new(),
+            entity_positions: HashMap::new(),
+            silent_entities: HashSet::new(),
             position_set: false,
             player_loaded_sent: false,
             options_from_game: false,
@@ -1356,8 +1364,13 @@ pub fn update_game(
     // Position the audio listener at the player's head and push current
     // volumes before draining sound packets this frame.
     let listener_pos = game.player.eye_pos();
+    core.audio.set_listener(
+        listener_pos,
+        game.player.look_dir.y_rot_deg(),
+        game.player.look_dir.x_rot_deg(),
+    );
     core.audio
-        .set_listener(listener_pos, game.player.look_dir.y_rot_deg());
+        .update_entity_sound_position(game.player.entity_id, game.player.position);
     core.audio.set_volumes(core.menu.category_volumes());
     core.audio.set_subtitles_enabled(core.menu.show_subtitles);
 
@@ -1477,7 +1490,7 @@ pub fn update_game(
             // Vanilla forLocalAmbience: AMBIENT category at the listener,
             // volume 0.25, pitch 0.8..1.2.
             core.audio.play_world_sound(
-                &SoundRef::Event("block.portal.trigger".into()),
+                &SoundRef::event("block.portal.trigger"),
                 CATEGORY_AMBIENT,
                 game.player.position,
                 0.25,
@@ -1791,7 +1804,7 @@ pub fn update_game(
                 let volume = 0.5 + 0.1 * (bubbles.empty - 3 + 1).max(0) as f32;
                 let pitch = 1.0 + 0.1 * (bubbles.empty - 5 + 1).max(0) as f32;
                 core.audio.play_world_sound(
-                    &SoundRef::Event("ui.hud.bubble_pop".into()),
+                    &SoundRef::event("ui.hud.bubble_pop"),
                     CATEGORY_PLAYERS,
                     game.player.position,
                     volume,

--- a/pomme-client/src/app/phases/in_menu.rs
+++ b/pomme-client/src/app/phases/in_menu.rs
@@ -100,6 +100,7 @@ pub fn update_menu(
         core.menu.reload_assets = false;
         gfx.renderer
             .reload_assets(&core.data_dirs.game_dir, &core.resource_packs);
+        core.audio.reload_assets(&core.resource_packs);
     }
 
     if result.clicked_button {

--- a/pomme-client/src/audio/decoder.rs
+++ b/pomme-client/src/audio/decoder.rs
@@ -1,0 +1,204 @@
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use symphonia::core::audio::SampleBuffer;
+use symphonia::core::codecs::{CODEC_TYPE_NULL, Decoder, DecoderOptions};
+use symphonia::core::errors::Error as SymphoniaError;
+use symphonia::core::formats::{FormatOptions, FormatReader};
+use symphonia::core::io::{MediaSourceStream, MediaSourceStreamOptions};
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct PcmFormat {
+    pub channels: u16,
+    pub sample_rate: u32,
+}
+
+#[derive(Debug)]
+pub(super) struct DecodedSound {
+    pub format: PcmFormat,
+    pub samples: Vec<i16>,
+}
+
+pub(super) struct StreamDecoder {
+    path: PathBuf,
+    format_reader: Box<dyn FormatReader>,
+    decoder: Box<dyn Decoder>,
+    track_id: u32,
+    format: PcmFormat,
+    pending: Vec<i16>,
+    pending_offset: usize,
+}
+
+impl StreamDecoder {
+    pub fn open(path: &Path) -> Result<Self, String> {
+        let file =
+            File::open(path).map_err(|e| format!("failed to open {}: {e}", path.display()))?;
+        let stream = MediaSourceStream::new(Box::new(file), MediaSourceStreamOptions::default());
+        let mut hint = Hint::new();
+        hint.with_extension("ogg");
+        let probed = symphonia::default::get_probe()
+            .format(
+                &hint,
+                stream,
+                &FormatOptions::default(),
+                &MetadataOptions::default(),
+            )
+            .map_err(|e| format!("failed to probe {}: {e}", path.display()))?;
+        let format_reader = probed.format;
+        let track = format_reader
+            .default_track()
+            .ok_or_else(|| format!("{} has no default audio track", path.display()))?;
+        if track.codec_params.codec == CODEC_TYPE_NULL {
+            return Err(format!("{} has no decodable codec", path.display()));
+        }
+        let channels = track
+            .codec_params
+            .channels
+            .ok_or_else(|| format!("{} has no channel metadata", path.display()))?
+            .count();
+        let channels = u16::try_from(channels)
+            .map_err(|_| format!("{} has too many channels", path.display()))?;
+        if !matches!(channels, 1 | 2) {
+            return Err(format!(
+                "{} uses unsupported {channels}-channel audio",
+                path.display()
+            ));
+        }
+        let sample_rate = track
+            .codec_params
+            .sample_rate
+            .ok_or_else(|| format!("{} has no sample-rate metadata", path.display()))?;
+        let track_id = track.id;
+        let decoder = symphonia::default::get_codecs()
+            .make(&track.codec_params, &DecoderOptions::default())
+            .map_err(|e| format!("failed to create decoder for {}: {e}", path.display()))?;
+
+        Ok(Self {
+            path: path.to_path_buf(),
+            format_reader,
+            decoder,
+            track_id,
+            format: PcmFormat {
+                channels,
+                sample_rate,
+            },
+            pending: Vec::new(),
+            pending_offset: 0,
+        })
+    }
+
+    pub fn format(&self) -> PcmFormat {
+        self.format
+    }
+
+    pub fn read_samples(&mut self, max_samples: usize) -> Result<Vec<i16>, String> {
+        let mut output = Vec::with_capacity(max_samples);
+        self.drain_pending(&mut output, max_samples);
+
+        while output.len() < max_samples {
+            let packet = match self.format_reader.next_packet() {
+                Ok(packet) => packet,
+                Err(SymphoniaError::ResetRequired) => {
+                    self.decoder.reset();
+                    continue;
+                }
+                Err(SymphoniaError::IoError(e))
+                    if e.kind() == std::io::ErrorKind::UnexpectedEof =>
+                {
+                    break;
+                }
+                Err(e) => {
+                    return Err(format!("failed to read {}: {e}", self.path.display()));
+                }
+            };
+            if packet.track_id() != self.track_id {
+                continue;
+            }
+            let decoded = match self.decoder.decode(&packet) {
+                Ok(decoded) => decoded,
+                Err(SymphoniaError::DecodeError(_)) => continue,
+                Err(SymphoniaError::ResetRequired) => {
+                    self.decoder.reset();
+                    continue;
+                }
+                Err(SymphoniaError::IoError(e))
+                    if e.kind() == std::io::ErrorKind::UnexpectedEof =>
+                {
+                    break;
+                }
+                Err(e) => {
+                    return Err(format!("failed to decode {}: {e}", self.path.display()));
+                }
+            };
+
+            let spec = *decoded.spec();
+            if spec.channels.count() != usize::from(self.format.channels)
+                || spec.rate != self.format.sample_rate
+            {
+                return Err(format!(
+                    "{} changed PCM format mid-stream",
+                    self.path.display()
+                ));
+            }
+            let mut samples = SampleBuffer::<f32>::new(decoded.capacity() as u64, spec);
+            samples.copy_interleaved_ref(decoded);
+            self.pending.clear();
+            self.pending
+                .extend(samples.samples().iter().copied().map(vanilla_pcm_i16));
+            self.pending_offset = 0;
+            self.drain_pending(&mut output, max_samples);
+        }
+
+        Ok(output)
+    }
+
+    fn drain_pending(&mut self, output: &mut Vec<i16>, max_samples: usize) {
+        let wanted = max_samples.saturating_sub(output.len());
+        let available = self.pending.len().saturating_sub(self.pending_offset);
+        let take = wanted.min(available);
+        output.extend_from_slice(&self.pending[self.pending_offset..self.pending_offset + take]);
+        self.pending_offset += take;
+        if self.pending_offset == self.pending.len() {
+            self.pending.clear();
+            self.pending_offset = 0;
+        }
+    }
+}
+
+pub(super) fn decode_all(path: &Path) -> Result<DecodedSound, String> {
+    let mut decoder = StreamDecoder::open(path)?;
+    let format = decoder.format();
+    let chunk_samples = usize::try_from(format.sample_rate)
+        .unwrap_or(usize::MAX)
+        .saturating_mul(usize::from(format.channels));
+    let mut samples = Vec::new();
+    loop {
+        let chunk = decoder.read_samples(chunk_samples)?;
+        if chunk.is_empty() {
+            break;
+        }
+        samples.extend(chunk);
+    }
+    Ok(DecodedSound { format, samples })
+}
+
+pub(super) fn vanilla_pcm_i16(sample: f32) -> i16 {
+    let value = (sample * 32767.5 - 0.5) as i32;
+    value.clamp(i16::MIN as i32, i16::MAX as i32) as i16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pcm_conversion_matches_vanilla_boundaries() {
+        assert_eq!(vanilla_pcm_i16(-2.0), i16::MIN);
+        assert_eq!(vanilla_pcm_i16(-1.0), i16::MIN);
+        assert_eq!(vanilla_pcm_i16(0.0), 0);
+        assert_eq!(vanilla_pcm_i16(1.0), i16::MAX);
+        assert_eq!(vanilla_pcm_i16(2.0), i16::MAX);
+    }
+}

--- a/pomme-client/src/audio/mod.rs
+++ b/pomme-client/src/audio/mod.rs
@@ -177,6 +177,10 @@ enum AudioCommand {
 #[derive(Debug)]
 enum AudioEvent {
     Finished(u64),
+    /// Balances one entity-bound play command, whether the sound ended, was
+    /// stopped, or was refused. The engine counts these rather than tracking
+    /// an idle flag, which would race a sound dispatched in between.
+    EntitySoundEnded(i32),
 }
 
 /// Plays menu and in-world sounds using a dedicated OpenAL worker thread.
@@ -193,6 +197,10 @@ pub struct AudioEngine {
     subtitles_enabled: bool,
     subtitle_events: std::sync::Mutex<Vec<QueuedSubtitle>>,
     next_id: AtomicU64,
+    /// Entity ids to the number of dispatched sounds the worker has not yet
+    /// reported ended. Only these entities get position updates. The worker
+    /// drives every decrement, so this is never cleared directly.
+    entity_sound_targets: HashMap<i32, u32>,
     music_id: Option<u64>,
     menu_music_active: bool,
     next_song_delay_ticks: i32,
@@ -208,7 +216,9 @@ impl AudioEngine {
     ) -> Self {
         let sounds = SoundsIndex::load(jar_assets_dir, &asset_index, packs);
         let (command_tx, command_rx) = crossbeam_channel::unbounded();
-        let (event_tx, event_rx) = crossbeam_channel::bounded(1);
+        // The worker reports with `try_send`, and a dropped `Finished` would
+        // park the menu-music delay at `i32::MAX` forever.
+        let (event_tx, event_rx) = crossbeam_channel::unbounded();
         let (init_tx, init_rx) = crossbeam_channel::bounded(1);
 
         let worker = std::thread::Builder::new()
@@ -236,7 +246,11 @@ impl AudioEngine {
                     (Some(command_tx), Some(handle))
                 }
                 Ok(Err(e)) => {
-                    tracing::warn!("audio disabled: failed to initialize OpenAL ({e})");
+                    tracing::warn!(
+                        "audio disabled: failed to initialize OpenAL ({e}). \
+                         Releases ship the library next to the binary; for a dev \
+                         build run `just openal` to stage it."
+                    );
                     let _ = handle.join();
                     (None, None)
                 }
@@ -252,22 +266,62 @@ impl AudioEngine {
             }
         };
 
+        Self::attached(
+            command_tx,
+            event_rx,
+            worker,
+            jar_assets_dir.to_path_buf(),
+            asset_index,
+            sounds,
+            volumes,
+        )
+    }
+
+    /// Wraps an already-running (or absent) worker.
+    fn attached(
+        command_tx: Option<Sender<AudioCommand>>,
+        event_rx: Receiver<AudioEvent>,
+        worker: Option<JoinHandle<()>>,
+        jar_assets_dir: PathBuf,
+        asset_index: Option<AssetIndex>,
+        sounds: SoundsIndex,
+        volumes: [f32; SoundCategory::COUNT],
+    ) -> Self {
         Self {
             command_tx,
             event_rx,
             worker,
-            jar_assets_dir: jar_assets_dir.to_path_buf(),
+            jar_assets_dir,
             asset_index,
             sounds,
             volumes,
             subtitles_enabled: false,
             subtitle_events: std::sync::Mutex::new(Vec::new()),
             next_id: AtomicU64::new(1),
+            entity_sound_targets: HashMap::new(),
             music_id: None,
             menu_music_active: false,
             next_song_delay_ticks: MENU_MUSIC_STARTING_DELAY_TICKS,
             music_tick_accumulator: 0.0,
         }
+    }
+
+    /// An engine wired to plain channels instead of a worker thread, so a test
+    /// can feed it worker reports and read back the commands it emits.
+    #[cfg(test)]
+    fn for_test() -> (Self, Sender<AudioEvent>, Receiver<AudioCommand>) {
+        let (command_tx, command_rx) = crossbeam_channel::unbounded();
+        let (event_tx, event_rx) = crossbeam_channel::unbounded();
+        let engine = Self::attached(
+            Some(command_tx),
+            event_rx,
+            None,
+            PathBuf::new(),
+            None,
+            SoundsIndex::default(),
+            [1.0; SoundCategory::COUNT],
+        );
+        (engine, event_tx, command_rx)
     }
 
     pub fn set_volumes(&mut self, volumes: [f32; SoundCategory::COUNT]) {
@@ -282,15 +336,28 @@ impl AudioEngine {
     /// stack and clears native sources/buffers that may reference old assets.
     pub fn reload_assets(&mut self, packs: &ResourcePackManager) {
         self.sounds = SoundsIndex::load(&self.jar_assets_dir, &self.asset_index, packs);
-        let had_music = self.music_id.take().is_some();
-        if had_music && self.menu_music_active {
-            self.next_song_delay_ticks = random_menu_delay_ticks();
-        }
+        self.forget_active_sounds();
         self.send(AudioCommand::ReloadAssets);
     }
 
+    /// Forgets the sounds the worker is about to drop without reporting
+    /// completion. `play_menu_track` parks the delay at `i32::MAX` and waits
+    /// for that report, so the delay has to be re-rolled here or menu music
+    /// never starts again. Vanilla's `SoundEngine.stopAll` and `reload` both
+    /// clear `soundDeleteTime` outright, so the 20-tick logical retention
+    /// does not apply on either path.
+    fn forget_active_sounds(&mut self) {
+        // `entity_sound_targets` is deliberately untouched; the worker reports
+        // the sounds it drops here too, and those reports balance the counts.
+        if self.music_id.take().is_some() && self.menu_music_active {
+            self.next_song_delay_ticks = random_menu_delay_ticks();
+        }
+    }
+
     /// Updates the listener using the camera's full yaw/pitch orientation.
+    /// Also the in-game per-frame entry point, so it drains worker reports.
     pub fn set_listener(&mut self, pos: Position, y_rot_deg: f32, x_rot_deg: f32) {
+        self.poll_events();
         let (forward, up) = listener_vectors(y_rot_deg, x_rot_deg);
         self.send(AudioCommand::SetListener {
             position: [pos.x as f32, pos.y as f32, pos.z as f32],
@@ -354,7 +421,7 @@ impl AudioEngine {
     }
 
     pub fn play_entity_sound(
-        &self,
+        &mut self,
         sound_ref: &SoundRef,
         category: u8,
         target: EntitySoundTarget,
@@ -362,7 +429,8 @@ impl AudioEngine {
         pitch: f32,
         seed: u64,
     ) {
-        self.play_positioned_sound(
+        // Only a dispatched sound gets an end report to balance the count.
+        if self.play_positioned_sound(
             sound_ref,
             category,
             target.pos,
@@ -370,9 +438,12 @@ impl AudioEngine {
             pitch,
             seed,
             Some(target.id),
-        );
+        ) {
+            *self.entity_sound_targets.entry(target.id).or_default() += 1;
+        }
     }
 
+    /// Returns whether the sound resolved and was handed to the worker.
     #[allow(clippy::too_many_arguments)]
     fn play_positioned_sound(
         &self,
@@ -383,9 +454,9 @@ impl AudioEngine {
         pitch: f32,
         seed: u64,
         entity_id: Option<i32>,
-    ) {
+    ) -> bool {
         let Some(sound) = self.resolve_sound(sound_ref, Some(seed)) else {
-            return;
+            return false;
         };
         let instance_volume = volume * sound.entry_volume;
 
@@ -418,16 +489,27 @@ impl AudioEngine {
             entity_id,
             report_completion: false,
         }));
+        self.command_tx.is_some()
     }
 
+    /// Every entity move packet reaches this, so entities with no sound of
+    /// their own are filtered out before the worker scans for a match.
     pub fn update_entity_sound_position(&self, entity_id: i32, pos: Position) {
+        if !self.entity_sound_targets.contains_key(&entity_id) {
+            return;
+        }
         self.send(AudioCommand::UpdateEntityPosition {
             entity_id,
             position: [pos.x as f32, pos.y as f32, pos.z as f32],
         });
     }
 
-    pub fn stop_entity_sounds(&self, entity_id: i32) {
+    pub fn stop_entity_sounds(&mut self, entity_id: i32) {
+        if !self.entity_sound_targets.contains_key(&entity_id) {
+            return;
+        }
+        // The count stays until the worker reports each stopped sound, so one
+        // dispatched before the worker drains this is still tracked.
         self.send(AudioCommand::StopEntity(entity_id));
     }
 
@@ -451,7 +533,7 @@ impl AudioEngine {
     /// Stops all currently active native sources. Static buffer cache remains
     /// valid and is released with the audio context at shutdown.
     pub fn stop_all_sounds(&mut self) {
-        self.music_id = None;
+        self.forget_active_sounds();
         self.send(AudioCommand::StopAll);
     }
 
@@ -467,15 +549,34 @@ impl AudioEngine {
         });
     }
 
+    /// Drains everything the worker has reported. Both phases call this every
+    /// frame, so it must stay independent of whether menu music is running.
+    pub fn poll_events(&mut self) {
+        while let Ok(event) = self.event_rx.try_recv() {
+            match event {
+                AudioEvent::Finished(id) => {
+                    if self.music_id == Some(id) {
+                        self.music_id = None;
+                        self.next_song_delay_ticks =
+                            menu_delay_after_finish(random_menu_delay_ticks());
+                    }
+                }
+                AudioEvent::EntitySoundEnded(entity_id) => {
+                    if let Some(count) = self.entity_sound_targets.get_mut(&entity_id) {
+                        *count -= 1;
+                        if *count == 0 {
+                            self.entity_sound_targets.remove(&entity_id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     pub fn update_menu_music(&mut self, dt: f32) {
+        self.poll_events();
         if self.command_tx.is_none() || !self.menu_music_active {
             return;
-        }
-        while let Ok(AudioEvent::Finished(id)) = self.event_rx.try_recv() {
-            if self.music_id == Some(id) {
-                self.music_id = None;
-                self.next_song_delay_ticks = menu_delay_after_finish(random_menu_delay_ticks());
-            }
         }
 
         self.music_tick_accumulator += dt.max(0.0);
@@ -636,6 +737,8 @@ impl AudioWorker {
                 self.tick();
             }
         }
+        // The one removal that skips `report_entity_sound_ended`; nothing
+        // reads the counts after shutdown.
         self.active.clear();
         self.static_buffers.clear();
     }
@@ -645,8 +748,14 @@ impl AudioWorker {
             AudioCommand::Play(play) => {
                 let id = play.id;
                 let report_completion = play.report_completion;
-                if !self.play(play) && report_completion {
-                    let _ = self.events.try_send(AudioEvent::Finished(id));
+                let entity_id = play.entity_id;
+                // A refusal still reports, or the engine keeps counting an
+                // entity sound that never got a source.
+                if !self.play(play) {
+                    if report_completion {
+                        let _ = self.events.try_send(AudioEvent::Finished(id));
+                    }
+                    self.report_entity_sound_ended(entity_id);
                 }
             }
             AudioCommand::SetVolumes(volumes) => {
@@ -708,10 +817,10 @@ impl AudioWorker {
                 }
             }
             AudioCommand::StopAll => {
-                self.active.clear();
+                self.clear_active();
             }
             AudioCommand::ReloadAssets => {
-                self.active.clear();
+                self.clear_active();
                 self.static_buffers.clear();
             }
             AudioCommand::Shutdown => return true,
@@ -729,10 +838,25 @@ impl AudioWorker {
         if sound.report_completion {
             let _ = self.events.try_send(AudioEvent::Finished(id));
         }
+        self.report_entity_sound_ended(sound.entity_id);
+    }
+
+    /// Drops every active sound, reporting each so the engine's entity counts
+    /// stay balanced.
+    fn clear_active(&mut self) {
+        let entities: Vec<Option<i32>> = self
+            .active
+            .drain()
+            .map(|(_, sound)| sound.entity_id)
+            .collect();
+        for entity_id in entities {
+            self.report_entity_sound_ended(entity_id);
+        }
     }
 
     fn play(&mut self, play: PlayCommand) -> bool {
-        self.cleanup_finished();
+        // Frees the sources finished sounds still hold before the pool check.
+        self.tick();
         let base_gain = clamped_source_volume(play.volume);
         let gain = category_gain(&self.volumes, play.category) * base_gain;
         if gain == 0.0 && play.category != SoundCategory::Music {
@@ -915,18 +1039,24 @@ impl AudioWorker {
             }
         }
         for id in finished {
-            if self
-                .active
-                .remove(&id)
-                .is_some_and(|sound| sound.report_completion)
-            {
+            let Some(sound) = self.active.remove(&id) else {
+                continue;
+            };
+            if sound.report_completion {
                 let _ = self.events.try_send(AudioEvent::Finished(id));
             }
+            self.report_entity_sound_ended(sound.entity_id);
         }
     }
 
-    fn cleanup_finished(&mut self) {
-        self.tick();
+    /// Every path that removes a sound from `active`, or refuses to add one,
+    /// must call this exactly once or the engine's count never reaches zero.
+    fn report_entity_sound_ended(&self, entity_id: Option<i32>) {
+        if let Some(entity_id) = entity_id {
+            let _ = self
+                .events
+                .try_send(AudioEvent::EntitySoundEnded(entity_id));
+        }
     }
 }
 
@@ -1097,5 +1227,113 @@ mod tests {
     fn ui_matches_vanilla_sound_source_ordinal() {
         assert_eq!(SoundCategory::Ui as usize, 10);
         assert!(matches!(SoundCategory::from_index(10), SoundCategory::Ui));
+    }
+
+    /// Drains the worker's view of the command channel, reporting each
+    /// entity-bound play back the way `AudioWorker` does.
+    fn end_dispatched_sounds(events: &Sender<AudioEvent>, commands: &Receiver<AudioCommand>) {
+        while let Ok(command) = commands.try_recv() {
+            if let AudioCommand::Play(PlayCommand {
+                entity_id: Some(entity_id),
+                ..
+            }) = command
+            {
+                events
+                    .send(AudioEvent::EntitySoundEnded(entity_id))
+                    .unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn entity_sound_end_report_stops_position_forwarding() {
+        let (mut engine, events, commands) = AudioEngine::for_test();
+        engine.entity_sound_targets.insert(7, 1);
+
+        engine.update_entity_sound_position(7, Position::new(1.0, 2.0, 3.0));
+        assert!(matches!(
+            commands.try_recv(),
+            Ok(AudioCommand::UpdateEntityPosition { entity_id: 7, .. })
+        ));
+
+        events.send(AudioEvent::EntitySoundEnded(7)).unwrap();
+        engine.poll_events();
+        assert!(!engine.entity_sound_targets.contains_key(&7));
+
+        engine.update_entity_sound_position(7, Position::new(4.0, 5.0, 6.0));
+        assert!(commands.try_recv().is_err());
+    }
+
+    #[test]
+    fn untracked_entity_never_reaches_the_worker() {
+        let (engine, _events, commands) = AudioEngine::for_test();
+        engine.update_entity_sound_position(7, Position::new(1.0, 2.0, 3.0));
+        assert!(commands.try_recv().is_err());
+    }
+
+    /// A second sound for the same entity must survive the first one's end
+    /// report, which an idle flag rather than a count would drop.
+    #[test]
+    fn overlapping_entity_sounds_keep_tracking_until_the_last_ends() {
+        let (mut engine, events, _commands) = AudioEngine::for_test();
+        engine.entity_sound_targets.insert(7, 2);
+
+        events.send(AudioEvent::EntitySoundEnded(7)).unwrap();
+        engine.poll_events();
+        assert_eq!(engine.entity_sound_targets.get(&7), Some(&1));
+
+        events.send(AudioEvent::EntitySoundEnded(7)).unwrap();
+        engine.poll_events();
+        assert!(!engine.entity_sound_targets.contains_key(&7));
+    }
+
+    /// Stop-all drops sounds the worker never reported finished, so the counts
+    /// must reach zero from its reports, not from the engine clearing them.
+    #[test]
+    fn stop_all_leaves_no_entity_counted() {
+        let (mut engine, events, commands) = AudioEngine::for_test();
+        engine.sounds = SoundsIndex::for_test_event("entity.test");
+
+        for _ in 0..3 {
+            engine.play_entity_sound(
+                &SoundRef::event("entity.test"),
+                CATEGORY_PLAYERS,
+                EntitySoundTarget {
+                    id: 7,
+                    pos: Position::new(0.0, 0.0, 0.0),
+                },
+                1.0,
+                1.0,
+                0,
+            );
+        }
+        assert_eq!(engine.entity_sound_targets.get(&7), Some(&3));
+
+        engine.stop_all_sounds();
+        end_dispatched_sounds(&events, &commands);
+        engine.poll_events();
+        assert!(engine.entity_sound_targets.is_empty());
+    }
+
+    /// Menu music parks the delay at `i32::MAX` until the worker reports the
+    /// track finished, so that report has to survive whatever else is queued.
+    #[test]
+    fn music_finish_report_survives_a_burst_of_entity_reports() {
+        let (mut engine, events, _commands) = AudioEngine::for_test();
+        engine.music_id = Some(42);
+        engine.next_song_delay_ticks = i32::MAX;
+
+        for entity_id in 0..64 {
+            events
+                .send(AudioEvent::EntitySoundEnded(entity_id))
+                .unwrap();
+        }
+        events.send(AudioEvent::Finished(42)).unwrap();
+        engine.poll_events();
+
+        assert_eq!(engine.music_id, None);
+        assert!(
+            engine.next_song_delay_ticks <= menu_delay_after_finish(MENU_MUSIC_MAX_DELAY_TICKS)
+        );
     }
 }

--- a/pomme-client/src/audio/mod.rs
+++ b/pomme-client/src/audio/mod.rs
@@ -1,15 +1,22 @@
+mod decoder;
+mod openal;
 mod sounds;
 
-use std::fs::File;
-use std::io::BufReader;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread::JoinHandle;
+use std::time::Duration;
 
-use rodio::source::ChannelVolume;
-use rodio::{Decoder, DeviceSinkBuilder, MixerDeviceSink, Player};
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 
-use self::sounds::{SoundsIndex, sound_asset_key};
-use crate::assets::{AssetIndex, resolve_asset_path};
+use self::decoder::{StreamDecoder, decode_all};
+use self::openal::{Buffer, Context, Source, SourceState};
+use self::sounds::{SoundVariant, SoundsIndex};
+use crate::assets::AssetIndex;
 use crate::entity::components::Position;
+use crate::resource_pack::ResourcePackManager;
 
 const MENU_MUSIC_EVENT: &str = "music.menu";
 const UI_CLICK_EVENT: &str = "ui.button.click";
@@ -17,21 +24,15 @@ const UI_CLICK_EVENT: &str = "ui.button.click";
 /// Vanilla `SimpleSoundInstance.forUI` plays the click at this fixed volume.
 const UI_CLICK_VOLUME: f32 = 0.25;
 
-/// Vanilla `Music(MUSIC_MENU)` waits a random 20..600 tick gap between tracks
-/// (1.0s..30.0s at 20 ticks/second).
-const MENU_MUSIC_MIN_GAP: f32 = 1.0;
-const MENU_MUSIC_MAX_GAP: f32 = 30.0;
-
-/// Half the distance between the listener's ears, in blocks. Wider values
-/// exaggerate left/right panning.
-const LISTENER_EAR_OFFSET: f32 = 0.5;
-
-/// Vanilla's linear attenuation distance in blocks for a normal sound.
-const SOUND_ATTENUATION_BLOCKS: f32 = 16.0;
+const SOUND_TICK_SECONDS: f32 = 1.0 / 20.0;
+const LOGICAL_SOUND_RETENTION_TICKS: i32 = 20;
+const MENU_MUSIC_STARTING_DELAY_TICKS: i32 = 100;
+const MENU_MUSIC_MIN_DELAY_TICKS: i32 = 20;
+const MENU_MUSIC_MAX_DELAY_TICKS: i32 = 600;
 
 /// Sound categories, matching the protocol `SoundSource` order so a packet's
 /// source index maps straight onto a volume slot.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SoundCategory {
     Master = 0,
     Music = 1,
@@ -43,8 +44,6 @@ pub enum SoundCategory {
     Players = 7,
     Ambient = 8,
     Voice = 9,
-    /// Client-local: azalea's `SoundSource` stops at `Voice`, so no server
-    /// sound reaches this slot.
     Ui = 10,
 }
 
@@ -79,42 +78,42 @@ impl SoundCategory {
     }
 }
 
-/// How a server sound resolves to a file: either a `sounds.json` event (which
-/// maps to one or more variants) or a direct sound-file path.
+/// A sound-event identifier resolved through `sounds.json`.
 #[derive(Clone)]
-pub enum SoundRef {
-    /// A `sounds.json` event name, e.g. `block.stone.break`.
-    Event(String),
-    /// A direct sound path, e.g. `minecraft:custom/foo`.
-    Direct(String),
-}
+pub struct SoundRef(String);
 
 impl SoundRef {
-    /// Resolves a sound holder into either a `sounds.json` event name
-    /// (registry reference) or a direct sound-file path (inline custom sound).
+    pub fn event(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    /// Both registry-backed and inline protocol holders are sound events.
     pub fn resolve(
         holder: &azalea_registry::Holder<
             azalea_registry::builtin::SoundEvent,
             azalea_core::sound::CustomSound,
         >,
     ) -> Self {
-        match holder {
-            azalea_registry::Holder::Reference(event) => {
-                // `to_str` yields e.g. `minecraft:block.stone.break`;
-                // sounds.json is keyed by the path without the namespace.
-                let id = event.to_str();
-                let name = id.strip_prefix("minecraft:").unwrap_or(id);
-                SoundRef::Event(name.to_string())
-            }
-            azalea_registry::Holder::Direct(custom) => {
-                SoundRef::Direct(custom.sound_id.to_string())
-            }
-        }
+        let id = match holder {
+            azalea_registry::Holder::Reference(event) => event.to_str().to_string(),
+            azalea_registry::Holder::Direct(custom) => custom.sound_id.to_string(),
+        };
+        Self::event(id.strip_prefix("minecraft:").unwrap_or(&id))
+    }
+
+    fn event_name(&self) -> &str {
+        &self.0
     }
 }
 
 /// A played sound recorded for the subtitle overlay (vanilla
 /// `SoundEventListener.onPlaySound`).
+#[derive(Clone, Copy, Debug)]
+pub struct EntitySoundTarget {
+    pub id: i32,
+    pub pos: Position,
+}
+
 pub struct QueuedSubtitle {
     /// Subtitle translation key, e.g. `subtitles.block.anvil.land`.
     pub key: String,
@@ -124,118 +123,186 @@ pub struct QueuedSubtitle {
     pub range: f32,
 }
 
-/// The rodio output device. The `MixerDeviceSink` must be kept alive for the
-/// whole program; sounds play by connecting `Player`s to its mixer.
-struct Output {
-    sink: MixerDeviceSink,
+#[derive(Clone, Debug)]
+struct ResolvedSound {
+    sound_id: String,
+    path: PathBuf,
+    entry_volume: f32,
+    entry_pitch: f32,
+    stream: bool,
+    attenuation_distance: f32,
 }
 
-/// Plays menu and in-world sounds, resolving `.ogg` files through the same
-/// asset pipeline used for textures. Degrades to a silent no-op when no audio
-/// output device is available.
+#[derive(Debug)]
+struct PlayCommand {
+    id: u64,
+    sound_id: String,
+    path: PathBuf,
+    category: SoundCategory,
+    volume: f32,
+    pitch: f32,
+    position: [f32; 3],
+    relative: bool,
+    looping: bool,
+    stream: bool,
+    attenuation_distance: Option<f32>,
+    entity_id: Option<i32>,
+    report_completion: bool,
+}
+
+#[derive(Debug)]
+enum AudioCommand {
+    Play(PlayCommand),
+    SetVolumes([f32; SoundCategory::COUNT]),
+    SetListener {
+        position: [f32; 3],
+        forward: [f32; 3],
+        up: [f32; 3],
+    },
+    Stop(u64),
+    StopMatching {
+        sound_id: Option<String>,
+        category: Option<SoundCategory>,
+    },
+    UpdateEntityPosition {
+        entity_id: i32,
+        position: [f32; 3],
+    },
+    StopEntity(i32),
+    StopAll,
+    ReloadAssets,
+    Shutdown,
+}
+
+#[derive(Debug)]
+enum AudioEvent {
+    Finished(u64),
+}
+
+/// Plays menu and in-world sounds using a dedicated OpenAL worker thread.
+/// The public facade contains no native handles; OpenAL device/context/source/
+/// buffer state is created, used, and dropped only by the worker.
 pub struct AudioEngine {
-    output: Option<Output>,
+    command_tx: Option<Sender<AudioCommand>>,
+    event_rx: Receiver<AudioEvent>,
+    worker: Option<JoinHandle<()>>,
     jar_assets_dir: PathBuf,
     asset_index: Option<AssetIndex>,
     sounds: SoundsIndex,
-    /// Per-category volumes (0.0..=1.0), indexed by `SoundCategory as usize`.
     volumes: [f32; SoundCategory::COUNT],
-    listener_left: [f32; 3],
-    listener_right: [f32; 3],
-    /// Mirrors the Show Subtitles option; while off, sounds are never
-    /// recorded (vanilla removes the overlay listener entirely).
     subtitles_enabled: bool,
-    /// Sounds recorded since the last [`Self::take_subtitle_events`] drain.
-    /// A Mutex only because `play_world_sound` takes `&self`.
     subtitle_events: std::sync::Mutex<Vec<QueuedSubtitle>>,
-    music_sink: Option<Player>,
-    /// Per-entry `sounds.json` volume of the track currently in `music_sink`,
-    /// reapplied each frame so live volume changes keep its relative loudness.
-    music_track_volume: f32,
+    next_id: AtomicU64,
+    music_id: Option<u64>,
     menu_music_active: bool,
-    gap_remaining: f32,
+    next_song_delay_ticks: i32,
+    music_tick_accumulator: f32,
 }
 
 impl AudioEngine {
     pub fn new(
         jar_assets_dir: &Path,
         asset_index: Option<AssetIndex>,
+        packs: &ResourcePackManager,
         volumes: [f32; SoundCategory::COUNT],
     ) -> Self {
-        let output = match DeviceSinkBuilder::open_default_sink() {
-            Ok(mut sink) => {
-                // Only dropped at shutdown, so silence rodio's stderr drop warning.
-                sink.log_on_drop(false);
-                Some(Output { sink })
-            }
+        let sounds = SoundsIndex::load(jar_assets_dir, &asset_index, packs);
+        let (command_tx, command_rx) = crossbeam_channel::unbounded();
+        let (event_tx, event_rx) = crossbeam_channel::bounded(1);
+        let (init_tx, init_rx) = crossbeam_channel::bounded(1);
+
+        let worker = std::thread::Builder::new()
+            .name("Pomme Sound engine".to_string())
+            .spawn(move || {
+                let context = match Context::open_default(false) {
+                    Ok(context) => context,
+                    Err(e) => {
+                        let _ = init_tx.send(Err(e));
+                        return;
+                    }
+                };
+                let version = context.version().unwrap_or_else(|| "unknown".to_string());
+                let limits = (context.static_source_limit, context.streaming_source_limit);
+                let _ = init_tx.send(Ok((version, limits)));
+                AudioWorker::new(context, volumes, command_rx, event_tx).run();
+            });
+
+        let (command_tx, worker) = match worker {
+            Ok(handle) => match init_rx.recv() {
+                Ok(Ok((version, (static_limit, streaming_limit)))) => {
+                    tracing::info!(
+                        "OpenAL audio initialized ({version}; {static_limit} static, {streaming_limit} streaming sources)"
+                    );
+                    (Some(command_tx), Some(handle))
+                }
+                Ok(Err(e)) => {
+                    tracing::warn!("audio disabled: failed to initialize OpenAL ({e})");
+                    let _ = handle.join();
+                    (None, None)
+                }
+                Err(e) => {
+                    tracing::warn!("audio disabled: OpenAL worker exited during startup ({e})");
+                    let _ = handle.join();
+                    (None, None)
+                }
+            },
             Err(e) => {
-                tracing::warn!("audio disabled: no output device ({e})");
-                None
+                tracing::warn!("audio disabled: failed to start audio worker ({e})");
+                (None, None)
             }
         };
-        let sounds = SoundsIndex::load(jar_assets_dir, &asset_index);
+
         Self {
-            output,
+            command_tx,
+            event_rx,
+            worker,
             jar_assets_dir: jar_assets_dir.to_path_buf(),
             asset_index,
             sounds,
             volumes,
-            listener_left: [-LISTENER_EAR_OFFSET, 0.0, 0.0],
-            listener_right: [LISTENER_EAR_OFFSET, 0.0, 0.0],
             subtitles_enabled: false,
             subtitle_events: std::sync::Mutex::new(Vec::new()),
-            music_sink: None,
-            music_track_volume: 1.0,
+            next_id: AtomicU64::new(1),
+            music_id: None,
             menu_music_active: false,
-            gap_remaining: 0.0,
+            next_song_delay_ticks: MENU_MUSIC_STARTING_DELAY_TICKS,
+            music_tick_accumulator: 0.0,
         }
     }
 
-    /// Master-scaled gain for a category. The Master category itself is not
-    /// scaled twice.
-    fn category_gain(&self, category: SoundCategory) -> f32 {
-        let master = self.volumes[SoundCategory::Master as usize];
-        match category {
-            SoundCategory::Master => master,
-            other => master * self.volumes[other as usize],
-        }
-    }
-
-    fn current_music_volume(&self) -> f32 {
-        self.category_gain(SoundCategory::Music) * self.music_track_volume
-    }
-
-    /// Sets all per-category volumes (0.0..=1.0), applied live to any playing
-    /// menu track. No-op when the volumes are unchanged, so callers can invoke
-    /// it every frame cheaply.
     pub fn set_volumes(&mut self, volumes: [f32; SoundCategory::COUNT]) {
         if volumes == self.volumes {
             return;
         }
         self.volumes = volumes;
-        if let Some(sink) = self.music_sink.as_ref() {
-            sink.set_volume(self.current_music_volume());
+        self.send(AudioCommand::SetVolumes(volumes));
+    }
+
+    /// Rebuilds the sound-event registry against the current resource-pack
+    /// stack and clears native sources/buffers that may reference old assets.
+    pub fn reload_assets(&mut self, packs: &ResourcePackManager) {
+        self.sounds = SoundsIndex::load(&self.jar_assets_dir, &self.asset_index, packs);
+        let had_music = self.music_id.take().is_some();
+        if had_music && self.menu_music_active {
+            self.next_song_delay_ticks = random_menu_delay_ticks();
         }
+        self.send(AudioCommand::ReloadAssets);
     }
 
-    /// Updates the listener (camera) position and facing for positional audio.
-    pub fn set_listener(&mut self, pos: Position, y_rot_deg: f32) {
-        let y_rot = y_rot_deg.to_radians();
-        let rx = -y_rot.cos() * LISTENER_EAR_OFFSET;
-        let rz = -y_rot.sin() * LISTENER_EAR_OFFSET;
-
-        self.listener_left = [pos.x as f32 - rx, pos.y as f32, pos.z as f32 - rz];
-        self.listener_right = [pos.x as f32 + rx, pos.y as f32, pos.z as f32 + rz];
+    /// Updates the listener using the camera's full yaw/pitch orientation.
+    pub fn set_listener(&mut self, pos: Position, y_rot_deg: f32, x_rot_deg: f32) {
+        let (forward, up) = listener_vectors(y_rot_deg, x_rot_deg);
+        self.send(AudioCommand::SetListener {
+            position: [pos.x as f32, pos.y as f32, pos.z as f32],
+            forward,
+            up,
+        });
     }
 
-    /// Enables or disables subtitle recording. Cheap; callers can invoke it
-    /// every frame.
     pub fn set_subtitles_enabled(&mut self, enabled: bool) {
         self.subtitles_enabled = enabled;
     }
 
-    /// Drains the sounds recorded for the subtitle overlay since the last
-    /// call.
     pub fn take_subtitle_events(&mut self) -> Vec<QueuedSubtitle> {
         std::mem::take(
             self.subtitle_events
@@ -244,210 +311,713 @@ impl AudioEngine {
         )
     }
 
-    /// Plays the vanilla button click: UI category at the fixed `forUI` volume.
     pub fn play_ui_click(&self) {
         self.play_ui_sound(UI_CLICK_EVENT, UI_CLICK_VOLUME, 1.0);
     }
 
-    /// Plays a non-positional UI sound event (vanilla
-    /// `SimpleSoundInstance.forUI`): UI category.
+    /// Plays a non-positional UI sound using Vanilla's relative, no-attenuation
+    /// `SimpleSoundInstance.forUI` semantics.
     pub fn play_ui_sound(&self, event: &str, volume: f32, pitch: f32) {
-        if let Some((sink, entry_volume)) = self.make_sink(event) {
-            sink.set_speed(pitch.max(0.01));
-            sink.set_volume(self.category_gain(SoundCategory::Ui) * volume * entry_volume);
-            sink.detach();
-        }
+        let Some(sound) = self.resolve_event(event, None) else {
+            return;
+        };
+        let id = self.allocate_id();
+        self.send(AudioCommand::Play(PlayCommand {
+            id,
+            sound_id: sound.sound_id,
+            path: sound.path,
+            category: SoundCategory::Ui,
+            volume: volume * sound.entry_volume,
+            pitch: pitch * sound.entry_pitch,
+            position: [0.0, 0.0, 0.0],
+            relative: true,
+            looping: false,
+            stream: sound.stream,
+            attenuation_distance: None,
+            entity_id: None,
+            report_completion: false,
+        }));
     }
 
-    /// Plays a positional world sound at `pos`, mixed for its category and
-    /// spatialized relative to the current listener.
+    /// Plays a positional world sound. OpenAL owns spatialization and distance
+    /// attenuation; Pomme passes Vanilla-equivalent source parameters only.
     pub fn play_world_sound(
         &self,
-        sound: &SoundRef,
+        sound_ref: &SoundRef,
         category: u8,
         pos: Position,
         volume: f32,
         pitch: f32,
         seed: u64,
     ) {
-        let Some(output) = self.output.as_ref() else {
+        self.play_positioned_sound(sound_ref, category, pos, volume, pitch, seed, None);
+    }
+
+    pub fn play_entity_sound(
+        &self,
+        sound_ref: &SoundRef,
+        category: u8,
+        target: EntitySoundTarget,
+        volume: f32,
+        pitch: f32,
+        seed: u64,
+    ) {
+        self.play_positioned_sound(
+            sound_ref,
+            category,
+            target.pos,
+            volume,
+            pitch,
+            seed,
+            Some(target.id),
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn play_positioned_sound(
+        &self,
+        sound_ref: &SoundRef,
+        category: u8,
+        pos: Position,
+        volume: f32,
+        pitch: f32,
+        seed: u64,
+        entity_id: Option<i32>,
+    ) {
+        let Some(sound) = self.resolve_sound(sound_ref, Some(seed)) else {
             return;
         };
-        // Vanilla notifies subtitle listeners before the volume and distance
-        // checks; the overlay applies its own range test.
+        let instance_volume = volume * sound.entry_volume;
+
+        // Vanilla notifies subtitle listeners before category-volume/distance
+        // culling. The subtitle's own range uses the resolved sound's distance.
         if self.subtitles_enabled
-            && let SoundRef::Event(name) = sound
-            && let Some(key) = self.sounds.subtitle(name)
+            && let Some(key) = self.sounds.subtitle(sound_ref.event_name())
             && let Ok(mut queue) = self.subtitle_events.lock()
         {
             queue.push(QueuedSubtitle {
                 key: key.to_string(),
                 pos,
-                range: volume.max(1.0) * SOUND_ATTENUATION_BLOCKS,
+                range: instance_volume.max(1.0) * sound.attenuation_distance,
             });
         }
-        let Some((source, entry_volume)) = self.decode_sound(sound, seed) else {
-            return;
-        };
-        let emitter: [f32; 3] = pos.as_vec3().into();
-        let center = [
-            (self.listener_left[0] + self.listener_right[0]) * 0.5,
-            (self.listener_left[1] + self.listener_right[1]) * 0.5,
-            (self.listener_left[2] + self.listener_right[2]) * 0.5,
-        ];
 
-        // Vanilla linear distance attenuation, not rodio's 1/d^2.
-        let instance_volume = volume * entry_volume;
-        let atten_dist = instance_volume.max(1.0) * SOUND_ATTENUATION_BLOCKS;
-        let dist_gain = linear_attenuation(dist(center, emitter), atten_dist);
-        if dist_gain <= 0.0 {
-            return;
-        }
-
-        let (left_pan, right_pan) = stereo_pan(self.listener_left, self.listener_right, emitter);
-        let base =
-            self.category_gain(SoundCategory::from_index(category)) * instance_volume * dist_gain;
-
-        let sink = Player::connect_new(output.sink.mixer());
-        sink.set_speed(pitch.max(0.01));
-        sink.append(ChannelVolume::new(
-            source,
-            vec![base * left_pan, base * right_pan],
-        ));
-        sink.detach();
+        let id = self.allocate_id();
+        self.send(AudioCommand::Play(PlayCommand {
+            id,
+            sound_id: sound.sound_id,
+            path: sound.path,
+            category: SoundCategory::from_index(category),
+            volume: instance_volume,
+            pitch: pitch * sound.entry_pitch,
+            position: [pos.x as f32, pos.y as f32, pos.z as f32],
+            relative: false,
+            looping: false,
+            stream: sound.stream,
+            attenuation_distance: Some(instance_volume.max(1.0) * sound.attenuation_distance),
+            entity_id,
+            report_completion: false,
+        }));
     }
 
-    /// Begins menu music. Idempotent, so it is safe to call every frame.
+    pub fn update_entity_sound_position(&self, entity_id: i32, pos: Position) {
+        self.send(AudioCommand::UpdateEntityPosition {
+            entity_id,
+            position: [pos.x as f32, pos.y as f32, pos.z as f32],
+        });
+    }
+
+    pub fn stop_entity_sounds(&self, entity_id: i32) {
+        self.send(AudioCommand::StopEntity(entity_id));
+    }
+
     pub fn start_menu_music(&mut self) {
         if !self.menu_music_active {
             self.menu_music_active = true;
-            self.gap_remaining = 0.0;
+            self.next_song_delay_ticks = MENU_MUSIC_STARTING_DELAY_TICKS;
+            self.music_tick_accumulator = 0.0;
         }
     }
 
     pub fn stop_menu_music(&mut self) {
         self.menu_music_active = false;
-        self.gap_remaining = 0.0;
-        if let Some(sink) = self.music_sink.take() {
-            sink.stop();
+        self.next_song_delay_ticks = MENU_MUSIC_STARTING_DELAY_TICKS;
+        self.music_tick_accumulator = 0.0;
+        if let Some(id) = self.music_id.take() {
+            self.send(AudioCommand::Stop(id));
         }
     }
 
-    /// Advances menu music: syncs the live volume, schedules a random gap after
-    /// each finished track, and starts the next track once the gap elapses.
-    pub fn update_menu_music(&mut self, dt: f32) {
-        if !self.menu_music_active {
+    /// Stops all currently active native sources. Static buffer cache remains
+    /// valid and is released with the audio context at shutdown.
+    pub fn stop_all_sounds(&mut self) {
+        self.music_id = None;
+        self.send(AudioCommand::StopAll);
+    }
+
+    /// Implements Vanilla's `SoundEngine.stop(sound, source)` matching.
+    pub fn stop_sounds(&mut self, sound_id: Option<&str>, category: Option<u8>) {
+        if sound_id.is_none() && category.is_none() {
+            self.stop_all_sounds();
             return;
         }
-        if let Some(sink) = self.music_sink.as_ref() {
-            sink.set_volume(self.current_music_volume());
-            if !sink.empty() {
-                return;
+        self.send(AudioCommand::StopMatching {
+            sound_id: sound_id.map(canonical_sound_id),
+            category: category.map(SoundCategory::from_index),
+        });
+    }
+
+    pub fn update_menu_music(&mut self, dt: f32) {
+        if self.command_tx.is_none() || !self.menu_music_active {
+            return;
+        }
+        while let Ok(AudioEvent::Finished(id)) = self.event_rx.try_recv() {
+            if self.music_id == Some(id) {
+                self.music_id = None;
+                self.next_song_delay_ticks = menu_delay_after_finish(random_menu_delay_ticks());
             }
         }
-        // A finished track falls through to here; drop it and start the gap.
-        if self.music_sink.take().is_some() {
-            self.gap_remaining =
-                MENU_MUSIC_MIN_GAP + fastrand::f32() * (MENU_MUSIC_MAX_GAP - MENU_MUSIC_MIN_GAP);
-            return;
+
+        self.music_tick_accumulator += dt.max(0.0);
+        while self.music_tick_accumulator >= SOUND_TICK_SECONDS {
+            self.music_tick_accumulator -= SOUND_TICK_SECONDS;
+            if self.music_id.is_none() {
+                self.next_song_delay_ticks -= 1;
+                if self.next_song_delay_ticks <= 0 {
+                    self.play_menu_track();
+                }
+            }
         }
-        if self.gap_remaining > 0.0 {
-            self.gap_remaining -= dt;
-            return;
-        }
-        self.play_menu_track();
     }
 
     fn play_menu_track(&mut self) {
-        if let Some((sink, track_volume)) = self.make_sink(MENU_MUSIC_EVENT) {
-            self.music_track_volume = track_volume;
-            sink.set_volume(self.current_music_volume());
-            self.music_sink = Some(sink);
-        }
-    }
-
-    /// Decodes a weighted-random variant of `event` into a queued sink,
-    /// returned with the variant's per-entry volume for the caller to
-    /// apply.
-    fn make_sink(&self, event: &str) -> Option<(Player, f32)> {
-        let output = self.output.as_ref()?;
-        let (source, volume) = self.decode_event(event, None)?;
-        let sink = Player::connect_new(output.sink.mixer());
-        sink.append(source);
-        Some((sink, volume))
-    }
-
-    fn decode_sound(&self, sound: &SoundRef, seed: u64) -> Option<(Decoder<BufReader<File>>, f32)> {
-        match sound {
-            SoundRef::Event(name) => self.decode_event(name, Some(seed)),
-            SoundRef::Direct(path) => Some((self.open_decoder(&sound_asset_key(path))?, 1.0)),
-        }
-    }
-
-    /// Resolves `event` to a variant (seeded when `seed` is set, else random)
-    /// and decodes its `.ogg`, returning the decoder and per-entry volume.
-    fn decode_event(
-        &self,
-        event: &str,
-        seed: Option<u64>,
-    ) -> Option<(Decoder<BufReader<File>>, f32)> {
-        let (name, volume) = self.choose_variant(event, seed)?;
-        Some((self.open_decoder(&sound_asset_key(&name))?, volume))
-    }
-
-    fn choose_variant(&self, event: &str, seed: Option<u64>) -> Option<(String, f32)> {
-        let variants = self.sounds.variants(event)?;
-        let total: u32 = variants.iter().map(|v| v.weight).sum();
-        if total == 0 {
-            return None;
-        }
-        let mut pick = match seed {
-            Some(s) => (s % total as u64) as u32,
-            None => fastrand::u32(0..total),
+        let Some(sound) = self.resolve_event(MENU_MUSIC_EVENT, None) else {
+            self.next_song_delay_ticks = MENU_MUSIC_MIN_DELAY_TICKS;
+            return;
         };
-        for v in variants {
-            if pick < v.weight {
-                return Some((v.name.clone(), v.volume));
-            }
-            pick -= v.weight;
+        let id = self.allocate_id();
+        self.send(AudioCommand::Play(PlayCommand {
+            id,
+            sound_id: sound.sound_id,
+            path: sound.path,
+            category: SoundCategory::Music,
+            volume: sound.entry_volume,
+            pitch: sound.entry_pitch,
+            position: [0.0, 0.0, 0.0],
+            relative: true,
+            looping: false,
+            stream: sound.stream,
+            attenuation_distance: None,
+            entity_id: None,
+            report_completion: true,
+        }));
+        self.music_id = Some(id);
+        self.next_song_delay_ticks = i32::MAX;
+    }
+
+    fn resolve_sound(&self, sound: &SoundRef, seed: Option<u64>) -> Option<ResolvedSound> {
+        self.resolve_event(sound.event_name(), seed)
+    }
+
+    fn resolve_event(&self, event: &str, seed: Option<u64>) -> Option<ResolvedSound> {
+        let variant = self.sounds.choose(event, seed)?;
+        Some(self.resolve_variant(event, variant))
+    }
+
+    fn resolve_variant(&self, event: &str, variant: SoundVariant) -> ResolvedSound {
+        ResolvedSound {
+            sound_id: canonical_sound_id(event),
+            path: variant.path,
+            entry_volume: variant.volume,
+            entry_pitch: variant.pitch,
+            stream: variant.stream,
+            attenuation_distance: variant.attenuation_distance,
         }
-        let first = &variants[0];
-        Some((first.name.clone(), first.volume))
     }
 
-    fn open_decoder(&self, key: &str) -> Option<Decoder<BufReader<File>>> {
-        let path = resolve_asset_path(&self.jar_assets_dir, &self.asset_index, key);
-        let file = File::open(&path)
-            .map_err(|e| tracing::warn!("failed to open sound {}: {e}", path.display()))
-            .ok()?;
-        Decoder::new(BufReader::new(file))
-            .map_err(|e| tracing::warn!("failed to decode sound {}: {e}", path.display()))
-            .ok()
+    fn allocate_id(&self) -> u64 {
+        self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn send(&self, command: AudioCommand) {
+        if let Some(tx) = self.command_tx.as_ref()
+            && tx.send(command).is_err()
+        {
+            tracing::debug!("audio worker is unavailable");
+        }
     }
 }
 
-/// Vanilla linear sound attenuation: 1.0 at the listener, falling to 0.0 at
-/// `atten_dist` and beyond (OpenAL `AL_LINEAR_DISTANCE_CLAMPED`, rolloff 1).
-fn linear_attenuation(distance: f32, atten_dist: f32) -> f32 {
-    1.0 - (distance / atten_dist).clamp(0.0, 1.0)
+impl Drop for AudioEngine {
+    fn drop(&mut self) {
+        if let Some(tx) = self.command_tx.take() {
+            let _ = tx.send(AudioCommand::Shutdown);
+        }
+        if let Some(worker) = self.worker.take()
+            && worker.join().is_err()
+        {
+            tracing::warn!("audio worker panicked during shutdown");
+        }
+    }
 }
 
-fn dist(a: [f32; 3], b: [f32; 3]) -> f32 {
-    let dx = a[0] - b[0];
-    let dy = a[1] - b[1];
-    let dz = a[2] - b[2];
-    (dx * dx + dy * dy + dz * dz).sqrt()
+struct AudioWorker {
+    context: Context,
+    volumes: [f32; SoundCategory::COUNT],
+    commands: Receiver<AudioCommand>,
+    events: Sender<AudioEvent>,
+    static_buffers: HashMap<PathBuf, Rc<Buffer>>,
+    active: HashMap<u64, ActiveSound>,
 }
 
-/// Per-channel panning gains from each ear's distance to the emitter, matching
-/// rodio's `Spatial` balance so the left/right feel is unchanged.
-fn stereo_pan(left_ear: [f32; 3], right_ear: [f32; 3], emitter: [f32; 3]) -> (f32, f32) {
-    let left_d = dist(left_ear, emitter);
-    let right_d = dist(right_ear, emitter);
-    let max_diff = dist(left_ear, right_ear);
-    let left = (((left_d - right_d) / max_diff + 1.0) / 4.0 + 0.5).min(1.0);
-    let right = (((right_d - left_d) / max_diff + 1.0) / 4.0 + 0.5).min(1.0);
-    (left, right)
+struct ActiveSound {
+    source: Source,
+    sound_id: String,
+    category: SoundCategory,
+    base_gain: f32,
+    entity_id: Option<i32>,
+    report_completion: bool,
+    kind: ActiveKind,
+}
+
+enum ActiveKind {
+    Static { _buffer: Rc<Buffer> },
+    Stream(StreamPlayback),
+}
+
+impl Drop for ActiveSound {
+    fn drop(&mut self) {
+        if let ActiveKind::Stream(stream) = &mut self.kind
+            && let Err(e) = self.source.clear_queue(&mut stream.queued)
+        {
+            tracing::warn!("failed to clear OpenAL stream queue: {e}");
+        }
+    }
+}
+
+struct StreamPlayback {
+    decoder: StreamDecoder,
+    queued: VecDeque<Buffer>,
+    finished_decoding: bool,
+}
+
+impl AudioWorker {
+    fn new(
+        context: Context,
+        volumes: [f32; SoundCategory::COUNT],
+        commands: Receiver<AudioCommand>,
+        events: Sender<AudioEvent>,
+    ) -> Self {
+        Self {
+            context,
+            volumes,
+            commands,
+            events,
+            static_buffers: HashMap::new(),
+            active: HashMap::new(),
+        }
+    }
+
+    fn run(mut self) {
+        let mut shutdown = false;
+        while !shutdown {
+            match self.commands.recv_timeout(Duration::from_millis(10)) {
+                Ok(command) => shutdown = self.handle_command(command),
+                Err(RecvTimeoutError::Timeout) => {}
+                Err(RecvTimeoutError::Disconnected) => shutdown = true,
+            }
+            while !shutdown {
+                match self.commands.try_recv() {
+                    Ok(command) => shutdown = self.handle_command(command),
+                    Err(_) => break,
+                }
+            }
+            if !shutdown {
+                self.tick();
+            }
+        }
+        self.active.clear();
+        self.static_buffers.clear();
+    }
+
+    fn handle_command(&mut self, command: AudioCommand) -> bool {
+        match command {
+            AudioCommand::Play(play) => {
+                let id = play.id;
+                let report_completion = play.report_completion;
+                if !self.play(play) && report_completion {
+                    let _ = self.events.try_send(AudioEvent::Finished(id));
+                }
+            }
+            AudioCommand::SetVolumes(volumes) => {
+                self.volumes = volumes;
+                self.refresh_gains();
+            }
+            AudioCommand::SetListener {
+                position,
+                forward,
+                up,
+            } => {
+                if let Err(e) = self.context.set_listener(position, forward, up) {
+                    tracing::warn!("failed to update OpenAL listener: {e}");
+                }
+            }
+            AudioCommand::Stop(id) => {
+                self.stop_sound(id);
+            }
+            AudioCommand::StopMatching { sound_id, category } => {
+                let ids: Vec<u64> = self
+                    .active
+                    .iter()
+                    .filter_map(|(&id, sound)| {
+                        sound_matches_stop(
+                            &sound.sound_id,
+                            sound.category,
+                            sound_id.as_deref(),
+                            category,
+                        )
+                        .then_some(id)
+                    })
+                    .collect();
+                for id in ids {
+                    self.stop_sound(id);
+                }
+            }
+            AudioCommand::UpdateEntityPosition {
+                entity_id,
+                position,
+            } => {
+                for sound in self
+                    .active
+                    .values()
+                    .filter(|sound| sound.entity_id == Some(entity_id))
+                {
+                    if let Err(e) = sound.source.set_position(position) {
+                        tracing::warn!("failed to update entity-bound sound position: {e}");
+                    }
+                }
+            }
+            AudioCommand::StopEntity(entity_id) => {
+                let ids: Vec<u64> = self
+                    .active
+                    .iter()
+                    .filter_map(|(&id, sound)| (sound.entity_id == Some(entity_id)).then_some(id))
+                    .collect();
+                for id in ids {
+                    self.stop_sound(id);
+                }
+            }
+            AudioCommand::StopAll => {
+                self.active.clear();
+            }
+            AudioCommand::ReloadAssets => {
+                self.active.clear();
+                self.static_buffers.clear();
+            }
+            AudioCommand::Shutdown => return true,
+        }
+        false
+    }
+
+    fn stop_sound(&mut self, id: u64) {
+        let Some(sound) = self.active.remove(&id) else {
+            return;
+        };
+        if let Err(e) = sound.source.stop() {
+            tracing::warn!("failed to stop OpenAL source: {e}");
+        }
+        if sound.report_completion {
+            let _ = self.events.try_send(AudioEvent::Finished(id));
+        }
+    }
+
+    fn play(&mut self, play: PlayCommand) -> bool {
+        self.cleanup_finished();
+        let base_gain = clamped_source_volume(play.volume);
+        let gain = category_gain(&self.volumes, play.category) * base_gain;
+        if gain == 0.0 && play.category != SoundCategory::Music {
+            return false;
+        }
+        let pitch = clamped_source_pitch(play.pitch);
+
+        let stream_count = self
+            .active
+            .values()
+            .filter(|sound| matches!(sound.kind, ActiveKind::Stream(_)))
+            .count();
+        let static_count = self.active.len().saturating_sub(stream_count);
+        let at_capacity = if play.stream {
+            stream_count >= self.context.streaming_source_limit
+        } else {
+            static_count >= self.context.static_source_limit
+        };
+        if at_capacity {
+            tracing::debug!(
+                "OpenAL source pool exhausted; dropping sound {}",
+                play.path.display()
+            );
+            return false;
+        }
+
+        let source = match self.context.create_source() {
+            Ok(source) => source,
+            Err(e) => {
+                tracing::warn!("failed to allocate OpenAL source: {e}");
+                return false;
+            }
+        };
+        if let Err(e) = source.configure(
+            gain,
+            pitch,
+            play.position,
+            play.relative,
+            play.looping && !play.stream,
+            play.attenuation_distance,
+        ) {
+            tracing::warn!("failed to configure OpenAL source: {e}");
+            return false;
+        }
+
+        let (source, kind) = if play.stream {
+            match self.start_stream(source, &play.path) {
+                Ok((source, stream)) => (source, ActiveKind::Stream(stream)),
+                Err(e) => {
+                    tracing::warn!("failed to stream sound {}: {e}", play.path.display());
+                    return false;
+                }
+            }
+        } else {
+            let buffer = match self.static_buffer(&play.path) {
+                Ok(buffer) => buffer,
+                Err(e) => {
+                    tracing::warn!("failed to decode sound {}: {e}", play.path.display());
+                    return false;
+                }
+            };
+            if let Err(e) = source.attach_static(&buffer) {
+                tracing::warn!("failed to attach OpenAL buffer: {e}");
+                return false;
+            }
+            (source, ActiveKind::Static { _buffer: buffer })
+        };
+
+        if let Err(e) = source.play() {
+            tracing::warn!("failed to play OpenAL source: {e}");
+            return false;
+        }
+        self.active.insert(
+            play.id,
+            ActiveSound {
+                source,
+                sound_id: play.sound_id,
+                category: play.category,
+                base_gain,
+                entity_id: play.entity_id,
+                report_completion: play.report_completion,
+                kind,
+            },
+        );
+        true
+    }
+
+    fn static_buffer(&mut self, path: &Path) -> Result<Rc<Buffer>, String> {
+        if let Some(buffer) = self.static_buffers.get(path) {
+            return Ok(Rc::clone(buffer));
+        }
+        let decoded = decode_all(path)?;
+        let buffer = Rc::new(
+            self.context
+                .create_buffer(decoded.format, &decoded.samples)?,
+        );
+        self.static_buffers
+            .insert(path.to_path_buf(), Rc::clone(&buffer));
+        Ok(buffer)
+    }
+
+    fn start_stream(
+        &self,
+        source: Source,
+        path: &Path,
+    ) -> Result<(Source, StreamPlayback), String> {
+        let mut decoder = StreamDecoder::open(path)?;
+        let mut queued = VecDeque::new();
+        let mut finished_decoding = false;
+        for _ in 0..4 {
+            match queue_stream_chunk(&self.context, &source, &mut decoder, &mut queued) {
+                Ok(true) => {}
+                Ok(false) => {
+                    finished_decoding = true;
+                    break;
+                }
+                Err(error) => {
+                    if let Err(cleanup_error) = source.clear_queue(&mut queued) {
+                        // Releasing the source detaches any buffers OpenAL refused to unqueue.
+                        // Only then may the Rust Buffer owners drop and delete those native ids.
+                        drop(source);
+                        drop(queued);
+                        return Err(format!(
+                            "{error}; additionally failed to clear partial stream queue: {cleanup_error}"
+                        ));
+                    }
+                    return Err(error);
+                }
+            }
+        }
+        if queued.is_empty() {
+            return Err("stream contained no PCM samples".to_string());
+        }
+        Ok((
+            source,
+            StreamPlayback {
+                decoder,
+                queued,
+                finished_decoding,
+            },
+        ))
+    }
+
+    fn refresh_gains(&mut self) {
+        for sound in self.active.values() {
+            let gain = category_gain(&self.volumes, sound.category) * sound.base_gain;
+            if let Err(e) = sound.source.set_gain(gain) {
+                tracing::warn!("failed to update OpenAL source gain: {e}");
+            }
+        }
+    }
+
+    fn tick(&mut self) {
+        let ids: Vec<u64> = self.active.keys().copied().collect();
+        let mut finished = Vec::new();
+        for id in ids {
+            let Some(sound) = self.active.get_mut(&id) else {
+                continue;
+            };
+            let done = match &mut sound.kind {
+                ActiveKind::Static { .. } => match sound.source.state() {
+                    Ok(SourceState::Playing | SourceState::Paused) => false,
+                    Ok(_) => true,
+                    Err(e) => {
+                        tracing::warn!("failed to query OpenAL source state: {e}");
+                        true
+                    }
+                },
+                ActiveKind::Stream(stream) => {
+                    if let Err(e) = tick_stream(&self.context, &sound.source, stream) {
+                        tracing::warn!("stream playback failed: {e}");
+                        true
+                    } else {
+                        stream.finished_decoding && stream.queued.is_empty()
+                    }
+                }
+            };
+            if done {
+                finished.push(id);
+            }
+        }
+        for id in finished {
+            if self
+                .active
+                .remove(&id)
+                .is_some_and(|sound| sound.report_completion)
+            {
+                let _ = self.events.try_send(AudioEvent::Finished(id));
+            }
+        }
+    }
+
+    fn cleanup_finished(&mut self) {
+        self.tick();
+    }
+}
+
+fn queue_stream_chunk(
+    context: &Context,
+    source: &Source,
+    decoder: &mut StreamDecoder,
+    queued: &mut VecDeque<Buffer>,
+) -> Result<bool, String> {
+    let format = decoder.format();
+    let one_second_samples = usize::try_from(format.sample_rate)
+        .unwrap_or(usize::MAX)
+        .saturating_mul(usize::from(format.channels));
+    let samples = decoder.read_samples(one_second_samples)?;
+    if samples.is_empty() {
+        return Ok(false);
+    }
+    let buffer = context.create_buffer(format, &samples)?;
+    source.queue_buffer(&buffer)?;
+    queued.push_back(buffer);
+    Ok(true)
+}
+
+fn tick_stream(
+    context: &Context,
+    source: &Source,
+    stream: &mut StreamPlayback,
+) -> Result<(), String> {
+    source.remove_processed(&mut stream.queued)?;
+    while !stream.finished_decoding && stream.queued.len() < 4 {
+        if !queue_stream_chunk(context, source, &mut stream.decoder, &mut stream.queued)? {
+            stream.finished_decoding = true;
+        }
+    }
+    if !stream.queued.is_empty() && matches!(source.state()?, SourceState::Stopped) {
+        source.play()?;
+    }
+    Ok(())
+}
+
+fn listener_vectors(y_rot_deg: f32, x_rot_deg: f32) -> ([f32; 3], [f32; 3]) {
+    let yaw = y_rot_deg.to_radians();
+    let pitch = x_rot_deg.to_radians();
+    let (sin_yaw, cos_yaw) = yaw.sin_cos();
+    let (sin_pitch, cos_pitch) = pitch.sin_cos();
+    let forward = [-sin_yaw * cos_pitch, -sin_pitch, cos_yaw * cos_pitch];
+    // Vanilla's up vector is calculateViewVector(pitch - 90°, yaw).
+    let up = [-sin_yaw * sin_pitch, cos_pitch, cos_yaw * sin_pitch];
+    (forward, up)
+}
+
+fn sound_matches_stop(
+    sound_id: &str,
+    category: SoundCategory,
+    expected_sound_id: Option<&str>,
+    expected_category: Option<SoundCategory>,
+) -> bool {
+    expected_sound_id.is_none_or(|expected| sound_id == expected)
+        && expected_category.is_none_or(|expected| category == expected)
+}
+
+fn random_menu_delay_ticks() -> i32 {
+    fastrand::i32(MENU_MUSIC_MIN_DELAY_TICKS..=MENU_MUSIC_MAX_DELAY_TICKS)
+}
+
+fn menu_delay_after_finish(random_delay: i32) -> i32 {
+    LOGICAL_SOUND_RETENTION_TICKS.saturating_add(random_delay)
+}
+
+fn canonical_sound_id(sound_id: &str) -> String {
+    if sound_id.contains(':') {
+        sound_id.to_string()
+    } else {
+        format!("minecraft:{sound_id}")
+    }
+}
+
+fn clamped_source_volume(volume: f32) -> f32 {
+    volume.clamp(0.0, 1.0)
+}
+
+fn clamped_source_pitch(pitch: f32) -> f32 {
+    pitch.clamp(0.5, 2.0)
+}
+
+fn category_gain(volumes: &[f32; SoundCategory::COUNT], category: SoundCategory) -> f32 {
+    let master = volumes[SoundCategory::Master as usize];
+    match category {
+        SoundCategory::Master => master,
+        other => master * volumes[other as usize],
+    }
 }
 
 #[cfg(test)]
@@ -455,15 +1025,74 @@ mod tests {
     use super::*;
 
     #[test]
-    fn linear_attenuation_matches_vanilla() {
-        let d = SOUND_ATTENUATION_BLOCKS;
-        assert_eq!(linear_attenuation(0.0, d), 1.0);
-        assert_eq!(linear_attenuation(8.0, d), 0.5);
-        assert_eq!(linear_attenuation(16.0, d), 0.0);
-        assert_eq!(linear_attenuation(24.0, d), 0.0);
+    fn listener_vectors_match_vanilla_axes() {
+        let (forward, up) = listener_vectors(90.0, 30.0);
+        let expected_forward = [-30.0_f32.to_radians().cos(), -0.5, 0.0];
+        let expected_up = [-0.5, 30.0_f32.to_radians().cos(), 0.0];
+        for (actual, expected) in forward.into_iter().zip(expected_forward) {
+            assert!((actual - expected).abs() < 1.0e-6, "{actual} != {expected}");
+        }
+        for (actual, expected) in up.into_iter().zip(expected_up) {
+            assert!((actual - expected).abs() < 1.0e-6, "{actual} != {expected}");
+        }
     }
 
-    /// Vanilla's `SoundSource` puts `UI("ui")` last, at 10.
+    #[test]
+    fn category_gain_does_not_double_scale_master() {
+        let mut volumes = [1.0; SoundCategory::COUNT];
+        volumes[SoundCategory::Master as usize] = 0.5;
+        volumes[SoundCategory::Music as usize] = 0.25;
+        assert_eq!(category_gain(&volumes, SoundCategory::Master), 0.5);
+        assert_eq!(category_gain(&volumes, SoundCategory::Music), 0.125);
+    }
+
+    #[test]
+    fn source_parameter_clamps_match_vanilla() {
+        assert_eq!(clamped_source_volume(-1.0), 0.0);
+        assert_eq!(clamped_source_volume(0.25), 0.25);
+        assert_eq!(clamped_source_volume(2.0), 1.0);
+        assert_eq!(clamped_source_pitch(0.1), 0.5);
+        assert_eq!(clamped_source_pitch(1.25), 1.25);
+        assert_eq!(clamped_source_pitch(3.0), 2.0);
+    }
+
+    #[test]
+    fn sound_ids_use_minecraft_default_namespace() {
+        assert_eq!(
+            canonical_sound_id("block.stone.break"),
+            "minecraft:block.stone.break"
+        );
+        assert_eq!(canonical_sound_id("mod:custom.sound"), "mod:custom.sound");
+    }
+
+    #[test]
+    fn stop_filter_matches_vanilla_name_and_source_combinations() {
+        let id = "minecraft:block.stone.break";
+        let category = SoundCategory::Blocks;
+        assert!(sound_matches_stop(id, category, None, None));
+        assert!(sound_matches_stop(id, category, Some(id), None));
+        assert!(sound_matches_stop(id, category, None, Some(category)));
+        assert!(sound_matches_stop(id, category, Some(id), Some(category)));
+        assert!(!sound_matches_stop(
+            id,
+            category,
+            Some("minecraft:block.grass.break"),
+            None,
+        ));
+        assert!(!sound_matches_stop(
+            id,
+            category,
+            None,
+            Some(SoundCategory::Players),
+        ));
+    }
+
+    #[test]
+    fn menu_music_finish_includes_vanilla_logical_retention_ticks() {
+        assert_eq!(menu_delay_after_finish(400), 420);
+        assert_eq!(menu_delay_after_finish(20), 40);
+    }
+
     #[test]
     fn ui_matches_vanilla_sound_source_ordinal() {
         assert_eq!(SoundCategory::Ui as usize, 10);

--- a/pomme-client/src/audio/openal.rs
+++ b/pomme-client/src/audio/openal.rs
@@ -122,8 +122,13 @@ impl Api {
                     continue;
                 }
             };
-            return Self::from_library(library)
-                .map_err(|e| format!("loaded {display}, but OpenAL symbols were incomplete: {e}"));
+            match Self::from_library(library) {
+                Ok(api) => return Ok(api),
+                // A stub system library must not shadow the staged one.
+                Err(e) => {
+                    errors.push(format!("{display}: OpenAL symbols were incomplete: {e}"));
+                }
+            }
         }
         Err(format!("failed to load OpenAL ({})", errors.join("; ")))
     }
@@ -632,9 +637,19 @@ impl Source {
         match attenuation_distance {
             Some(max_distance) => {
                 self.sourcei(AL_DISTANCE_MODEL, AL_LINEAR_DISTANCE)?;
-                self.sourcef(AL_MAX_DISTANCE, max_distance)?;
-                self.sourcef(AL_ROLLOFF_FACTOR, 1.0)?;
-                self.sourcef(AL_REFERENCE_DISTANCE, 0.0)?;
+                // Vanilla's Channel.linearAttenuation issues these without
+                // checking alGetError, and accepts the negative
+                // attenuation_distance that OpenAL rejects, so a pack setting
+                // one must not lose the sound here.
+                for (param, value) in [
+                    (AL_MAX_DISTANCE, max_distance),
+                    (AL_ROLLOFF_FACTOR, 1.0),
+                    (AL_REFERENCE_DISTANCE, 0.0),
+                ] {
+                    if let Err(e) = self.sourcef(param, value) {
+                        tracing::debug!("ignoring OpenAL attenuation rejection: {e}");
+                    }
+                }
             }
             None => self.sourcei(AL_DISTANCE_MODEL, 0)?,
         }

--- a/pomme-client/src/audio/openal.rs
+++ b/pomme-client/src/audio/openal.rs
@@ -1,0 +1,798 @@
+use std::collections::VecDeque;
+use std::ffi::{CStr, CString, c_char, c_float, c_int, c_void};
+use std::rc::Rc;
+
+use libloading::Library;
+
+use super::decoder::PcmFormat;
+
+type AlBoolean = c_char;
+type AlEnum = c_int;
+type AlInt = c_int;
+type AlSize = c_int;
+type AlUint = u32;
+type AlcBoolean = c_char;
+type AlcEnum = c_int;
+type AlcInt = c_int;
+type AlcDevice = c_void;
+type AlcContext = c_void;
+
+const AL_NO_ERROR: AlEnum = 0;
+const AL_FALSE: AlInt = 0;
+const AL_TRUE: AlInt = 1;
+const AL_POSITION: AlEnum = 0x1004;
+const AL_ORIENTATION: AlEnum = 0x100f;
+const AL_PITCH: AlEnum = 0x1003;
+const AL_LOOPING: AlEnum = 0x1007;
+const AL_BUFFER: AlEnum = 0x1009;
+const AL_GAIN: AlEnum = 0x100a;
+const AL_SOURCE_STATE: AlEnum = 0x1010;
+const AL_PLAYING: AlEnum = 0x1012;
+const AL_PAUSED: AlEnum = 0x1013;
+const AL_STOPPED: AlEnum = 0x1014;
+const AL_BUFFERS_QUEUED: AlEnum = 0x1015;
+const AL_BUFFERS_PROCESSED: AlEnum = 0x1016;
+const AL_REFERENCE_DISTANCE: AlEnum = 0x1020;
+const AL_ROLLOFF_FACTOR: AlEnum = 0x1021;
+const AL_MAX_DISTANCE: AlEnum = 0x1023;
+const AL_FORMAT_MONO16: AlEnum = 0x1101;
+const AL_FORMAT_STEREO16: AlEnum = 0x1103;
+const AL_SOURCE_RELATIVE: AlEnum = 0x0202;
+const AL_INITIAL: AlEnum = 0x1011;
+/// `AL_EXT_source_distance_model` capability enabled globally with `alEnable`.
+const AL_SOURCE_DISTANCE_MODEL: AlEnum = 0x0200;
+/// Per-source property used with `alSourcei` once `AL_SOURCE_DISTANCE_MODEL` is
+/// enabled.
+const AL_DISTANCE_MODEL: AlEnum = 0xd000;
+const AL_LINEAR_DISTANCE: AlEnum = 0xd003;
+const AL_VERSION: AlEnum = 0xb002;
+
+const ALC_FALSE: AlcBoolean = 0;
+const ALC_MAJOR_VERSION: AlcEnum = 0x1000;
+const ALC_MINOR_VERSION: AlcEnum = 0x1001;
+const ALC_ATTRIBUTES_SIZE: AlcEnum = 0x1002;
+const ALC_ALL_ATTRIBUTES: AlcEnum = 0x1003;
+const ALC_MONO_SOURCES: AlcEnum = 0x1010;
+const ALC_HRTF_SOFT: AlcInt = 0x1992;
+const ALC_NUM_HRTF_SPECIFIERS_SOFT: AlcEnum = 0x1994;
+const ALC_HRTF_ID_SOFT: AlcInt = 0x1996;
+const ALC_OUTPUT_LIMITER_SOFT: AlcInt = 0x199a;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum SourceState {
+    Initial,
+    Playing,
+    Paused,
+    Stopped,
+    Unknown(AlInt),
+}
+
+struct Api {
+    _library: Library,
+    al_get_error: unsafe extern "C" fn() -> AlEnum,
+    al_get_string: unsafe extern "C" fn(AlEnum) -> *const c_char,
+    al_is_extension_present: unsafe extern "C" fn(*const c_char) -> AlBoolean,
+    al_enable: unsafe extern "C" fn(AlEnum),
+    al_listener3f: unsafe extern "C" fn(AlEnum, c_float, c_float, c_float),
+    al_listenerfv: unsafe extern "C" fn(AlEnum, *const c_float),
+    al_gen_sources: unsafe extern "C" fn(AlSize, *mut AlUint),
+    al_delete_sources: unsafe extern "C" fn(AlSize, *const AlUint),
+    al_source_play: unsafe extern "C" fn(AlUint),
+    al_source_stop: unsafe extern "C" fn(AlUint),
+    al_sourcef: unsafe extern "C" fn(AlUint, AlEnum, c_float),
+    al_sourcei: unsafe extern "C" fn(AlUint, AlEnum, AlInt),
+    al_source3f: unsafe extern "C" fn(AlUint, AlEnum, c_float, c_float, c_float),
+    al_get_sourcei: unsafe extern "C" fn(AlUint, AlEnum, *mut AlInt),
+    al_gen_buffers: unsafe extern "C" fn(AlSize, *mut AlUint),
+    al_delete_buffers: unsafe extern "C" fn(AlSize, *const AlUint),
+    al_buffer_data: unsafe extern "C" fn(AlUint, AlEnum, *const c_void, AlSize, AlSize),
+    al_source_queue_buffers: unsafe extern "C" fn(AlUint, AlSize, *const AlUint),
+    al_source_unqueue_buffers: unsafe extern "C" fn(AlUint, AlSize, *mut AlUint),
+    alc_open_device: unsafe extern "C" fn(*const c_char) -> *mut AlcDevice,
+    alc_close_device: unsafe extern "C" fn(*mut AlcDevice) -> AlcBoolean,
+    alc_create_context: unsafe extern "C" fn(*mut AlcDevice, *const AlcInt) -> *mut AlcContext,
+    alc_destroy_context: unsafe extern "C" fn(*mut AlcContext),
+    alc_make_context_current: unsafe extern "C" fn(*mut AlcContext) -> AlcBoolean,
+    alc_get_error: unsafe extern "C" fn(*mut AlcDevice) -> AlcEnum,
+    alc_is_extension_present: unsafe extern "C" fn(*mut AlcDevice, *const c_char) -> AlcBoolean,
+    alc_get_integerv: unsafe extern "C" fn(*mut AlcDevice, AlcEnum, AlSize, *mut AlcInt),
+}
+
+impl Api {
+    fn load() -> Result<Self, String> {
+        let mut candidates = Vec::new();
+        if let Ok(executable) = std::env::current_exe()
+            && let Some(directory) = executable.parent()
+        {
+            candidates.extend(library_names().iter().map(|name| directory.join(name)));
+        }
+        candidates.extend(library_names().iter().map(std::path::PathBuf::from));
+
+        let mut errors = Vec::new();
+        for path in candidates {
+            let display = path.display().to_string();
+            // SAFETY: Loading a shared library is inherently unsafe because its
+            // initialization code is outside Rust's control. We only try
+            // packaged/system OpenAL library names and keep the returned Library
+            // alive for the lifetime of every copied symbol pointer.
+            let library = match unsafe { Library::new(&path) } {
+                Ok(library) => library,
+                Err(e) => {
+                    errors.push(format!("{display}: {e}"));
+                    continue;
+                }
+            };
+            return Self::from_library(library)
+                .map_err(|e| format!("loaded {display}, but OpenAL symbols were incomplete: {e}"));
+        }
+        Err(format!("failed to load OpenAL ({})", errors.join("; ")))
+    }
+
+    fn from_library(library: Library) -> Result<Self, String> {
+        macro_rules! symbol {
+            ($name:literal, $ty:ty) => {{
+                // SAFETY: The requested symbols and ABI signatures are defined by OpenAL 1.1.
+                // The owning Library is stored in Api, so copied function pointers cannot
+                // outlive it.
+                *unsafe { library.get::<$ty>(concat!($name, "\0").as_bytes()) }
+                    .map_err(|e| format!(concat!($name, ": {}"), e))?
+            }};
+        }
+        Ok(Self {
+            al_get_error: symbol!("alGetError", unsafe extern "C" fn() -> AlEnum),
+            al_get_string: symbol!("alGetString", unsafe extern "C" fn(AlEnum) -> *const c_char),
+            al_is_extension_present: symbol!(
+                "alIsExtensionPresent",
+                unsafe extern "C" fn(*const c_char) -> AlBoolean
+            ),
+            al_enable: symbol!("alEnable", unsafe extern "C" fn(AlEnum)),
+            al_listener3f: symbol!(
+                "alListener3f",
+                unsafe extern "C" fn(AlEnum, c_float, c_float, c_float)
+            ),
+            al_listenerfv: symbol!("alListenerfv", unsafe extern "C" fn(AlEnum, *const c_float)),
+            al_gen_sources: symbol!("alGenSources", unsafe extern "C" fn(AlSize, *mut AlUint)),
+            al_delete_sources: symbol!(
+                "alDeleteSources",
+                unsafe extern "C" fn(AlSize, *const AlUint)
+            ),
+            al_source_play: symbol!("alSourcePlay", unsafe extern "C" fn(AlUint)),
+            al_source_stop: symbol!("alSourceStop", unsafe extern "C" fn(AlUint)),
+            al_sourcef: symbol!("alSourcef", unsafe extern "C" fn(AlUint, AlEnum, c_float)),
+            al_sourcei: symbol!("alSourcei", unsafe extern "C" fn(AlUint, AlEnum, AlInt)),
+            al_source3f: symbol!(
+                "alSource3f",
+                unsafe extern "C" fn(AlUint, AlEnum, c_float, c_float, c_float)
+            ),
+            al_get_sourcei: symbol!(
+                "alGetSourcei",
+                unsafe extern "C" fn(AlUint, AlEnum, *mut AlInt)
+            ),
+            al_gen_buffers: symbol!("alGenBuffers", unsafe extern "C" fn(AlSize, *mut AlUint)),
+            al_delete_buffers: symbol!(
+                "alDeleteBuffers",
+                unsafe extern "C" fn(AlSize, *const AlUint)
+            ),
+            al_buffer_data: symbol!(
+                "alBufferData",
+                unsafe extern "C" fn(AlUint, AlEnum, *const c_void, AlSize, AlSize)
+            ),
+            al_source_queue_buffers: symbol!(
+                "alSourceQueueBuffers",
+                unsafe extern "C" fn(AlUint, AlSize, *const AlUint)
+            ),
+            al_source_unqueue_buffers: symbol!(
+                "alSourceUnqueueBuffers",
+                unsafe extern "C" fn(AlUint, AlSize, *mut AlUint)
+            ),
+            alc_open_device: symbol!(
+                "alcOpenDevice",
+                unsafe extern "C" fn(*const c_char) -> *mut AlcDevice
+            ),
+            alc_close_device: symbol!(
+                "alcCloseDevice",
+                unsafe extern "C" fn(*mut AlcDevice) -> AlcBoolean
+            ),
+            alc_create_context: symbol!(
+                "alcCreateContext",
+                unsafe extern "C" fn(*mut AlcDevice, *const AlcInt) -> *mut AlcContext
+            ),
+            alc_destroy_context: symbol!(
+                "alcDestroyContext",
+                unsafe extern "C" fn(*mut AlcContext)
+            ),
+            alc_make_context_current: symbol!(
+                "alcMakeContextCurrent",
+                unsafe extern "C" fn(*mut AlcContext) -> AlcBoolean
+            ),
+            alc_get_error: symbol!(
+                "alcGetError",
+                unsafe extern "C" fn(*mut AlcDevice) -> AlcEnum
+            ),
+            alc_is_extension_present: symbol!(
+                "alcIsExtensionPresent",
+                unsafe extern "C" fn(*mut AlcDevice, *const c_char) -> AlcBoolean
+            ),
+            alc_get_integerv: symbol!(
+                "alcGetIntegerv",
+                unsafe extern "C" fn(*mut AlcDevice, AlcEnum, AlSize, *mut AlcInt)
+            ),
+            _library: library,
+        })
+    }
+
+    fn al_error(&self, operation: &str) -> Result<(), String> {
+        // SAFETY: alGetError has no pointer arguments and the current thread owns a
+        // live context.
+        let error = unsafe { (self.al_get_error)() };
+        if error == AL_NO_ERROR {
+            Ok(())
+        } else {
+            Err(format!("{operation}: OpenAL error 0x{error:04x}"))
+        }
+    }
+
+    fn alc_error(&self, device: *mut AlcDevice, operation: &str) -> Result<(), String> {
+        // SAFETY: device is a live handle returned by alcOpenDevice and owned by
+        // ContextInner.
+        let error = unsafe { (self.alc_get_error)(device) };
+        if error == 0 {
+            Ok(())
+        } else {
+            Err(format!("{operation}: OpenALC error 0x{error:04x}"))
+        }
+    }
+}
+
+fn library_names() -> &'static [&'static str] {
+    #[cfg(target_os = "windows")]
+    {
+        &["OpenAL.dll", "OpenAL32.dll", "soft_oal.dll"]
+    }
+    #[cfg(target_os = "macos")]
+    {
+        &[
+            "libopenal.1.dylib",
+            "libopenal.dylib",
+            "/System/Library/Frameworks/OpenAL.framework/OpenAL",
+        ]
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        &["libopenal.so.1", "libopenal.so"]
+    }
+    #[cfg(not(any(unix, target_os = "windows")))]
+    {
+        &[]
+    }
+}
+
+struct ContextInner {
+    api: Api,
+    device: *mut AlcDevice,
+    context: *mut AlcContext,
+}
+
+impl Drop for ContextInner {
+    fn drop(&mut self) {
+        // SAFETY: This thread exclusively owns the current context; null detaches it
+        // before destroy.
+        unsafe { (self.api.alc_make_context_current)(std::ptr::null_mut()) };
+        // SAFETY: context is a live handle created exactly once by alcCreateContext and
+        // is dropped once.
+        unsafe { (self.api.alc_destroy_context)(self.context) };
+        // SAFETY: device is a live handle created exactly once by alcOpenDevice and is
+        // closed once, after its dependent context has been destroyed.
+        unsafe { (self.api.alc_close_device)(self.device) };
+    }
+}
+
+pub(super) struct Context {
+    inner: Rc<ContextInner>,
+    pub static_source_limit: usize,
+    pub streaming_source_limit: usize,
+}
+
+impl Context {
+    pub fn open_default(use_hrtf: bool) -> Result<Self, String> {
+        let api = Api::load()?;
+        // SAFETY: A null name requests OpenAL's default playback device.
+        let device = unsafe { (api.alc_open_device)(std::ptr::null()) };
+        if device.is_null() {
+            return Err("alcOpenDevice returned null".to_string());
+        }
+        if let Err(e) = api.alc_error(device, "open device") {
+            // SAFETY: device was successfully opened above and no context depends on it
+            // yet.
+            unsafe { (api.alc_close_device)(device) };
+            return Err(e);
+        }
+
+        Self::create_for_device(api, device, use_hrtf)
+    }
+
+    fn create_for_device(api: Api, device: *mut AlcDevice, use_hrtf: bool) -> Result<Self, String> {
+        let mut major = 0;
+        let mut minor = 0;
+        // SAFETY: device is live; both output pointers reference valid AlcInt storage
+        // for one element.
+        unsafe { (api.alc_get_integerv)(device, ALC_MAJOR_VERSION, 1, &mut major) };
+        // SAFETY: same invariant as the preceding version query.
+        unsafe { (api.alc_get_integerv)(device, ALC_MINOR_VERSION, 1, &mut minor) };
+        if let Err(e) = api.alc_error(device, "query OpenALC version") {
+            // SAFETY: no context was created, so device may be closed directly.
+            unsafe { (api.alc_close_device)(device) };
+            return Err(e);
+        }
+        if major < 1 || (major == 1 && minor < 1) {
+            // SAFETY: no context was created, so device may be closed directly.
+            unsafe { (api.alc_close_device)(device) };
+            return Err(format!("OpenALC 1.1 required, found {major}.{minor}"));
+        }
+
+        let hrtf_extension = CString::new("ALC_SOFT_HRTF").expect("static string has no nul");
+        // SAFETY: device is live and the CString is NUL-terminated for the duration of
+        // the call.
+        let has_hrtf =
+            unsafe { (api.alc_is_extension_present)(device, hrtf_extension.as_ptr()) } != ALC_FALSE;
+        let limiter_extension =
+            CString::new("ALC_SOFT_output_limiter").expect("static string has no nul");
+        // SAFETY: device is live and the CString is NUL-terminated for the duration of
+        // the call.
+        let has_output_limiter =
+            unsafe { (api.alc_is_extension_present)(device, limiter_extension.as_ptr()) }
+                != ALC_FALSE;
+
+        let mut attributes = Vec::with_capacity(7);
+        if has_hrtf {
+            let mut count = 0;
+            // SAFETY: device is live and count points to one valid AlcInt output element.
+            unsafe { (api.alc_get_integerv)(device, ALC_NUM_HRTF_SPECIFIERS_SOFT, 1, &mut count) };
+            if count > 0 {
+                attributes.extend_from_slice(&[
+                    ALC_HRTF_SOFT,
+                    AlcInt::from(use_hrtf),
+                    ALC_HRTF_ID_SOFT,
+                    0,
+                ]);
+            }
+        }
+        if has_output_limiter {
+            attributes.extend_from_slice(&[ALC_OUTPUT_LIMITER_SOFT, 1]);
+        }
+        attributes.push(0);
+        // SAFETY: device is live and attributes is terminated by 0 as required by
+        // alcCreateContext.
+        let context = unsafe { (api.alc_create_context)(device, attributes.as_ptr()) };
+        if context.is_null() {
+            let error = match api.alc_error(device, "create context") {
+                Ok(()) => "alcCreateContext returned null".to_string(),
+                Err(e) => e,
+            };
+            // SAFETY: context creation failed, so device has no dependent context.
+            unsafe { (api.alc_close_device)(device) };
+            return Err(error);
+        }
+        // SAFETY: context is live and owned exclusively by this thread.
+        if unsafe { (api.alc_make_context_current)(context) } == ALC_FALSE {
+            // SAFETY: context and device were created above and are not owned elsewhere
+            // yet.
+            unsafe { (api.alc_destroy_context)(context) };
+            // SAFETY: context was destroyed immediately above, leaving no dependent object.
+            unsafe { (api.alc_close_device)(device) };
+            return Err("alcMakeContextCurrent failed".to_string());
+        }
+        if let Err(e) = api.alc_error(device, "make context current") {
+            // SAFETY: this thread just made the context current; detach it before
+            // destruction.
+            unsafe { (api.alc_make_context_current)(std::ptr::null_mut()) };
+            // SAFETY: this is still the sole owner of both handles on the initialization
+            // path.
+            unsafe { (api.alc_destroy_context)(context) };
+            // SAFETY: dependent context was destroyed immediately above.
+            unsafe { (api.alc_close_device)(device) };
+            return Err(e);
+        }
+
+        let source_distance_model =
+            CString::new("AL_EXT_source_distance_model").expect("static string has no nul");
+        let linear_distance =
+            CString::new("AL_EXT_LINEAR_DISTANCE").expect("static string has no nul");
+        // SAFETY: a context is current and both extension-name CStrings are valid for
+        // the call.
+        let has_source_distance =
+            unsafe { (api.al_is_extension_present)(source_distance_model.as_ptr()) } != 0;
+        // SAFETY: same current-context and CString validity invariant as above.
+        let has_linear_distance =
+            unsafe { (api.al_is_extension_present)(linear_distance.as_ptr()) } != 0;
+        if !has_source_distance || !has_linear_distance {
+            // SAFETY: initialization has exclusive ownership of context and device.
+            unsafe { (api.alc_make_context_current)(std::ptr::null_mut()) };
+            // SAFETY: context remains live and is destroyed exactly once here.
+            unsafe { (api.alc_destroy_context)(context) };
+            // SAFETY: context was destroyed above, so device can be closed.
+            unsafe { (api.alc_close_device)(device) };
+            return Err("required OpenAL distance-model extensions are unavailable".to_string());
+        }
+        // SAFETY: a live context is current; Vanilla enables AL_SOURCE_DISTANCE_MODEL
+        // globally.
+        unsafe { (api.al_enable)(AL_SOURCE_DISTANCE_MODEL) };
+        if let Err(e) = api.al_error("enable per-source distance models") {
+            // SAFETY: initialization has exclusive ownership of context and device.
+            unsafe { (api.alc_make_context_current)(std::ptr::null_mut()) };
+            // SAFETY: context remains live and is destroyed exactly once here.
+            unsafe { (api.alc_destroy_context)(context) };
+            // SAFETY: context was destroyed above, so device can be closed.
+            unsafe { (api.alc_close_device)(device) };
+            return Err(e);
+        }
+
+        let total_sources = query_source_count(&api, device).unwrap_or(30);
+        let streaming = ((total_sources as f32).sqrt() as usize).clamp(2, 8);
+        let static_sources = total_sources.saturating_sub(streaming).clamp(8, 255);
+        let inner = Rc::new(ContextInner {
+            api,
+            device,
+            context,
+        });
+        Ok(Self {
+            inner,
+            static_source_limit: static_sources,
+            streaming_source_limit: streaming,
+        })
+    }
+
+    pub fn version(&self) -> Option<String> {
+        // SAFETY: the context is current on its owning audio thread; AL_VERSION returns
+        // either null or a static NUL-terminated string owned by OpenAL.
+        let ptr = unsafe { (self.inner.api.al_get_string)(AL_VERSION) };
+        if ptr.is_null() {
+            return None;
+        }
+        // SAFETY: OpenAL guarantees a NUL-terminated string for non-null alGetString
+        // results.
+        Some(
+            unsafe { CStr::from_ptr(ptr) }
+                .to_string_lossy()
+                .into_owned(),
+        )
+    }
+
+    pub fn set_listener(
+        &self,
+        position: [f32; 3],
+        forward: [f32; 3],
+        up: [f32; 3],
+    ) -> Result<(), String> {
+        // SAFETY: a live context is current and scalar listener coordinates need no
+        // borrowed storage.
+        unsafe {
+            (self.inner.api.al_listener3f)(AL_POSITION, position[0], position[1], position[2])
+        };
+        let orientation = [forward[0], forward[1], forward[2], up[0], up[1], up[2]];
+        // SAFETY: orientation points to six contiguous f32 values and remains valid for
+        // the call.
+        unsafe { (self.inner.api.al_listenerfv)(AL_ORIENTATION, orientation.as_ptr()) };
+        self.inner.api.al_error("set listener transform")
+    }
+
+    pub fn create_source(&self) -> Result<Source, String> {
+        let mut id = 0;
+        // SAFETY: id points to one valid AlUint output slot and this context is
+        // current.
+        unsafe { (self.inner.api.al_gen_sources)(1, &mut id) };
+        if let Err(error) = self.inner.api.al_error("allocate source") {
+            if id != 0 {
+                // SAFETY: alGenSources wrote this id during the failed allocation call;
+                // deleting a non-zero returned id prevents a partial-initialization leak.
+                unsafe { (self.inner.api.al_delete_sources)(1, &id) };
+                let _ = self.inner.api.al_error("clean up failed source allocation");
+            }
+            return Err(error);
+        }
+        if id == 0 {
+            return Err("alGenSources returned source 0".to_string());
+        }
+        Ok(Source {
+            context: Rc::clone(&self.inner),
+            id,
+        })
+    }
+
+    pub fn create_buffer(&self, format: PcmFormat, samples: &[i16]) -> Result<Buffer, String> {
+        let al_format = match format.channels {
+            1 => AL_FORMAT_MONO16,
+            2 => AL_FORMAT_STEREO16,
+            channels => return Err(format!("unsupported OpenAL channel count {channels}")),
+        };
+        let byte_len = samples
+            .len()
+            .checked_mul(std::mem::size_of::<i16>())
+            .and_then(|len| AlSize::try_from(len).ok())
+            .ok_or_else(|| "PCM buffer is too large for OpenAL".to_string())?;
+        let sample_rate = AlSize::try_from(format.sample_rate)
+            .map_err(|_| "sample rate does not fit OpenAL integer range".to_string())?;
+        let mut id = 0;
+        // SAFETY: id points to one valid AlUint output slot and this context is
+        // current.
+        unsafe { (self.inner.api.al_gen_buffers)(1, &mut id) };
+        if let Err(error) = self.inner.api.al_error("allocate buffer") {
+            if id != 0 {
+                // SAFETY: alGenBuffers wrote this id during the failed allocation call;
+                // deleting a non-zero returned id prevents a partial-initialization leak.
+                unsafe { (self.inner.api.al_delete_buffers)(1, &id) };
+                let _ = self.inner.api.al_error("clean up failed buffer allocation");
+            }
+            return Err(error);
+        }
+        if id == 0 {
+            return Err("alGenBuffers returned buffer 0".to_string());
+        }
+        // SAFETY: samples points to byte_len initialized bytes. OpenAL copies buffer
+        // data before alBufferData returns, so the borrowed slice need not
+        // outlive this call.
+        unsafe {
+            (self.inner.api.al_buffer_data)(
+                id,
+                al_format,
+                samples.as_ptr().cast(),
+                byte_len,
+                sample_rate,
+            )
+        };
+        if let Err(e) = self.inner.api.al_error("upload PCM buffer") {
+            // SAFETY: id was generated above and has not been transferred elsewhere.
+            unsafe { (self.inner.api.al_delete_buffers)(1, &id) };
+            return Err(e);
+        }
+        Ok(Buffer {
+            context: Rc::clone(&self.inner),
+            id,
+        })
+    }
+}
+
+fn query_source_count(api: &Api, device: *mut AlcDevice) -> Option<usize> {
+    let mut size = 0;
+    // SAFETY: device is live and size points to one valid AlcInt output element.
+    unsafe { (api.alc_get_integerv)(device, ALC_ATTRIBUTES_SIZE, 1, &mut size) };
+    if api
+        .alc_error(device, "query context attribute size")
+        .is_err()
+        || size <= 0
+    {
+        return None;
+    }
+    let mut attributes = vec![0; usize::try_from(size).ok()?];
+    // SAFETY: attributes has exactly `size` writable AlcInt elements.
+    unsafe { (api.alc_get_integerv)(device, ALC_ALL_ATTRIBUTES, size, attributes.as_mut_ptr()) };
+    if api.alc_error(device, "query context attributes").is_err() {
+        return None;
+    }
+    for pair in attributes.chunks_exact(2) {
+        if pair[0] == 0 {
+            break;
+        }
+        if pair[0] == ALC_MONO_SOURCES {
+            return usize::try_from(pair[1]).ok();
+        }
+    }
+    None
+}
+
+pub(super) struct Buffer {
+    context: Rc<ContextInner>,
+    id: AlUint,
+}
+
+impl Drop for Buffer {
+    fn drop(&mut self) {
+        // SAFETY: id is owned by this Buffer, context is kept live by Rc, and Drop runs
+        // once.
+        unsafe { (self.context.api.al_delete_buffers)(1, &self.id) };
+        if let Err(e) = self.context.api.al_error("delete buffer") {
+            tracing::warn!("{e}");
+        }
+    }
+}
+
+pub(super) struct Source {
+    context: Rc<ContextInner>,
+    id: AlUint,
+}
+
+impl Source {
+    pub fn configure(
+        &self,
+        gain: f32,
+        pitch: f32,
+        position: [f32; 3],
+        relative: bool,
+        looping: bool,
+        attenuation_distance: Option<f32>,
+    ) -> Result<(), String> {
+        self.sourcef(AL_GAIN, gain)?;
+        self.sourcef(AL_PITCH, pitch)?;
+        self.sourcei(
+            AL_SOURCE_RELATIVE,
+            if relative { AL_TRUE } else { AL_FALSE },
+        )?;
+        self.sourcei(AL_LOOPING, if looping { AL_TRUE } else { AL_FALSE })?;
+        // SAFETY: source id is live and position is passed by value.
+        unsafe {
+            (self.context.api.al_source3f)(
+                self.id,
+                AL_POSITION,
+                position[0],
+                position[1],
+                position[2],
+            )
+        };
+        self.context.api.al_error("set source position")?;
+        match attenuation_distance {
+            Some(max_distance) => {
+                self.sourcei(AL_DISTANCE_MODEL, AL_LINEAR_DISTANCE)?;
+                self.sourcef(AL_MAX_DISTANCE, max_distance)?;
+                self.sourcef(AL_ROLLOFF_FACTOR, 1.0)?;
+                self.sourcef(AL_REFERENCE_DISTANCE, 0.0)?;
+            }
+            None => self.sourcei(AL_DISTANCE_MODEL, 0)?,
+        }
+        Ok(())
+    }
+
+    pub fn set_gain(&self, gain: f32) -> Result<(), String> {
+        self.sourcef(AL_GAIN, gain)
+    }
+
+    pub fn set_position(&self, position: [f32; 3]) -> Result<(), String> {
+        // SAFETY: source id is live and position is passed by value.
+        unsafe {
+            (self.context.api.al_source3f)(
+                self.id,
+                AL_POSITION,
+                position[0],
+                position[1],
+                position[2],
+            )
+        };
+        self.context.api.al_error("set source position")
+    }
+
+    pub fn attach_static(&self, buffer: &Buffer) -> Result<(), String> {
+        if !Rc::ptr_eq(&self.context, &buffer.context) {
+            return Err("source and buffer belong to different OpenAL contexts".to_string());
+        }
+        let id = AlInt::try_from(buffer.id).map_err(|_| "buffer id exceeds ALint".to_string())?;
+        self.sourcei(AL_BUFFER, id)
+    }
+
+    pub fn queue_buffer(&self, buffer: &Buffer) -> Result<(), String> {
+        if !Rc::ptr_eq(&self.context, &buffer.context) {
+            return Err("source and buffer belong to different OpenAL contexts".to_string());
+        }
+        // SAFETY: both ids are live in the same current context; one buffer id is
+        // readable here.
+        unsafe { (self.context.api.al_source_queue_buffers)(self.id, 1, &buffer.id) };
+        self.context.api.al_error("queue stream buffer")
+    }
+
+    pub fn remove_processed(&self, queued: &mut VecDeque<Buffer>) -> Result<usize, String> {
+        let processed = self.get_sourcei(AL_BUFFERS_PROCESSED)?.max(0);
+        let processed =
+            usize::try_from(processed).map_err(|_| "invalid processed count".to_string())?;
+        for _ in 0..processed {
+            let mut id = 0;
+            // SAFETY: OpenAL reports this source has a processed buffer available to
+            // unqueue.
+            unsafe { (self.context.api.al_source_unqueue_buffers)(self.id, 1, &mut id) };
+            self.context.api.al_error("unqueue stream buffer")?;
+            let expected = queued
+                .front()
+                .ok_or_else(|| "OpenAL processed more buffers than Pomme queued".to_string())?;
+            if expected.id != id {
+                return Err(format!(
+                    "OpenAL unqueued buffer {id}, expected {}",
+                    expected.id
+                ));
+            }
+            drop(queued.pop_front());
+        }
+        Ok(processed)
+    }
+
+    pub fn clear_queue(&self, queued: &mut VecDeque<Buffer>) -> Result<(), String> {
+        self.stop()?;
+        let count = self.get_sourcei(AL_BUFFERS_QUEUED)?.max(0);
+        let count = usize::try_from(count).map_err(|_| "invalid queued count".to_string())?;
+        for _ in 0..count {
+            let mut id = 0;
+            // SAFETY: after stopping a source, its queued buffers are available to unqueue.
+            unsafe { (self.context.api.al_source_unqueue_buffers)(self.id, 1, &mut id) };
+            self.context.api.al_error("clear stream buffer")?;
+            let expected = queued
+                .front()
+                .ok_or_else(|| "OpenAL queued more buffers than Pomme tracks".to_string())?;
+            if expected.id != id {
+                return Err(format!(
+                    "OpenAL cleared buffer {id}, expected {}",
+                    expected.id
+                ));
+            }
+            drop(queued.pop_front());
+        }
+        Ok(())
+    }
+
+    pub fn play(&self) -> Result<(), String> {
+        // SAFETY: id is a live source owned by this Source and its context is current.
+        unsafe { (self.context.api.al_source_play)(self.id) };
+        self.context.api.al_error("play source")
+    }
+
+    pub fn stop(&self) -> Result<(), String> {
+        // SAFETY: id is a live source owned by this Source and its context is current.
+        unsafe { (self.context.api.al_source_stop)(self.id) };
+        self.context.api.al_error("stop source")
+    }
+
+    pub fn state(&self) -> Result<SourceState, String> {
+        Ok(match self.get_sourcei(AL_SOURCE_STATE)? {
+            AL_PLAYING => SourceState::Playing,
+            AL_PAUSED => SourceState::Paused,
+            AL_STOPPED => SourceState::Stopped,
+            AL_INITIAL => SourceState::Initial,
+            other => SourceState::Unknown(other),
+        })
+    }
+
+    fn sourcef(&self, param: AlEnum, value: f32) -> Result<(), String> {
+        // SAFETY: id is live, param is an OpenAL source float property, and context is
+        // current.
+        unsafe { (self.context.api.al_sourcef)(self.id, param, value) };
+        self.context.api.al_error("set source float")
+    }
+
+    fn sourcei(&self, param: AlEnum, value: AlInt) -> Result<(), String> {
+        // SAFETY: id is live, param is an OpenAL source integer property, and context
+        // is current.
+        unsafe { (self.context.api.al_sourcei)(self.id, param, value) };
+        self.context.api.al_error(&format!(
+            "set source integer parameter 0x{param:04x} to 0x{value:x}"
+        ))
+    }
+
+    fn get_sourcei(&self, param: AlEnum) -> Result<AlInt, String> {
+        let mut value = 0;
+        // SAFETY: id is live and value points to one writable AlInt output slot.
+        unsafe { (self.context.api.al_get_sourcei)(self.id, param, &mut value) };
+        self.context.api.al_error("query source integer")?;
+        Ok(value)
+    }
+}
+
+impl Drop for Source {
+    fn drop(&mut self) {
+        // SAFETY: id is owned by this Source, context remains live via Rc, and Drop
+        // runs once.
+        unsafe { (self.context.api.al_source_stop)(self.id) };
+        // SAFETY: same ownership invariant; delete occurs exactly once after stopping.
+        unsafe { (self.context.api.al_delete_sources)(1, &self.id) };
+        if let Err(e) = self.context.api.al_error("delete source") {
+            tracing::warn!("{e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_distance_model_capability_and_property_are_distinct() {
+        assert_eq!(AL_SOURCE_DISTANCE_MODEL, 0x0200);
+        assert_eq!(AL_DISTANCE_MODEL, 0xd000);
+        assert_eq!(AL_LINEAR_DISTANCE, 0xd003);
+        assert_ne!(AL_SOURCE_DISTANCE_MODEL, AL_DISTANCE_MODEL);
+    }
+}

--- a/pomme-client/src/audio/sounds.rs
+++ b/pomme-client/src/audio/sounds.rs
@@ -5,6 +5,9 @@ use crate::assets::{AssetIndex, resolve_asset_path};
 use crate::resource_pack::ResourcePackManager;
 use crate::util::JavaRandom;
 
+/// Vanilla `SoundEventRegistrationSerializer`'s `attenuation_distance` default.
+const DEFAULT_ATTENUATION_DISTANCE: i32 = 16;
+
 /// A single playable file variant from `sounds.json` after resolving any
 /// `type: "event"` indirection.
 #[derive(Clone, Debug, PartialEq)]
@@ -42,6 +45,7 @@ struct SoundEvent {
 
 /// Parsed `sounds.json` registry across the built-in assets and active resource
 /// packs.
+#[derive(Default)]
 pub struct SoundsIndex {
     events: HashMap<String, SoundEvent>,
 }
@@ -103,6 +107,29 @@ impl SoundsIndex {
     pub fn choose(&self, event: &str, seed: Option<u64>) -> Option<SoundVariant> {
         let mut random = SoundRandom::new(seed);
         self.choose_inner(normalize_event_name(event), &mut random, &mut Vec::new())
+    }
+
+    /// A one-event index, so a test can dispatch a sound without a resource
+    /// pack on disk.
+    #[cfg(test)]
+    pub fn for_test_event(event: &str) -> Self {
+        let variant = SoundVariant {
+            path: PathBuf::from("test.ogg"),
+            weight: 1,
+            volume: 1.0,
+            pitch: 1.0,
+            stream: false,
+            attenuation_distance: DEFAULT_ATTENUATION_DISTANCE as f32,
+        };
+        Self {
+            events: HashMap::from([(
+                normalize_event_name(event).to_string(),
+                SoundEvent {
+                    entries: vec![SoundEntry::File(variant)],
+                    subtitle: None,
+                },
+            )]),
+        }
     }
 
     /// The subtitle translation key for an event, e.g.
@@ -225,7 +252,7 @@ impl SoundsIndex {
                     volume: 1.0,
                     pitch: 1.0,
                     stream: false,
-                    attenuation_distance: 16.0,
+                    attenuation_distance: DEFAULT_ATTENUATION_DISTANCE as f32,
                 })))
             }
             serde_json::Value::Object(map) => {
@@ -248,7 +275,8 @@ impl SoundsIndex {
                 }
                 let stream = json_bool(map, "stream", false)?;
                 let _preload = json_bool(map, "preload", false)?;
-                let attenuation_distance = json_i32(map, "attenuation_distance", 16)? as f32;
+                let attenuation_distance =
+                    json_i32(map, "attenuation_distance", DEFAULT_ATTENUATION_DISTANCE)? as f32;
                 let sound_type = match map.get("type") {
                     Some(value) => value
                         .as_str()
@@ -484,7 +512,7 @@ mod tests {
             volume: 1.0,
             pitch: 1.0,
             stream: false,
-            attenuation_distance: 16.0,
+            attenuation_distance: DEFAULT_ATTENUATION_DISTANCE as f32,
         })
     }
 

--- a/pomme-client/src/audio/sounds.rs
+++ b/pomme-client/src/audio/sounds.rs
@@ -1,116 +1,742 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::assets::{AssetIndex, resolve_asset_path};
+use crate::resource_pack::ResourcePackManager;
+use crate::util::JavaRandom;
 
-/// A single playable variant for a sound event, as listed in `sounds.json`.
+/// A single playable file variant from `sounds.json` after resolving any
+/// `type: "event"` indirection.
+#[derive(Clone, Debug, PartialEq)]
 pub struct SoundVariant {
-    /// The resource name, e.g. `music/menu/menu1` or `namespace:path`.
-    pub name: String,
+    /// Resolved file in the current resource-pack stack.
+    pub path: PathBuf,
     pub weight: u32,
     /// Per-entry volume multiplier (defaults to 1.0 when unspecified).
     pub volume: f32,
+    /// Per-entry pitch multiplier (defaults to 1.0 when unspecified).
+    pub pitch: f32,
+    /// Whether Vanilla decodes this sound as a queued stream.
+    pub stream: bool,
+    /// Vanilla per-entry attenuation distance in blocks.
+    pub attenuation_distance: f32,
 }
 
-/// A sound event's entry in `sounds.json`: its variants and optional
+#[derive(Clone, Debug)]
+enum SoundEntry {
+    File(SoundVariant),
+    Event {
+        name: String,
+        volume: f32,
+        pitch: f32,
+        stream: bool,
+    },
+}
+
+/// A sound event's entry in `sounds.json`: its weighted entries and optional
 /// subtitle translation key.
 struct SoundEvent {
-    variants: Vec<SoundVariant>,
+    entries: Vec<SoundEntry>,
     subtitle: Option<String>,
 }
 
-/// Parsed `sounds.json`: a map from event name (e.g. `music.menu`) to its
-/// definition.
+/// Parsed `sounds.json` registry across the built-in assets and active resource
+/// packs.
 pub struct SoundsIndex {
     events: HashMap<String, SoundEvent>,
 }
 
 impl SoundsIndex {
-    /// Loads and parses `minecraft/sounds.json` from the asset index / jar
-    /// assets. Returns an empty index if the file is missing or malformed.
-    pub fn load(jar_assets_dir: &Path, asset_index: &Option<AssetIndex>) -> Self {
-        let path = resolve_asset_path(jar_assets_dir, asset_index, "minecraft/sounds.json");
-        let mut events = HashMap::new();
-
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            tracing::warn!("sounds.json not found at {}", path.display());
-            return Self { events };
-        };
-        let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
-            tracing::warn!("failed to parse sounds.json");
-            return Self { events };
-        };
-        let Some(obj) = json.as_object() else {
-            return Self { events };
+    /// Loads the built-in `minecraft/sounds.json`, then applies every active
+    /// resource-pack `sounds.json` from low to high priority. Higher packs
+    /// append by default and reset an event only when `replace: true`,
+    /// matching Vanilla.
+    pub fn load(
+        jar_assets_dir: &Path,
+        asset_index: &Option<AssetIndex>,
+        packs: &ResourcePackManager,
+    ) -> Self {
+        let mut index = Self {
+            events: HashMap::new(),
         };
 
-        for (event, def) in obj {
-            let Some(sounds) = def.get("sounds").and_then(|s| s.as_array()) else {
+        let resolve_sound = |name: &str| {
+            let asset_key = sound_asset_key(name);
+            if let Some(path) = packs.resolve_asset(&asset_key) {
+                return Some(path);
+            }
+            if let Some(path) = asset_index.as_ref().and_then(|idx| idx.resolve(&asset_key)) {
+                return Some(path);
+            }
+            let path = jar_assets_dir.join(&asset_key);
+            path.is_file().then_some(path)
+        };
+
+        let base = resolve_asset_path(jar_assets_dir, asset_index, "minecraft/sounds.json");
+        index.apply_file("minecraft", &base, &resolve_sound);
+
+        for pack_dir in packs.active_pack_dirs() {
+            let assets_dir = pack_dir.join("assets");
+            let Ok(entries) = std::fs::read_dir(&assets_dir) else {
                 continue;
             };
-            let mut variants = Vec::new();
-            for entry in sounds {
-                match entry {
-                    // Bare string form: `"music/menu/menu1"`.
-                    serde_json::Value::String(name) => {
-                        variants.push(SoundVariant {
-                            name: name.clone(),
-                            weight: 1,
-                            volume: 1.0,
-                        });
-                    }
-                    // Object form: `{ "name", "weight", "volume", "type", ... }`.
-                    serde_json::Value::Object(map) => {
-                        // `type: "event"` redirects to another event; not handled yet.
-                        if map.get("type").and_then(|t| t.as_str()) == Some("event") {
-                            continue;
-                        }
-                        if let Some(name) = map.get("name").and_then(|n| n.as_str()) {
-                            let weight = map
-                                .get("weight")
-                                .and_then(|w| w.as_u64())
-                                .unwrap_or(1)
-                                .max(1) as u32;
-                            let volume =
-                                map.get("volume").and_then(|v| v.as_f64()).unwrap_or(1.0) as f32;
-                            variants.push(SoundVariant {
-                                name: name.to_string(),
-                                weight,
-                                volume,
-                            });
-                        }
-                    }
-                    _ => {}
+            let mut namespaces: Vec<_> = entries
+                .flatten()
+                .filter(|entry| entry.path().is_dir())
+                .collect();
+            namespaces.sort_by_key(|entry| entry.file_name());
+            for namespace in namespaces {
+                let namespace_name = namespace.file_name().to_string_lossy().into_owned();
+                let sounds_path = namespace.path().join("sounds.json");
+                if sounds_path.is_file() {
+                    index.apply_file(&namespace_name, &sounds_path, &resolve_sound);
                 }
-            }
-            if !variants.is_empty() {
-                let subtitle = def
-                    .get("subtitle")
-                    .and_then(|s| s.as_str())
-                    .map(str::to_string);
-                events.insert(event.clone(), SoundEvent { variants, subtitle });
             }
         }
 
-        Self { events }
+        index
     }
 
-    pub fn variants(&self, event: &str) -> Option<&[SoundVariant]> {
-        self.events.get(event).map(|e| e.variants.as_slice())
+    /// Resolves an event to a concrete file using Vanilla's weighted selection
+    /// semantics. Event redirects contribute the referenced event's total
+    /// weight and consume another random draw when selected.
+    pub fn choose(&self, event: &str, seed: Option<u64>) -> Option<SoundVariant> {
+        let mut random = SoundRandom::new(seed);
+        self.choose_inner(normalize_event_name(event), &mut random, &mut Vec::new())
     }
 
     /// The subtitle translation key for an event, e.g.
     /// `subtitles.block.anvil.land`.
     pub fn subtitle(&self, event: &str) -> Option<&str> {
-        self.events.get(event)?.subtitle.as_deref()
+        self.events
+            .get(normalize_event_name(event))?
+            .subtitle
+            .as_deref()
+    }
+
+    fn apply_file(
+        &mut self,
+        namespace: &str,
+        path: &Path,
+        resolve_sound: &impl Fn(&str) -> Option<PathBuf>,
+    ) {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            tracing::warn!("sounds.json not found at {}", path.display());
+            return;
+        };
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+            tracing::warn!("failed to parse sounds.json at {}", path.display());
+            return;
+        };
+        if let Err(error) = self.apply_value(namespace, &json, resolve_sound) {
+            tracing::warn!("invalid sounds.json at {}: {error}", path.display());
+        }
+    }
+
+    fn apply_value(
+        &mut self,
+        namespace: &str,
+        json: &serde_json::Value,
+        resolve_sound: &impl Fn(&str) -> Option<PathBuf>,
+    ) -> Result<(), String> {
+        let registrations = self.parse_value(namespace, json, resolve_sound)?;
+        for (event_name, replace, event) in registrations {
+            match self.events.get_mut(&event_name) {
+                Some(existing) if replace => *existing = event,
+                Some(existing) => existing.entries.extend(event.entries),
+                None => {
+                    self.events.insert(event_name, event);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn parse_value(
+        &self,
+        namespace: &str,
+        json: &serde_json::Value,
+        resolve_sound: &impl Fn(&str) -> Option<PathBuf>,
+    ) -> Result<Vec<(String, bool, SoundEvent)>, String> {
+        let obj = json
+            .as_object()
+            .ok_or_else(|| "top-level value must be an object".to_string())?;
+        let mut registrations = Vec::with_capacity(obj.len());
+
+        for (event_path, def) in obj {
+            if !valid_resource_location_path(event_path) {
+                return Err(format!("invalid sound event path {event_path:?}"));
+            }
+            let def = def
+                .as_object()
+                .ok_or_else(|| format!("sound event {event_path:?} must be an object"))?;
+            let replace = match def.get("replace") {
+                Some(value) => value
+                    .as_bool()
+                    .ok_or_else(|| format!("sound event {event_path:?} has non-boolean replace"))?,
+                None => false,
+            };
+            let subtitle = match def.get("subtitle") {
+                Some(value) => Some(
+                    value
+                        .as_str()
+                        .ok_or_else(|| {
+                            format!("sound event {event_path:?} has non-string subtitle")
+                        })?
+                        .to_string(),
+                ),
+                None => None,
+            };
+            let sounds: &[serde_json::Value] = match def.get("sounds") {
+                Some(value) => value
+                    .as_array()
+                    .ok_or_else(|| format!("sound event {event_path:?} has non-array sounds"))?,
+                None => &[],
+            };
+            let mut entries = Vec::with_capacity(sounds.len());
+            for entry in sounds {
+                if let Some(entry) = self.parse_entry(entry, resolve_sound)? {
+                    entries.push(entry);
+                }
+            }
+            registrations.push((
+                event_key(namespace, event_path),
+                replace,
+                SoundEvent { entries, subtitle },
+            ));
+        }
+        Ok(registrations)
+    }
+
+    fn parse_entry(
+        &self,
+        entry: &serde_json::Value,
+        resolve_sound: &impl Fn(&str) -> Option<PathBuf>,
+    ) -> Result<Option<SoundEntry>, String> {
+        match entry {
+            serde_json::Value::String(name) => {
+                validate_sound_name(name)?;
+                let Some(path) = resolve_sound(name) else {
+                    return Ok(None);
+                };
+                Ok(Some(SoundEntry::File(SoundVariant {
+                    path,
+                    weight: 1,
+                    volume: 1.0,
+                    pitch: 1.0,
+                    stream: false,
+                    attenuation_distance: 16.0,
+                })))
+            }
+            serde_json::Value::Object(map) => {
+                let name = map
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| "sound object is missing string name".to_string())?;
+                validate_sound_name(name)?;
+                let volume = json_f32(map, "volume", 1.0)?;
+                if volume <= 0.0 {
+                    return Err("invalid sound volume".to_string());
+                }
+                let pitch = json_f32(map, "pitch", 1.0)?;
+                if pitch <= 0.0 {
+                    return Err("invalid sound pitch".to_string());
+                }
+                let weight = json_i32(map, "weight", 1)?;
+                if weight <= 0 {
+                    return Err("invalid sound weight".to_string());
+                }
+                let stream = json_bool(map, "stream", false)?;
+                let _preload = json_bool(map, "preload", false)?;
+                let attenuation_distance = json_i32(map, "attenuation_distance", 16)? as f32;
+                let sound_type = match map.get("type") {
+                    Some(value) => value
+                        .as_str()
+                        .ok_or_else(|| "sound type must be a string".to_string())?,
+                    None => "file",
+                };
+
+                match sound_type {
+                    "event" => Ok(Some(SoundEntry::Event {
+                        name: normalize_event_name(name).to_string(),
+                        volume,
+                        pitch,
+                        stream,
+                    })),
+                    "file" => {
+                        let Some(path) = resolve_sound(name) else {
+                            return Ok(None);
+                        };
+                        Ok(Some(SoundEntry::File(SoundVariant {
+                            path,
+                            weight: weight as u32,
+                            volume,
+                            pitch,
+                            stream,
+                            attenuation_distance,
+                        })))
+                    }
+                    other => Err(format!("invalid sound type {other:?}")),
+                }
+            }
+            _ => Err("sound entry must be a string or object".to_string()),
+        }
+    }
+
+    fn choose_inner(
+        &self,
+        event: &str,
+        random: &mut SoundRandom,
+        stack: &mut Vec<String>,
+    ) -> Option<SoundVariant> {
+        if stack.iter().any(|entry| entry == event) {
+            tracing::warn!("cyclic sound event reference involving {event}");
+            return None;
+        }
+        let sound_event = self.events.get(event)?;
+        stack.push(event.to_string());
+
+        let weights: Vec<u32> = sound_event
+            .entries
+            .iter()
+            .map(|entry| self.entry_weight(entry, stack))
+            .collect();
+        let total = weights
+            .iter()
+            .try_fold(0_u32, |total, &weight| total.checked_add(weight))?;
+        let mut pick = random.next(total)?;
+
+        let selected = sound_event
+            .entries
+            .iter()
+            .zip(weights)
+            .find_map(|(entry, weight)| {
+                if pick < weight {
+                    Some(entry)
+                } else {
+                    pick -= weight;
+                    None
+                }
+            })?;
+
+        let result = match selected {
+            SoundEntry::File(variant) => Some(variant.clone()),
+            SoundEntry::Event {
+                name,
+                volume,
+                pitch,
+                stream,
+            } => {
+                let mut variant = self.choose_inner(name, random, stack)?;
+                variant.volume *= *volume;
+                variant.pitch *= *pitch;
+                variant.stream |= *stream;
+                Some(variant)
+            }
+        };
+        stack.pop();
+        result
+    }
+
+    fn event_weight(&self, event: &str, stack: &mut Vec<String>) -> u32 {
+        if stack.iter().any(|entry| entry == event) {
+            tracing::warn!("cyclic sound event reference involving {event}");
+            return 0;
+        }
+        let Some(sound_event) = self.events.get(event) else {
+            return 0;
+        };
+        stack.push(event.to_string());
+        let total = sound_event.entries.iter().fold(0_u32, |total, entry| {
+            total.saturating_add(self.entry_weight(entry, stack))
+        });
+        stack.pop();
+        total
+    }
+
+    fn entry_weight(&self, entry: &SoundEntry, stack: &mut Vec<String>) -> u32 {
+        match entry {
+            SoundEntry::File(variant) => variant.weight,
+            SoundEntry::Event { name, .. } => self.event_weight(name, stack),
+        }
     }
 }
 
-/// Converts a `sounds.json` variant name into an asset key.
+enum SoundRandom {
+    Seeded(JavaRandom),
+    Unseeded,
+}
+
+impl SoundRandom {
+    fn new(seed: Option<u64>) -> Self {
+        match seed {
+            Some(seed) => Self::Seeded(JavaRandom::new(seed as i64)),
+            None => Self::Unseeded,
+        }
+    }
+
+    fn next(&mut self, bound: u32) -> Option<u32> {
+        if bound == 0 {
+            return None;
+        }
+        match self {
+            Self::Seeded(random) => {
+                let bound = i32::try_from(bound).ok()?;
+                Some(random.next_int(bound) as u32)
+            }
+            Self::Unseeded => Some(fastrand::u32(0..bound)),
+        }
+    }
+}
+
+fn event_key(namespace: &str, path: &str) -> String {
+    if namespace == "minecraft" {
+        path.to_string()
+    } else {
+        format!("{namespace}:{path}")
+    }
+}
+
+fn normalize_event_name(name: &str) -> &str {
+    name.strip_prefix("minecraft:").unwrap_or(name)
+}
+
+fn validate_sound_name(name: &str) -> Result<(), String> {
+    let (namespace, path) = name.split_once(':').unwrap_or(("minecraft", name));
+    if namespace.is_empty()
+        || !namespace.bytes().all(|c| {
+            c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, b'_' | b'-' | b'.')
+        })
+        || !valid_resource_location_path(path)
+    {
+        return Err(format!("invalid sound identifier {name:?}"));
+    }
+    Ok(())
+}
+
+fn valid_resource_location_path(path: &str) -> bool {
+    !path.is_empty()
+        && path.bytes().all(|c| {
+            c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, b'_' | b'-' | b'.' | b'/')
+        })
+}
+
+fn json_bool(
+    map: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    default: bool,
+) -> Result<bool, String> {
+    match map.get(key) {
+        Some(value) => value
+            .as_bool()
+            .ok_or_else(|| format!("sound {key} must be a boolean")),
+        None => Ok(default),
+    }
+}
+
+fn json_f32(
+    map: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    default: f32,
+) -> Result<f32, String> {
+    match map.get(key) {
+        Some(value) => value
+            .as_f64()
+            .map(|value| value as f32)
+            .ok_or_else(|| format!("sound {key} must be a number")),
+        None => Ok(default),
+    }
+}
+
+fn json_i32(
+    map: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    default: i32,
+) -> Result<i32, String> {
+    match map.get(key) {
+        Some(value) => {
+            let value = value
+                .as_i64()
+                .ok_or_else(|| format!("sound {key} must be an integer"))?;
+            i32::try_from(value).map_err(|_| format!("sound {key} is out of range"))
+        }
+        None => Ok(default),
+    }
+}
+
+/// Converts a `sounds.json` file variant name into an asset key.
 ///
 /// `music/menu/menu1` -> `minecraft/sounds/music/menu/menu1.ogg`
 /// `namespace:path`   -> `namespace/sounds/path.ogg`
 pub fn sound_asset_key(name: &str) -> String {
     let (ns, path) = name.split_once(':').unwrap_or(("minecraft", name));
     format!("{ns}/sounds/{path}.ogg")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(name: &str, weight: u32) -> SoundEntry {
+        SoundEntry::File(SoundVariant {
+            path: PathBuf::from(name),
+            weight,
+            volume: 1.0,
+            pitch: 1.0,
+            stream: false,
+            attenuation_distance: 16.0,
+        })
+    }
+
+    fn resolve_test_sound(name: &str) -> Option<PathBuf> {
+        (!name.starts_with("missing")).then(|| PathBuf::from(name))
+    }
+
+    #[test]
+    fn sound_asset_key_handles_default_and_explicit_namespaces() {
+        assert_eq!(
+            sound_asset_key("music/menu/menu1"),
+            "minecraft/sounds/music/menu/menu1.ogg"
+        );
+        assert_eq!(sound_asset_key("mod:foo/bar"), "mod/sounds/foo/bar.ogg");
+    }
+
+    #[test]
+    fn stacked_registrations_append_and_replace_like_vanilla() {
+        let mut index = SoundsIndex {
+            events: HashMap::new(),
+        };
+        index
+            .apply_value(
+                "minecraft",
+                &serde_json::json!({
+                    "test": {"subtitle": "low", "sounds": ["a"]}
+                }),
+                &resolve_test_sound,
+            )
+            .unwrap();
+        index
+            .apply_value(
+                "minecraft",
+                &serde_json::json!({
+                    "test": {"subtitle": "ignored", "sounds": ["b"]}
+                }),
+                &resolve_test_sound,
+            )
+            .unwrap();
+        let event = index.events.get("test").unwrap();
+        assert_eq!(event.entries.len(), 2);
+        assert_eq!(event.subtitle.as_deref(), Some("low"));
+
+        index
+            .apply_value(
+                "minecraft",
+                &serde_json::json!({
+                    "test": {"replace": true, "subtitle": "high", "sounds": ["c"]}
+                }),
+                &resolve_test_sound,
+            )
+            .unwrap();
+        let event = index.events.get("test").unwrap();
+        assert_eq!(event.entries.len(), 1);
+        assert_eq!(event.subtitle.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn resource_pack_namespace_qualifies_event_name() {
+        let mut index = SoundsIndex {
+            events: HashMap::new(),
+        };
+        index
+            .apply_value(
+                "custom",
+                &serde_json::json!({"event": {"sounds": ["custom:clip"]}}),
+                &resolve_test_sound,
+            )
+            .unwrap();
+        assert!(index.events.contains_key("custom:event"));
+    }
+
+    #[test]
+    fn missing_file_entries_are_excluded_from_weighted_selection() {
+        let mut index = SoundsIndex {
+            events: HashMap::new(),
+        };
+        index
+            .apply_value(
+                "minecraft",
+                &serde_json::json!({
+                    "test": {"sounds": [
+                        {"name": "missing/file", "weight": 10},
+                        {"name": "present/file", "weight": 1}
+                    ]}
+                }),
+                &resolve_test_sound,
+            )
+            .unwrap();
+        let event = index.events.get("test").unwrap();
+        assert_eq!(event.entries.len(), 1);
+        assert_eq!(
+            index.choose("test", Some(0)).unwrap().path,
+            PathBuf::from("present/file")
+        );
+    }
+
+    #[test]
+    fn malformed_resource_layer_is_rejected_atomically() {
+        let mut index = SoundsIndex {
+            events: HashMap::new(),
+        };
+        index
+            .apply_value(
+                "minecraft",
+                &serde_json::json!({
+                    "test": {"subtitle": "base", "sounds": ["present/base"]}
+                }),
+                &resolve_test_sound,
+            )
+            .unwrap();
+
+        let result = index.apply_value(
+            "minecraft",
+            &serde_json::json!({
+                "test": {"replace": true, "subtitle": "replacement", "sounds": ["present/new"]},
+                "broken": {"sounds": [{"name": "present/bad", "weight": 0}]}
+            }),
+            &resolve_test_sound,
+        );
+        assert!(result.is_err());
+
+        let event = index.events.get("test").unwrap();
+        assert_eq!(event.subtitle.as_deref(), Some("base"));
+        assert_eq!(event.entries.len(), 1);
+        assert!(!index.events.contains_key("broken"));
+    }
+
+    #[test]
+    fn unknown_type_rejects_resource_but_negative_attenuation_is_valid() {
+        let mut index = SoundsIndex {
+            events: HashMap::new(),
+        };
+        assert!(
+            index
+                .apply_value(
+                    "minecraft",
+                    &serde_json::json!({
+                        "broken": {"sounds": [{"name": "present/file", "type": "mystery"}]}
+                    }),
+                    &resolve_test_sound,
+                )
+                .is_err()
+        );
+        assert!(index.events.is_empty());
+
+        index
+            .apply_value(
+                "minecraft",
+                &serde_json::json!({
+                    "test": {"sounds": [{"name": "present/file", "attenuation_distance": -4}]}
+                }),
+                &resolve_test_sound,
+            )
+            .unwrap();
+        let SoundEntry::File(variant) = &index.events.get("test").unwrap().entries[0] else {
+            panic!("expected file sound");
+        };
+        assert_eq!(variant.attenuation_distance, -4.0);
+    }
+
+    #[test]
+    fn event_redirect_uses_nested_random_draw_and_multiplies_parameters() {
+        let index = SoundsIndex {
+            events: HashMap::from([
+                (
+                    "target".to_string(),
+                    SoundEvent {
+                        entries: vec![file("first", 1), file("second", 1)],
+                        subtitle: None,
+                    },
+                ),
+                (
+                    "parent".to_string(),
+                    SoundEvent {
+                        entries: vec![SoundEntry::Event {
+                            name: "target".to_string(),
+                            volume: 0.5,
+                            pitch: 2.0,
+                            stream: true,
+                        }],
+                        subtitle: None,
+                    },
+                ),
+            ]),
+        };
+
+        // LegacyRandomSource(1) draws 1 then 0 for nextInt(2). The first draw
+        // selects the only redirect; the nested draw therefore selects `first`.
+        let resolved = index.choose("parent", Some(1)).unwrap();
+        assert_eq!(resolved.path, PathBuf::from("first"));
+        assert_eq!(resolved.volume, 0.5);
+        assert_eq!(resolved.pitch, 2.0);
+        assert!(resolved.stream);
+        assert_eq!(resolved.attenuation_distance, 16.0);
+    }
+
+    #[test]
+    fn missing_event_redirect_has_zero_weight_without_hiding_siblings() {
+        let index = SoundsIndex {
+            events: HashMap::from([(
+                "parent".to_string(),
+                SoundEvent {
+                    entries: vec![
+                        SoundEntry::Event {
+                            name: "missing".to_string(),
+                            volume: 1.0,
+                            pitch: 1.0,
+                            stream: false,
+                        },
+                        file("fallback", 1),
+                    ],
+                    subtitle: None,
+                },
+            )]),
+        };
+        assert_eq!(
+            index.choose("parent", Some(0)).unwrap().path,
+            PathBuf::from("fallback")
+        );
+    }
+
+    #[test]
+    fn cyclic_event_redirect_is_rejected() {
+        let index = SoundsIndex {
+            events: HashMap::from([
+                (
+                    "a".to_string(),
+                    SoundEvent {
+                        entries: vec![SoundEntry::Event {
+                            name: "b".to_string(),
+                            volume: 1.0,
+                            pitch: 1.0,
+                            stream: false,
+                        }],
+                        subtitle: None,
+                    },
+                ),
+                (
+                    "b".to_string(),
+                    SoundEvent {
+                        entries: vec![SoundEntry::Event {
+                            name: "a".to_string(),
+                            volume: 1.0,
+                            pitch: 1.0,
+                            stream: false,
+                        }],
+                        subtitle: None,
+                    },
+                ),
+            ]),
+        };
+        assert!(index.choose("a", Some(0)).is_none());
+    }
 }

--- a/pomme-client/src/net/azalea_compat.rs
+++ b/pomme-client/src/net/azalea_compat.rs
@@ -6,8 +6,12 @@
 //! "investigate which side is wrong", with in-game behavior as tiebreaker.
 
 use azalea_core::entity_id::MinecraftEntityId;
+use azalea_core::sound::CustomSound;
 use azalea_protocol::packets::ProtocolPacket;
 use azalea_protocol::packets::game::{ClientboundGamePacket, ServerboundGamePacket};
+use azalea_registry::Holder;
+use azalea_registry::builtin::SoundEvent;
+use azalea_registry::identifier::Identifier;
 use glam::DVec3;
 use pomme_protocol::packets::{Direction, PacketTable, Phase};
 use pomme_protocol::wire;
@@ -145,6 +149,72 @@ fn packet_ids_match_azalea() {
     assert_eq!(
         hurt_animation.id(),
         table_id(Direction::Clientbound, "hurt_animation")
+    );
+
+    use azalea_protocol::packets::game::{c_sound, c_sound_entity, c_stop_sound};
+
+    let sound = ClientboundGamePacket::Sound(c_sound::ClientboundSound {
+        sound: sound_holder(),
+        source: c_sound::SoundSource::Master,
+        x: 0,
+        y: 0,
+        z: 0,
+        volume: 1.0,
+        pitch: 1.0,
+        seed: 0,
+    });
+    assert_eq!(sound.id(), table_id(Direction::Clientbound, "sound"));
+
+    let sound_entity = ClientboundGamePacket::SoundEntity(c_sound_entity::ClientboundSoundEntity {
+        sound: sound_holder(),
+        source: c_sound::SoundSource::Master,
+        id: MinecraftEntityId(0),
+        volume: 1.0,
+        pitch: 1.0,
+        seed: 0,
+    });
+    assert_eq!(
+        sound_entity.id(),
+        table_id(Direction::Clientbound, "sound_entity")
+    );
+
+    let stop_sound = ClientboundGamePacket::StopSound(c_stop_sound::ClientboundStopSound {
+        source: None,
+        name: None,
+    });
+    assert_eq!(
+        stop_sound.id(),
+        table_id(Direction::Clientbound, "stop_sound")
+    );
+}
+
+fn sound_holder() -> Holder<SoundEvent, CustomSound> {
+    Holder::Direct(CustomSound {
+        sound_id: Identifier::new("minecraft:test.sound"),
+        range: None,
+    })
+}
+
+/// Pins the azalea bug the raw sound path in `handler::handle_raw_game_packet`
+/// works around: azalea's `SoundSource` stops at `Voice = 9`, and the `AzBuf`
+/// derive decodes an unknown discriminant as the first variant rather than
+/// failing, so vanilla's `UI = 10` silently arrives as `Master`. When azalea
+/// gains the variant this fails, and the raw path can be deleted.
+#[test]
+fn azalea_sound_source_still_misdecodes_ui() {
+    use azalea_buf::AzBuf;
+    use azalea_protocol::packets::game::c_sound::SoundSource;
+
+    let mut ui = std::io::Cursor::new(&[10u8][..]);
+    assert_eq!(
+        SoundSource::azalea_read(&mut ui).unwrap(),
+        SoundSource::Master
+    );
+
+    let mut voice = std::io::Cursor::new(&[9u8][..]);
+    assert_eq!(
+        SoundSource::azalea_read(&mut voice).unwrap(),
+        SoundSource::Voice
     );
 }
 

--- a/pomme-client/src/net/handler.rs
+++ b/pomme-client/src/net/handler.rs
@@ -1,9 +1,12 @@
 use azalea_buf::{AzBuf, AzBufVar};
+use azalea_core::bitset::FixedBitSet;
 use azalea_core::position::ChunkPos;
 use azalea_core::registry_holder::RegistryHolder;
+use azalea_core::sound::CustomSound;
 use azalea_protocol::packets::game::{ClientboundGamePacket, ServerboundGamePacket};
-use azalea_registry::Registry;
-use azalea_registry::builtin::EntityKind;
+use azalea_registry::builtin::{EntityKind, SoundEvent};
+use azalea_registry::identifier::Identifier;
+use azalea_registry::{Holder, Registry};
 use crossbeam_channel::Sender;
 
 use super::NetworkEvent;
@@ -107,9 +110,6 @@ pub fn handle_game_packet(
         }
         ClientboundGamePacket::Sound(p) => {
             // Coordinates are fixed-point: block position times 8.
-            // TODO: azalea's `SoundSource` stops at `Voice = 9` and `AzBuf`
-            // decodes an unknown discriminant as the first variant, so
-            // `UI = 10` plays under `Master`. Only a plugin server sends it.
             let _ = event_tx.try_send(NetworkEvent::PlaySound {
                 sound: crate::audio::SoundRef::resolve(&p.sound),
                 category: p.source as u8,
@@ -127,6 +127,12 @@ pub fn handle_game_packet(
                 volume: p.volume,
                 pitch: p.pitch,
                 seed: p.seed,
+            });
+        }
+        ClientboundGamePacket::StopSound(p) => {
+            let _ = event_tx.try_send(NetworkEvent::StopSound {
+                sound_id: p.name.as_ref().map(ToString::to_string),
+                category: p.source.map(|source| source as u8),
             });
         }
         ClientboundGamePacket::BlockEntityData(p) => {
@@ -1207,15 +1213,35 @@ fn send_entity_moved(
     });
 }
 
-/// Consume `ClientboundLevelParticles` from the raw packet bytes, before
-/// azalea's typed decode. azalea 26.2's `Particle` wire enum is out of sync
-/// with the particle registry (the new 26.2 particles are appended at the end
-/// instead of inserted in registry order), misdecoding every type id past
-/// `bubble`; pomme reads the id itself and skips the type-specific payload,
-/// which is the packet's last field. Returns whether the packet was consumed.
+/// Consume packets that azalea's 26.2 codecs cannot represent correctly
+/// before the typed decode runs. Returns whether the packet was consumed.
 pub fn handle_raw_game_packet(raw: &[u8], event_tx: &Sender<NetworkEvent>) -> bool {
     let mut cur = std::io::Cursor::new(raw);
-    if u32::azalea_read_var(&mut cur).ok() != Some(level_particles_packet_id()) {
+    let Ok(packet_id) = u32::azalea_read_var(&mut cur) else {
+        return false;
+    };
+
+    let sound_ids = sound_packet_ids();
+    let sound_result = if packet_id == sound_ids.sound {
+        Some(handle_raw_ui_sound(&mut cur, event_tx))
+    } else if packet_id == sound_ids.sound_entity {
+        Some(handle_raw_ui_entity_sound(&mut cur, event_tx))
+    } else if packet_id == sound_ids.stop_sound {
+        Some(handle_raw_ui_stop_sound(&mut cur, event_tx))
+    } else {
+        None
+    };
+    if let Some(result) = sound_result {
+        return match result {
+            Ok(consumed) => consumed,
+            Err(e) => {
+                tracing::warn!("Skipping malformed sound packet: {e}");
+                true
+            }
+        };
+    }
+
+    if packet_id != level_particles_packet_id() {
         return false;
     }
     match parse_level_particles(&mut cur) {
@@ -1226,6 +1252,116 @@ pub fn handle_raw_game_packet(raw: &[u8], event_tx: &Sender<NetworkEvent>) -> bo
         Err(e) => tracing::warn!("Skipping malformed LevelParticles packet: {e}"),
     }
     true
+}
+
+/// Azalea's pinned 26.2 `SoundSource` omits Vanilla's ordinal-10 `UI` value
+/// and decodes unknown ordinals as `Master`. Read just that valid ordinal here;
+/// ordinals 0..=9 fall through to Azalea's normal typed decoder.
+fn handle_raw_ui_sound(
+    cur: &mut std::io::Cursor<&[u8]>,
+    event_tx: &Sender<NetworkEvent>,
+) -> Result<bool, azalea_buf::BufReadError> {
+    let mut sound = Holder::<SoundEvent, CustomSound>::azalea_read(cur)?;
+    if u32::azalea_read_var(cur)? != UI_SOUND_SOURCE {
+        return Ok(false);
+    }
+    if let Some(translation) = super::translate::active()
+        && !translation.remap_sound(&mut sound)
+    {
+        return Ok(true);
+    }
+    let x = i32::azalea_read(cur)?;
+    let y = i32::azalea_read(cur)?;
+    let z = i32::azalea_read(cur)?;
+    let volume = f32::azalea_read(cur)?;
+    let pitch = f32::azalea_read(cur)?;
+    let seed = u64::azalea_read(cur)?;
+    let _ = event_tx.try_send(NetworkEvent::PlaySound {
+        sound: crate::audio::SoundRef::resolve(&sound),
+        category: UI_SOUND_SOURCE as u8,
+        pos: Position::new(x as f64 / 8.0, y as f64 / 8.0, z as f64 / 8.0),
+        volume,
+        pitch,
+        seed,
+    });
+    Ok(true)
+}
+
+fn handle_raw_ui_entity_sound(
+    cur: &mut std::io::Cursor<&[u8]>,
+    event_tx: &Sender<NetworkEvent>,
+) -> Result<bool, azalea_buf::BufReadError> {
+    let mut sound = Holder::<SoundEvent, CustomSound>::azalea_read(cur)?;
+    if u32::azalea_read_var(cur)? != UI_SOUND_SOURCE {
+        return Ok(false);
+    }
+    if let Some(translation) = super::translate::active()
+        && !translation.remap_sound(&mut sound)
+    {
+        return Ok(true);
+    }
+    let entity_id = i32::azalea_read_var(cur)?;
+    let volume = f32::azalea_read(cur)?;
+    let pitch = f32::azalea_read(cur)?;
+    let seed = u64::azalea_read(cur)?;
+    let _ = event_tx.try_send(NetworkEvent::PlayEntitySound {
+        sound: crate::audio::SoundRef::resolve(&sound),
+        category: UI_SOUND_SOURCE as u8,
+        entity_id,
+        volume,
+        pitch,
+        seed,
+    });
+    Ok(true)
+}
+
+fn handle_raw_ui_stop_sound(
+    cur: &mut std::io::Cursor<&[u8]>,
+    event_tx: &Sender<NetworkEvent>,
+) -> Result<bool, azalea_buf::BufReadError> {
+    let set = FixedBitSet::<2>::azalea_read(cur)?;
+    if !set.index(0) || u32::azalea_read_var(cur)? != UI_SOUND_SOURCE {
+        return Ok(false);
+    }
+    let name = if set.index(1) {
+        Some(Identifier::azalea_read(cur)?.to_string())
+    } else {
+        None
+    };
+    let _ = event_tx.try_send(NetworkEvent::StopSound {
+        sound_id: name,
+        category: Some(UI_SOUND_SOURCE as u8),
+    });
+    Ok(true)
+}
+
+const UI_SOUND_SOURCE: u32 = 10;
+
+#[derive(Clone, Copy)]
+struct SoundPacketIds {
+    sound: u32,
+    sound_entity: u32,
+    stop_sound: u32,
+}
+
+fn sound_packet_ids() -> SoundPacketIds {
+    use pomme_protocol::{Direction, PacketTable, Phase};
+
+    static IDS: std::sync::OnceLock<SoundPacketIds> = std::sync::OnceLock::new();
+    *IDS.get_or_init(|| {
+        let table = PacketTable::latest();
+        SoundPacketIds {
+            sound: table
+                .id(Phase::Game, Direction::Clientbound, "sound")
+                .expect("sound in packet table"),
+            sound_entity: table
+                .id(Phase::Game, Direction::Clientbound, "sound_entity")
+                .expect("sound_entity in packet table"),
+            stop_sound: table
+                .id(Phase::Game, Direction::Clientbound, "stop_sound")
+                .expect("stop_sound in packet table"),
+        }
+    })
 }
 
 /// The wire layout of vanilla `ClientboundLevelParticlesPacket.write`, up to
@@ -1328,5 +1464,93 @@ fn slot_display_first_item(
         SlotDisplayData::SmithingTrim(d) => slot_display_first_item(&d.base),
         SlotDisplayData::WithRemainder(d) => slot_display_first_item(&d.input),
         SlotDisplayData::Composite(d) => d.contents.iter().find_map(slot_display_first_item),
+    }
+}
+
+#[cfg(test)]
+mod raw_sound_tests {
+    use pomme_protocol::wire;
+
+    use super::*;
+
+    fn direct_sound() -> Holder<SoundEvent, CustomSound> {
+        Holder::Direct(CustomSound {
+            sound_id: Identifier::new("minecraft:test.ui"),
+            range: None,
+        })
+    }
+
+    #[test]
+    fn raw_sound_preserves_ui_source_ordinal() {
+        let mut raw = Vec::new();
+        wire::write_varint(&mut raw, sound_packet_ids().sound);
+        direct_sound().azalea_write(&mut raw).unwrap();
+        wire::write_varint(&mut raw, UI_SOUND_SOURCE);
+        8_i32.azalea_write(&mut raw).unwrap();
+        16_i32.azalea_write(&mut raw).unwrap();
+        24_i32.azalea_write(&mut raw).unwrap();
+        0.75_f32.azalea_write(&mut raw).unwrap();
+        1.25_f32.azalea_write(&mut raw).unwrap();
+        7_u64.azalea_write(&mut raw).unwrap();
+
+        let (tx, rx) = crossbeam_channel::bounded(1);
+        assert!(handle_raw_game_packet(&raw, &tx));
+        match rx.recv().unwrap() {
+            NetworkEvent::PlaySound { category, pos, .. } => {
+                assert_eq!(category, 10);
+                assert_eq!(pos, Position::new(1.0, 2.0, 3.0));
+            }
+            _ => panic!("expected PlaySound"),
+        }
+    }
+
+    #[test]
+    fn raw_entity_sound_preserves_ui_source_ordinal() {
+        let mut raw = Vec::new();
+        wire::write_varint(&mut raw, sound_packet_ids().sound_entity);
+        direct_sound().azalea_write(&mut raw).unwrap();
+        wire::write_varint(&mut raw, UI_SOUND_SOURCE);
+        42_i32.azalea_write_var(&mut raw).unwrap();
+        1.0_f32.azalea_write(&mut raw).unwrap();
+        0.5_f32.azalea_write(&mut raw).unwrap();
+        9_u64.azalea_write(&mut raw).unwrap();
+
+        let (tx, rx) = crossbeam_channel::bounded(1);
+        assert!(handle_raw_game_packet(&raw, &tx));
+        match rx.recv().unwrap() {
+            NetworkEvent::PlayEntitySound {
+                category,
+                entity_id,
+                ..
+            } => {
+                assert_eq!(category, 10);
+                assert_eq!(entity_id, 42);
+            }
+            _ => panic!("expected PlayEntitySound"),
+        }
+    }
+
+    #[test]
+    fn raw_stop_sound_preserves_ui_source_ordinal() {
+        let mut raw = Vec::new();
+        wire::write_varint(&mut raw, sound_packet_ids().stop_sound);
+        let mut flags = FixedBitSet::<2>::new();
+        flags.set(0);
+        flags.set(1);
+        flags.azalea_write(&mut raw).unwrap();
+        wire::write_varint(&mut raw, UI_SOUND_SOURCE);
+        Identifier::new("minecraft:test.ui")
+            .azalea_write(&mut raw)
+            .unwrap();
+
+        let (tx, rx) = crossbeam_channel::bounded(1);
+        assert!(handle_raw_game_packet(&raw, &tx));
+        match rx.recv().unwrap() {
+            NetworkEvent::StopSound { sound_id, category } => {
+                assert_eq!(category, Some(10));
+                assert_eq!(sound_id.as_deref(), Some("minecraft:test.ui"));
+            }
+            _ => panic!("expected StopSound"),
+        }
     }
 }

--- a/pomme-client/src/net/mod.rs
+++ b/pomme-client/src/net/mod.rs
@@ -262,6 +262,10 @@ pub enum NetworkEvent {
         pitch: f32,
         seed: u64,
     },
+    StopSound {
+        sound_id: Option<String>,
+        category: Option<u8>,
+    },
     TimeUpdate {
         game_time: u64,
         day_time: Option<u64>,

--- a/pomme-client/src/net/translate.rs
+++ b/pomme-client/src/net/translate.rs
@@ -1222,7 +1222,7 @@ impl Translation {
         }
     }
 
-    fn remap_sound(&self, sound: &mut Holder<SoundEvent, CustomSound>) -> bool {
+    pub(super) fn remap_sound(&self, sound: &mut Holder<SoundEvent, CustomSound>) -> bool {
         match sound {
             Holder::Reference(kind) => remap_with(self.to_latest, ClientRegistry::SoundEvent, kind),
             Holder::Direct(_) => true,

--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -1335,7 +1335,7 @@ fn play_block_sound(audio: &AudioEngine, event: &str, pos: BlockPos, volume: f32
         return;
     }
     audio.play_world_sound(
-        &SoundRef::Event(event.to_string()),
+        &SoundRef::event(event),
         CATEGORY_BLOCKS,
         Position::new(pos.x as f64 + 0.5, pos.y as f64 + 0.5, pos.z as f64 + 0.5),
         volume,

--- a/pomme-client/src/resource_pack.rs
+++ b/pomme-client/src/resource_pack.rs
@@ -64,6 +64,12 @@ impl ResourcePackManager {
         None
     }
 
+    /// Active pack roots in low-to-high priority order, matching the order in
+    /// which stacked resources are registered by Vanilla.
+    pub fn active_pack_dirs(&self) -> impl Iterator<Item = &Path> {
+        self.active_packs.iter().map(|pack| pack.dir.as_path())
+    }
+
     fn server_pack_dir(&self, hash: &str) -> PathBuf {
         self.server_cache_dir.join(hash)
     }
@@ -116,9 +122,14 @@ impl ResourcePackManager {
         removed
     }
 
-    pub fn clear_server_packs(&mut self) {
+    pub fn clear_server_packs(&mut self) -> bool {
+        let before = self.active_packs.len();
         self.active_packs.retain(|p| p.source != PackSource::Server);
-        tracing::info!("Cleared all server resource packs");
+        let removed = self.active_packs.len() != before;
+        if removed {
+            tracing::info!("Cleared all server resource packs");
+        }
+        removed
     }
 
     pub fn scan_local_packs(&mut self) {

--- a/pomme-client/src/ui/menu/credits.json
+++ b/pomme-client/src/ui/menu/credits.json
@@ -50,7 +50,7 @@
           },
           {
             "title": "Platform",
-            "names": ["winit", "rodio", "tokio"]
+            "names": ["winit", "OpenAL Soft", "libloading", "symphonia", "tokio"]
           }
         ]
       }

--- a/pomme-client/third-party/OpenAL-Soft-LICENSE.txt
+++ b/pomme-client/third-party/OpenAL-Soft-LICENSE.txt
@@ -1,0 +1,437 @@
+                  GNU LIBRARY GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1991 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the library GPL.  It is
+ numbered 2 because it goes with version 2 of the ordinary GPL.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Library General Public License, applies to some
+specially designated Free Software Foundation software, and to any
+other libraries whose authors decide to use it.  You can use it for
+your libraries, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if
+you distribute copies of the library, or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link a program with the library, you must provide
+complete object files to the recipients so that they can relink them
+with the library, after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  Our method of protecting your rights has two steps: (1) copyright
+the library, and (2) offer you this license which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  Also, for each distributor's protection, we want to make certain
+that everyone understands that there is no warranty for this free
+library.  If the library is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original
+version, so that any problems introduced by others will not reflect on
+the original authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that companies distributing free
+software will individually obtain patent licenses, thus in effect
+transforming the program into proprietary software.  To prevent this,
+we have made it clear that any patent must be licensed for everyone's
+free use or not licensed at all.
+
+  Most GNU software, including some libraries, is covered by the ordinary
+GNU General Public License, which was designed for utility programs.  This
+license, the GNU Library General Public License, applies to certain
+designated libraries.  This license is quite different from the ordinary
+one; be sure to read it in full, and don't assume that anything in it is
+the same as in the ordinary license.
+
+  The reason we have a separate public license for some libraries is that
+they blur the distinction we usually make between modifying or adding to a
+program and simply using it.  Linking a program with a library, without
+changing the library, is in some sense simply using the library, and is
+analogous to running a utility program or application program.  However, in
+a textual and legal sense, the linked executable is a combined work, a
+derivative of the original library, and the ordinary General Public License
+treats it as such.
+
+  Because of this blurred distinction, using the ordinary General
+Public License for libraries did not effectively promote software
+sharing, because most developers did not use the libraries.  We
+concluded that weaker conditions might promote sharing better.
+
+  However, unrestricted linking of non-free programs would deprive the
+users of those programs of all benefit from the free status of the
+libraries themselves.  This Library General Public License is intended to
+permit developers of non-free programs to use free libraries, while
+preserving your freedom as a user of such programs to change the free
+libraries that are incorporated in them.  (We have not seen how to achieve
+this as regards changes in header files, but we have achieved it as regards
+changes in the actual functions of the Library.)  The hope is that this
+will lead to faster development of free libraries.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, while the latter only
+works together with the library.
+
+  Note that it is possible for a library to be covered by the ordinary
+General Public License rather than by this special one.
+
+                  GNU LIBRARY GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library which
+contains a notice placed by the copyright holder or other authorized
+party saying it may be distributed under the terms of this Library
+General Public License (also called "this License").  Each licensee is
+addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also compile or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    c) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    d) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the source code distributed need not include anything that is normally
+distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Library General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS

--- a/pomme-client/third-party/OpenAL-Soft-NOTICE.txt
+++ b/pomme-client/third-party/OpenAL-Soft-NOTICE.txt
@@ -1,0 +1,9 @@
+OpenAL Soft 1.25.1
+
+Pomme release archives bundle the unmodified OpenAL Soft native library shipped
+with Minecraft 26.2's LWJGL OpenAL 3.4.1 natives. OpenAL Soft source for this
+version is available from the upstream 1.25.1 tag:
+https://github.com/kcat/openal-soft/tree/1.25.1
+
+OpenAL Soft is licensed under the GNU Library General Public License version 2;
+see OpenAL-Soft-LICENSE.txt.

--- a/pomme-client/third-party/openal-natives.txt
+++ b/pomme-client/third-party/openal-natives.txt
@@ -1,0 +1,16 @@
+# OpenAL Soft natives, as shipped by Minecraft 26.2 via LWJGL.
+#
+# Read by tools/fetch_openal.py, which both `just openal` and the release
+# workflow call, so a development build and a release bundle can never end up
+# on different builds of the library.
+#
+# Jars come from https://libraries.minecraft.net/org/lwjgl/lwjgl-openal/
+# <version>/lwjgl-openal-<version>-<classifier>.jar and the checksum covers the
+# whole jar, matching what the Mojang library index publishes.
+
+version 3.4.1
+
+# classifier          jar member                                    output name       jar sha256
+natives-windows       windows/x64/org/lwjgl/openal/OpenAL.dll       OpenAL.dll        28d4065b9c6be68454eb4d7c0da665bd4bc7cc77d854c1f67afbd2f38ff730a3
+natives-linux         linux/x64/org/lwjgl/openal/libopenal.so       libopenal.so      c3be36ffda26c46b77bfa359586424a95d7620be11427897c7a454abb16c0994
+natives-macos-arm64   macos/arm64/org/lwjgl/openal/libopenal.dylib  libopenal.dylib   704365e5bfc028c006d2fe54862742d661295bd4b960824a0d2fbe5a9c7b8ffd

--- a/pomme-protocol/src/packets.rs
+++ b/pomme-protocol/src/packets.rs
@@ -283,6 +283,18 @@ mod tests {
             Some(115)
         );
         assert_eq!(
+            t.id(Phase::Game, Direction::Clientbound, "sound_entity"),
+            Some(116)
+        );
+        assert_eq!(
+            t.id(Phase::Game, Direction::Clientbound, "sound"),
+            Some(117)
+        );
+        assert_eq!(
+            t.id(Phase::Game, Direction::Clientbound, "stop_sound"),
+            Some(119)
+        );
+        assert_eq!(
             t.id(Phase::Handshake, Direction::Serverbound, "intention"),
             Some(0)
         );

--- a/tools/fetch_openal.py
+++ b/tools/fetch_openal.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Stage Minecraft's OpenAL Soft native library into one or more directories.
+
+The client loads OpenAL at runtime with `libloading`, trying the directory
+holding the executable before any system path, so dropping the library into
+`target/debug` is all a development build needs. Release bundles use the same
+script so CI and dev builds stay on one pinned version.
+
+Usage:
+  fetch_openal.py <out-dir> [<out-dir> ...] [--classifier <lwjgl-classifier>]
+
+The classifier defaults to the host platform. Pinned version, jar members and
+checksums live in pomme-client/third-party/openal-natives.txt.
+"""
+
+import argparse
+import hashlib
+import platform
+import sys
+import urllib.request
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = REPO_ROOT / "pomme-client" / "third-party" / "openal-natives.txt"
+CACHE_DIR = REPO_ROOT / "target" / "openal-natives"
+BASE_URL = "https://libraries.minecraft.net/org/lwjgl/lwjgl-openal"
+
+
+class Unreachable(Exception):
+    """The library could not be downloaded. Not fatal: audio degrades to off."""
+
+
+class Native:
+    def __init__(self, member, name, sha256):
+        self.member = member
+        self.name = name
+        self.sha256 = sha256
+
+
+def read_manifest():
+    """Returns (version, {classifier: Native})."""
+    version = None
+    natives = {}
+    for lineno, raw in enumerate(MANIFEST.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        fields = line.split()
+        if fields[0] == "version" and len(fields) == 2:
+            version = fields[1]
+        elif len(fields) == 4:
+            natives[fields[0]] = Native(fields[1], fields[2], fields[3])
+        else:
+            raise SystemExit(f"{MANIFEST}:{lineno}: cannot parse {raw!r}")
+    if version is None:
+        raise SystemExit(f"{MANIFEST}: no version line")
+    return version, natives
+
+
+def host_classifier():
+    """Returns the LWJGL classifier for this host, or None if there is none.
+
+    TODO: only the three classifiers the release job builds for are pinned in
+    the manifest. A host outside that set (Intel mac, arm64 Linux) resolves to
+    a classifier with no entry and degrades to no audio.
+    """
+    system = platform.system()
+    machine = platform.machine().lower()
+    arm = machine in ("arm64", "aarch64")
+    if system == "Windows":
+        return "natives-windows-arm64" if arm else "natives-windows"
+    if system == "Linux":
+        return "natives-linux-arm64" if arm else "natives-linux"
+    if system == "Darwin":
+        return "natives-macos-arm64" if arm else "natives-macos"
+    return None
+
+
+def fetch_jar(version, classifier, expected_sha256):
+    """Downloads the jar unless a verified copy is already cached."""
+    cached = CACHE_DIR / f"lwjgl-openal-{version}-{classifier}.jar"
+    if cached.is_file() and sha256(cached.read_bytes()) == expected_sha256:
+        return cached
+
+    url = f"{BASE_URL}/{version}/lwjgl-openal-{version}-{classifier}.jar"
+    print(f"downloading {url}")
+    try:
+        with urllib.request.urlopen(url) as response:
+            payload = response.read()
+    except OSError as e:
+        # An offline build should still compile and run, just without sound.
+        raise Unreachable(f"{url}: {e}") from e
+    actual = sha256(payload)
+    if actual != expected_sha256:
+        raise SystemExit(f"{url}: sha256 {actual} does not match the pinned {expected_sha256}")
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cached.write_bytes(payload)
+    return cached
+
+
+def sha256(payload):
+    return hashlib.sha256(payload).hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("out_dirs", nargs="+", metavar="out-dir")
+    parser.add_argument("--classifier", default=None)
+    parser.add_argument(
+        "--require",
+        action="store_true",
+        help="fail instead of warning when the library cannot be downloaded "
+        "(release packaging, where a silent miss would ship a mute build)",
+    )
+    args = parser.parse_args()
+
+    version, natives = read_manifest()
+    classifier = args.classifier or host_classifier()
+    native = natives.get(classifier) if classifier else None
+    if native is None:
+        known = ", ".join(sorted(natives))
+        described = classifier or f"{platform.system()}/{platform.machine()}"
+        message = f"{MANIFEST} pins no native for {described} (has {known})"
+        # Release packaging names its classifier explicitly and must not ship a
+        # mute build; a development host outside the pinned set just goes quiet.
+        if args.require:
+            raise SystemExit(message)
+        print(f"warning: {message}; audio will be disabled", file=sys.stderr)
+        return
+
+    targets = [Path(d) for d in args.out_dirs]
+    missing = [d for d in targets if not (d / native.name).is_file()]
+    if not missing:
+        print(f"{native.name} is already staged in every requested directory")
+        return
+
+    try:
+        jar = fetch_jar(version, classifier, native.sha256)
+    except Unreachable as e:
+        if args.require:
+            raise SystemExit(str(e)) from e
+        print(f"warning: {e}; audio will be disabled", file=sys.stderr)
+        return
+    with zipfile.ZipFile(jar) as archive:
+        payload = archive.read(native.member)
+    for directory in missing:
+        directory.mkdir(parents=True, exist_ok=True)
+        out = directory / native.name
+        out.write_bytes(payload)
+        print(f"staged {out} (OpenAL Soft via LWJGL {version})")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- replace Rodio playback and software spatialization with a dedicated-thread OpenAL Soft backend matching Minecraft 26.2 source/listener behavior, linear attenuation, pitch, static buffers, four-buffer streaming, seeded weighted selection, recursive `sounds.json` redirects, StopSound/entity-bound lifecycle, and Vanilla logical sound-retention timing without holding stopped native channels
- make audio resource-pack aware: parse each `sounds.json` resource transactionally with Vanilla validation, stack valid resources low-to-high with `replace`/append semantics, discard missing OGG registrations, resolve overridden OGGs through active pack priority, and reload audio alongside renderer assets on pack apply/pop/disconnect/menu reload
- preserve Vanilla's valid `SoundSource.UI = 10` for Sound, SoundEntity, and StopSound packets even though the pinned Azalea enum currently stops at ordinal 9 (Workaround for Azalea bug)
- match the menu-music delay behavior Pomme currently exposes (100-tick initial delay and the logical 20-tick retention plus 20–600-tick post-track gap), without claiming the rest of Minecraft 26.2's broader `MusicManager` state machine
- keep native OpenAL state confined to the audio worker and pin/package Minecraft 26.2's OpenAL Soft 1.25.1 natives for supported release targets; partial initialization/stream cleanup paths were explicitly reviewed, though native failure injection is not part of the automated test suite
- deferred parity gaps: Pomme currently has no directional-audio/HRTF option plumbing, no audio-device selection/device-loss recovery subsystem, and no full 26.2 `MusicManager`/situational-music system; additionally, the pre-existing server resource-pack downloader supports only one in-flight push at a time, although audio correctly stacks every pack that becomes active

## Testing

- `just client-pre-pr` — 146 filtered client tests passed
- `cargo test -p pomme-client -- audio::` — 18/18 passed
- `cargo test -p pomme-client -- net::handler::raw_sound_tests` — 3/3 passed
- `cargo check -p pomme-client --target x86_64-pc-windows-gnu`
- `git diff --check`
- manual backend verification: UI/world/music audio worked correctly, and active one-shot sounds stopped when leaving a server

Closes #538 