### PR TITLE
add pr template with auto-labeling and tighten ci

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+Ticking a box applies the matching label. The wording is matched exactly by
+.github/workflows/pr-tags.yml, so edit the two together.
+-->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Refactor / code cleanup
+- [ ] Performance improvement
+- [ ] Chore / tooling
+- [ ] Documentation
+
+## Summary
+
+<!-- What changed and why. -->
+
+## Reference
+
+<!-- Classes under reference/26.2/decompiled this was checked against, or n/a
+     for launcher/tooling/chores. -->
+
+## Testing
+
+<!-- `just client-pre-pr`, plus anything still needing an in-game check. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,42 @@ jobs:
         # --release reuses the dependency artifacts the clippy step built.
         run: |
           cargo test -p pomme-protocol
-          cargo test -p pomme-client --release -- net::azalea_compat world::block renderer::camera:: ui::menu:: player::tests:: audio:: net::handler::
+          cargo test -p pomme-client --release
+
+  pr-template:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check PR template and labeler agree
+        # The labeler matches checkbox text exactly, so a reworded box silently
+        # stops applying its label.
+        run: |
+          python3 - <<'PY'
+          import pathlib, re, sys
+
+          def read(path):
+              # Normalized, so a CRLF checkout doesn't look like a missing section.
+              return pathlib.Path(path).read_text(encoding="utf-8").replace("\r\n", "\n")
+
+          template = read(".github/PULL_REQUEST_TEMPLATE.md")
+          workflow = read(".github/workflows/pr-tags.yml")
+
+          section = re.search(r"## Type of change\n(.*?)(?=\n## |\Z)", template, re.S)
+          if section is None:
+              sys.exit("::error::PULL_REQUEST_TEMPLATE.md has no '## Type of change' section")
+
+          boxes = set(re.findall(r"^- \[ \] (.+)$", section.group(1), re.M))
+          mapped = set(re.findall(r'text:\s*"([^"]+)"', workflow))
+
+          drift = [f"checkbox {t!r} has no label in pr-tags.yml" for t in sorted(boxes - mapped)]
+          drift += [f"pr-tags.yml maps {t!r}, which is not a checkbox" for t in sorted(mapped - boxes)]
+          for problem in drift:
+              print(f"::error::{problem}")
+          if drift:
+              sys.exit(1)
+          print(f"{len(boxes)} checkboxes match their label mappings")
+          PY
 
   launcher-frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -1,0 +1,33 @@
+name: Merge conflict labeler
+
+# Every run rescans all open PRs, which is what covers a stack: pushing a
+# lower layer fires `synchronize` for its own PR, and the rescan re-evaluates
+# the layers sitting on it.
+on:
+  push:
+    branches: [master]
+  # Not `pull_request`, which cannot label PRs from forks. Nothing here checks
+  # out the PR branch.
+  pull_request_target:
+    types: [synchronize]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  conflicts:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # `commentOnDirty`/`commentOnClean` are deliberately unset: a stack is
+      # many open PRs, and one master merge would comment on every one.
+      - name: Label PRs that conflict with master
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "merge conflict"
+          repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-tags.yml
+++ b/.github/workflows/pr-tags.yml
@@ -1,0 +1,82 @@
+name: PR auto-labeler
+
+# Not `pull_request`, whose token is read-only on fork PRs. Safe only because
+# nothing checks out the PR branch; the body comes from the event payload, so
+# do not add a checkout step.
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync labels from "Type of change" checklist
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // Checkbox text must match .github/PULL_REQUEST_TEMPLATE.md exactly;
+            // CI's pr-template job fails if the two drift. A label missing from
+            // the repo is created on first use.
+            const TYPE_LABELS = [
+              { text: "Bug fix",                 label: "bug",             color: "d73a4a" },
+              { text: "New feature",             label: "enhancement",     color: "a2eeef" },
+              { text: "Breaking change",         label: "breaking change", color: "b60205" },
+              { text: "Refactor / code cleanup", label: "refactor",        color: "cfd3d7" },
+              { text: "Performance improvement", label: "performance",     color: "fbca04" },
+              { text: "Chore / tooling",         label: "chore",           color: "cccccc" },
+              { text: "Documentation",           label: "documentation",   color: "0075ca" },
+            ];
+
+            // Case-insensitive key, so a differently cased label already on the
+            // repo still matches and can be synced or removed.
+            const norm = s => s.trim().toLowerCase();
+            const managed = new Map(TYPE_LABELS.map(t => [norm(t.label), t]));
+
+            // Matches "- [x] Some text" checklist lines.
+            const checked = new Set();
+            for (const line of (context.payload.pull_request.body || "").split("\n")) {
+              const m = line.match(/^\s*-\s*\[\s*[xX]\s*\]\s*(.+?)\s*$/);
+              if (m) checked.add(m[1].trim());
+            }
+            const wanted = new Set(
+              TYPE_LABELS.filter(t => checked.has(t.text)).map(t => norm(t.label))
+            );
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const current = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner, repo, issue_number,
+            });
+            // Keep the repo's actual spelling around for removeLabel calls.
+            const currentByNorm = new Map(current.map(l => [norm(l.name), l.name]));
+
+            const toAdd = [];
+            for (const key of wanted) {
+              if (currentByNorm.has(key)) continue;
+              const { label, color } = managed.get(key);
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+                await github.rest.issues.createLabel({ owner, repo, name: label, color });
+              }
+              toAdd.push(label);
+            }
+            if (toAdd.length) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: toAdd });
+            }
+
+            for (const [key, name] of currentByNorm) {
+              if (managed.has(key) && !wanted.has(key)) {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name });
+              }
+            }

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -18,6 +18,13 @@ env:
 
 permissions:
   contents: write
