### PR TITLE
bump pinned nightly to 2026-08-21

### DIFF
--- a/pomme-client/src/renderer/chunk/atlas.rs
+++ b/pomme-client/src/renderer/chunk/atlas.rs
@@ -336,7 +336,7 @@ fn pixel_region(x: u32, y: u32, w: u32, h: u32, atlas_size: u32) -> AtlasRegion 
 /// Conservative: any transparency (or unknown) routes the sprite to the cutout
 /// pass, so a hole never renders solid.
 fn sprite_is_opaque(data: &[u8]) -> bool {
-    data.chunks_exact(4).all(|px| px[3] == 255)
+    data.as_chunks::<4>().0.iter().all(|px| px[3] == 255)
 }
 
 type PackResult = (HashMap<String, Option<(u32, u32)>>, AtlasRegion);

--- a/pomme-client/src/renderer/pipelines/clouds.rs
+++ b/pomme-client/src/renderer/pipelines/clouds.rs
@@ -321,9 +321,7 @@ impl CloudPipeline {
             self.prev_mode = mode;
             self.prev_rel = rel;
             self.have_mesh = true;
-            for d in &mut self.dirty {
-                *d = true;
-            }
+            self.dirty.fill(true);
         }
 
         if self.faces.is_empty() {

--- a/pomme-client/src/renderer/pipelines/entity_renderer.rs
+++ b/pomme-client/src/renderer/pipelines/entity_renderer.rs
@@ -2536,10 +2536,7 @@ fn destroy_player_skin_texture(
 }
 
 pub(super) fn fallback_texture(size: u32) -> (Vec<u8>, u32, u32) {
-    let mut pixels = vec![0u8; (size * size * 4) as usize];
-    for pixel in pixels.chunks_exact_mut(4) {
-        pixel.copy_from_slice(&[219, 148, 148, 255]);
-    }
+    let pixels = [219u8, 148, 148, 255].repeat((size * size) as usize);
     (pixels, size, size)
 }
 

--- a/pomme-client/src/renderer/pipelines/hand.rs
+++ b/pomme-client/src/renderer/pipelines/hand.rs
@@ -532,10 +532,7 @@ fn update_skin_descriptor(
 fn fallback_skin() -> (Vec<u8>, u32, u32) {
     let w = 64u32;
     let h = 64u32;
-    let mut pixels = vec![0u8; (w * h * 4) as usize];
-    for pixel in pixels.chunks_exact_mut(4) {
-        pixel.copy_from_slice(&[196, 161, 125, 255]);
-    }
+    let pixels = [196u8, 161, 125, 255].repeat((w * h) as usize);
     (pixels, w, h)
 }
 

--- a/pomme-client/src/renderer/screenshot.rs
+++ b/pomme-client/src/renderer/screenshot.rs
@@ -246,7 +246,7 @@ fn encode_and_write(
 ) -> Result<String, String> {
     // Vanilla screenshots are opaque RGB; drop alpha and reorder BGRA if needed.
     let mut rgb = Vec::with_capacity(width as usize * height as usize * 3);
-    for px in pixels.chunks_exact(4) {
+    for px in pixels.as_chunks::<4>().0 {
         if bgra {
             rgb.extend_from_slice(&[px[2], px[1], px[0]]);
         } else {

--- a/pomme-client/src/renderer/util.rs
+++ b/pomme-client/src/renderer/util.rs
@@ -383,7 +383,7 @@ pub fn load_png(path: &Path) -> Option<(Vec<u8>, u32, u32)> {
         png::ColorType::Rgb => {
             let pixels = info.width as usize * info.height as usize;
             let mut rgba = Vec::with_capacity(pixels * 4);
-            for chunk in buf[..pixels * 3].chunks_exact(3) {
+            for chunk in buf[..pixels * 3].as_chunks::<3>().0 {
                 rgba.extend_from_slice(chunk);
                 rgba.push(255);
             }
@@ -392,7 +392,7 @@ pub fn load_png(path: &Path) -> Option<(Vec<u8>, u32, u32)> {
         png::ColorType::GrayscaleAlpha => {
             let pixels = info.width as usize * info.height as usize;
             let mut rgba = Vec::with_capacity(pixels * 4);
-            for chunk in buf[..pixels * 2].chunks_exact(2) {
+            for chunk in buf[..pixels * 2].as_chunks::<2>().0 {
                 rgba.extend_from_slice(&[chunk[0], chunk[0], chunk[0], chunk[1]]);
             }
             rgba

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,6 @@
 [toolchain]
-# Pinned so local and CI build identically. Bump deliberately; nightly is only
-# needed for rustfmt's options.
-channel = "nightly-2026-03-21"
+# Pinned so local and CI build identically. Nightly is needed for rustfmt's
+# options and to match SteelMC's pin, whose library crates gate on nightly
+# features. Bump deliberately, SteelMC first.
+channel = "nightly-2026-08-21"
 components = ["clippy", "rustfmt", "rust-analyzer", "rust-src"]


### PR DESCRIPTION
Moves the pin to `nightly-2026-08-21`.

SteelMC's library crates gate on `try_as_dyn`, `const_trait_impl`, `derive_const` and `portable_simd`, so an embedded integrated server cannot build on the old pin. Pomme uses no nightly features of its own, so it can follow.

Clears the seven clippy lints that were queued against the bump. No rustfmt churn.