+  actions: read # reading CI's conclusion for the commit being released
+
+# Serialized, never cancelled: two runs would resolve the same next version and
+# race on the tag, and cancelling one mid-upload would leave a partial release.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   check:
@@ -31,20 +38,35 @@ jobs:
       - name: Check for new commits since last release
         id: check
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # Only the weekly cron skips an unchanged master; manual/tag runs always release.
+          release() { echo "should_release=true" >> "$GITHUB_OUTPUT"; exit 0; }
+          skip() { echo "should_release=false" >> "$GITHUB_OUTPUT"; echo "$1"; exit 0; }
+
+          # Only the weekly cron is gated; a tag push or manual dispatch is a
+          # deliberate act and always releases.
           if [ "${{ github.event_name }}" != "schedule" ]; then
-            echo "should_release=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            release
           fi
+
           git fetch --tags --force
           last_tag=$(git tag --list 'client-v*' --sort=-v:refname | head -n1)
-          if [ -z "$last_tag" ] || [ -n "$(git rev-list "${last_tag}..HEAD")" ]; then
-            echo "should_release=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_release=false" >> "$GITHUB_OUTPUT"
-            echo "No new commits on master since ${last_tag}; skipping weekly release."
+          if [ -n "$last_tag" ] && [ -z "$(git rev-list "${last_tag}..HEAD")" ]; then
+            skip "No new commits on master since ${last_tag}."
           fi
+
+          # Merges are gated on CI, but master can still go red when two PRs pass
+          # separately and then conflict, and this release is announced to
+          # Discord. A run still in progress reports null and also skips.
+          ci=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${GITHUB_SHA}&per_page=1" \
+            --jq '.workflow_runs[0].conclusion // "none"')
+          if [ "$ci" != "success" ]; then
+            skip "CI for ${GITHUB_SHA} is '${ci}', not success."
+          fi
+
+          release
 
   build-client:
     needs: check

--- a/.github/workflows/release-launcher.yml
+++ b/.github/workflows/release-launcher.yml
@@ -12,6 +12,12 @@ env:
 permissions:
   contents: write
 
+# Serialized, never cancelled: cancelling mid-upload would leave a partial
+# release. The tag comes from the ref here, so there is no version to race on.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   build-launcher:
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,16 +39,15 @@ just launcher-pre-pr        # Launcher (Rust & TypeScript)
 
 ## Pull Request Format
 
-Every PR must include:
+Opening a PR prefills a template with the sections we expect. Fill them in rather
+than deleting them.
 
-```markdown
-## Summary
-- Brief bullet points of what changed and why
+Ticking a box under **Type of change** applies the matching label automatically,
+and unticking it removes the label again.
 
-## Test plan
-- [ ] Steps to verify the changes work
-- [ ] Edge cases checked
-```
+Under **Reference**, name the classes in `reference/26.2/decompiled` you checked
+the change against. This is what reviewers compare against, so it saves a round
+trip. Put `n/a` for launcher, tooling and chore PRs.
 
 For bug fixes, also include:
 

--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ client-pre-pr:
     @cargo clippy -p pomme-client --release --all-targets --all-features -- -D warnings
     @cargo clippy -p pomme-protocol --release --all-targets --all-features -- -D warnings
     @cargo test -p pomme-protocol
-    @cargo test -p pomme-client -- net::azalea_compat world::block renderer::camera:: ui::menu:: player::tests:: audio:: net::handler::
+    @cargo test -p pomme-client
 
 # Regenerate a version's packet-id table from the decompiled reference.
 protogen version="26.2":


### PR DESCRIPTION
- pr template with a type-of-change checklist; ticking a box applies the matching label
- label prs that conflict with master
- ci runs the full client test suite instead of a seven-module filter, 111 tests were never running
- weekly release skips when ci for the commit is not green, and both release workflows are serialized