### PR TITLE
match vanilla 26.2 physics value types

### DIFF
--- a/pomme-client/src/app/core.rs
+++ b/pomme-client/src/app/core.rs
@@ -3,6 +3,7 @@ use std::ops::Add;
 use std::sync::Arc;
 use std::time::Instant;
 
+use azalea_protocol::packets::game::s_player_input::ServerboundPlayerInput;
 use azalea_protocol::packets::game::{
     ServerboundClientCommand, ServerboundGamePacket, s_client_command, s_client_tick_end,
 };
@@ -210,6 +211,34 @@ pub struct PlayerInputState {
     jump: bool,
     shift: bool,
     sprint: bool,
+}
+
+fn player_input_state(
+    input: &InputState,
+    analog_move: glam::Vec2,
+    sprinting: bool,
+) -> PlayerInputState {
+    PlayerInputState {
+        forward: input.key_pressed(KeyCode::KeyW) || analog_move.y > STICK_MOVEMENT_THRESHOLD,
+        backward: input.key_pressed(KeyCode::KeyS) || analog_move.y < -STICK_MOVEMENT_THRESHOLD,
+        left: input.key_pressed(KeyCode::KeyA) || analog_move.x > STICK_MOVEMENT_THRESHOLD,
+        right: input.key_pressed(KeyCode::KeyD) || analog_move.x < -STICK_MOVEMENT_THRESHOLD,
+        jump: input.performing_action(Action::Jump),
+        shift: input.performing_action(Action::Sneak),
+        sprint: sprinting,
+    }
+}
+
+fn serverbound_player_input(state: &PlayerInputState) -> ServerboundPlayerInput {
+    ServerboundPlayerInput {
+        forward: state.forward,
+        backward: state.backward,
+        left: state.left,
+        right: state.right,
+        jump: state.jump,
+        shift: state.shift,
+        sprint: state.sprint,
+    }
 }
 
 pub struct AppCore {
@@ -1179,10 +1208,11 @@ impl AppCore {
                 }
                 NetworkEvent::BlockChangedAck { seq } => {
                     let mut ack_dirty: Vec<azalea_core::position::BlockPos> = Vec::new();
+                    let player_aabb = game.player.bounding_box();
                     let snap = game.interaction.acknowledge(
                         seq,
                         &game.chunk_store,
-                        game.player.position.into(),
+                        player_aabb,
                         &mut ack_dirty,
                     );
                     if let Some(snap) = snap {
@@ -1875,12 +1905,14 @@ impl AppCore {
         });
         let hands_empty = held_stack.is_none() && game.player.inventory.offhand().is_empty();
 
+        let player_aabb = game.player.bounding_box();
         let dirty = game.interaction.tick(
             input,
             &game.chunk_store,
             &connection.packet_tx,
             &self.audio,
             game.player.position.into(),
+            player_aabb,
             game.player.eye_pos().into(),
             game.player.look_dir,
             game.player.on_ground,
@@ -1960,29 +1992,15 @@ impl AppCore {
     fn send_input_packet(input: &InputState, connection: &ConnectionHandle, game: &mut GameState) {
         let sender = &connection.packet_tx;
 
-        let analog_move = input.get_gamepad_left_analog().unwrap_or(glam::Vec2::ZERO);
+        let analog_move = input
+            .get_gamepad_movement_axes()
+            .unwrap_or(glam::Vec2::ZERO);
 
-        let current = PlayerInputState {
-            forward: input.key_pressed(KeyCode::KeyW) || analog_move.y > STICK_MOVEMENT_THRESHOLD,
-            backward: input.key_pressed(KeyCode::KeyS) || analog_move.y < -STICK_MOVEMENT_THRESHOLD,
-            left: input.key_pressed(KeyCode::KeyA) || analog_move.x > STICK_MOVEMENT_THRESHOLD,
-            right: input.key_pressed(KeyCode::KeyD) || analog_move.x < -STICK_MOVEMENT_THRESHOLD,
-            jump: input.performing_action(Action::Jump),
-            shift: input.performing_action(Action::Sneak),
-            sprint: game.player.sprinting,
-        };
+        let current = player_input_state(input, analog_move, game.player.sprinting);
 
         if current != game.last_sent_input {
             sender.send(ServerboundGamePacket::PlayerInput(
-                azalea_protocol::packets::game::s_player_input::ServerboundPlayerInput {
-                    forward: current.forward,
-                    backward: current.backward,
-                    left: current.left,
-                    right: current.right,
-                    jump: current.jump,
-                    shift: current.shift,
-                    sprint: current.sprint,
-                },
+                serverbound_player_input(&current),
             ));
             game.last_sent_input = current;
         }
@@ -2138,7 +2156,33 @@ fn compute_fov_modifier(player: &LocalPlayer, effect_scale: f32) -> f32 {
 
 #[cfg(test)]
 mod tests {
-    use super::server_view_distance_update;
+    use super::{player_input_state, server_view_distance_update, serverbound_player_input};
+    use crate::app::input::{InputState, gamepad_movement_axes};
+
+    #[test]
+    fn controller_packet_directions_match_physical_stick_direction() {
+        let input = InputState::released();
+
+        let right_state =
+            player_input_state(&input, gamepad_movement_axes(glam::vec2(1.0, 0.0)), false);
+        let right = serverbound_player_input(&right_state);
+        assert!(right.right);
+        assert!(!right.left);
+
+        let left_state =
+            player_input_state(&input, gamepad_movement_axes(glam::vec2(-1.0, 0.0)), false);
+        let left = serverbound_player_input(&left_state);
+        assert!(left.left);
+        assert!(!left.right);
+
+        let forward_right_state =
+            player_input_state(&input, gamepad_movement_axes(glam::vec2(0.8, 0.8)), false);
+        let forward_right = serverbound_player_input(&forward_right_state);
+        assert!(forward_right.forward);
+        assert!(forward_right.right);
+        assert!(!forward_right.backward);
+        assert!(!forward_right.left);
+    }
 
     #[test]
     fn server_view_distance_updates() {

--- a/pomme-client/src/app/input.rs
+++ b/pomme-client/src/app/input.rs
@@ -12,6 +12,12 @@ use crate::app::state_slot::StateSlot;
 /// Left-stick deflection past which a direction counts as a digital press.
 pub const STICK_MOVEMENT_THRESHOLD: f32 = 0.25;
 
+/// Convert gilrs left-stick axes into vanilla movement axes: X is `xxa`
+/// (positive left, negative right) and Y is `zza` (positive forward).
+pub(crate) fn gamepad_movement_axes(analog: glam::Vec2) -> glam::Vec2 {
+    glam::vec2(-analog.x, analog.y)
+}
+
 /// Value in milliseconds for how long the controller should rumble to be only
 /// an "instant".
 pub const SHORT_RUMBLE_TIME: u32 = 5;
@@ -454,6 +460,10 @@ impl InputState {
 
     pub fn get_gamepad_left_analog(&self) -> Option<glam::Vec2> {
         self.gamepad_stick(gilrs::Axis::LeftStickX, gilrs::Axis::LeftStickY)
+    }
+
+    pub fn get_gamepad_movement_axes(&self) -> Option<glam::Vec2> {
+        self.get_gamepad_left_analog().map(gamepad_movement_axes)
     }
 
     pub fn get_gamepad_right_analog(&self) -> Option<glam::Vec2> {

--- a/pomme-client/src/app/phases/in_game.rs
+++ b/pomme-client/src/app/phases/in_game.rs
@@ -1868,7 +1868,10 @@ pub fn update_game(
                         e.position.y.floor() as i32,
                         e.position.z.floor() as i32,
                     );
-                    (block_pos, *feet + glam::DVec3::new(0.0, eye_height, 0.0))
+                    (
+                        block_pos,
+                        *feet + glam::DVec3::new(0.0, f64::from(eye_height), 0.0),
+                    )
                 })
             };
             game.waypoints.extract_dots(

--- a/pomme-client/src/physics/aabb.rs
+++ b/pomme-client/src/physics/aabb.rs
@@ -2,7 +2,8 @@ use glam::{DVec3, dvec3};
 
 use super::block_shape::LocalBox;
 
-/// Vanilla `Mth.EPSILON`, the slop `AABB.clip` works to.
+/// Vanilla's double `1.0E-7` slop used by `AABB.clip`/voxel collision math.
+/// This is intentionally not `Mth.EPSILON`, which is the float `1.0E-5f`.
 const EPSILON: f64 = 1.0e-7;
 
 #[derive(Debug, Clone, Copy)]

--- a/pomme-client/src/physics/movement.rs
+++ b/pomme-client/src/physics/movement.rs
@@ -8,51 +8,63 @@ use winit::keyboard::KeyCode;
 use super::aabb::Aabb;
 use super::collision::{no_collision, resolve_collision};
 use crate::app::input::{self, InputState};
-use crate::player::{CROUCH_HEIGHT, LocalPlayer, STANDING_HEIGHT};
+use crate::player::{CROUCH_HEIGHT, LocalPlayer, PLAYER_HALF_WIDTH, STANDING_HEIGHT};
 use crate::world::chunk::ChunkStore;
 
 const GRAVITY: f64 = 0.08;
-const JUMP_VELOCITY: f64 = 0.42;
+// Vanilla mixes float and double physics values. Keep float values as f32 until
+// the exact point where vanilla widens them into Vec3/AABB doubles.
+const JUMP_VELOCITY: f32 = 0.42;
 const VERTICAL_DRAG: f32 = 0.98;
-const HORIZONTAL_DRAG: f64 = 0.91;
-const BLOCK_FRICTION: f64 = 0.6;
-const GROUND_FRICTION: f64 = BLOCK_FRICTION * HORIZONTAL_DRAG;
-const GROUND_ACCEL_FACTOR: f64 = 0.216;
-const MOVEMENT_SPEED: f64 = 0.1;
-const SPRINT_SPEED_MODIFIER: f64 = 0.3;
-// TODO: SNEAKING_SPEED attribute - 0.3 is the default value
-const SNEAKING_SPEED: f64 = 0.3;
-const INPUT_DAMPING: f64 = 0.98;
-const AIR_ACCELERATION: f64 = 0.02;
-// TODO: WATER_MOVEMENT_EFFICIENCY attribute - scales drag toward 0.546 and
-// accel toward land speed
-const WATER_ACCELERATION: f64 = 0.02;
-const WATER_HORIZONTAL_DRAG: f64 = 0.8;
-const WATER_HORIZONTAL_DRAG_SPRINT: f64 = 0.9;
-const WATER_VERTICAL_DRAG: f64 = 0.8;
+const HORIZONTAL_DRAG: f32 = 0.91;
+const BLOCK_FRICTION: f32 = 0.6;
+const GROUND_FRICTION: f32 = BLOCK_FRICTION * HORIZONTAL_DRAG;
+const GROUND_ACCEL_FACTOR: f32 = 0.216_000_02;
+// Player.createAttributes receives 0.1f; the sprint modifier amount is 0.3f.
+// Both are widened into the double-backed attribute system before
+// Player.getSpeed casts the final value back to float.
+const MOVEMENT_SPEED_ATTRIBUTE: f64 = 0.1_f32 as f64;
+const SPRINT_SPEED_MODIFIER: f64 = 0.3_f32 as f64;
+// SNEAKING_SPEED is a double attribute (default 0.3), then LocalPlayer casts it
+// to float before scaling its Vec2 input.
+const SNEAKING_SPEED: f32 = 0.3_f64 as f32;
+const INPUT_DAMPING: f32 = 0.98;
+const AIR_ACCELERATION: f32 = 0.02;
+// TODO: WATER_MOVEMENT_EFFICIENCY attribute - scales drag toward 0.54600006f
+// and accel toward land speed.
+const WATER_ACCELERATION: f32 = 0.02;
+const WATER_HORIZONTAL_DRAG: f32 = 0.8;
+const WATER_HORIZONTAL_DRAG_SPRINT: f32 = 0.9;
+const WATER_VERTICAL_DRAG: f32 = 0.8;
+// Pomme's water-gravity path is still simplified. Vanilla supplies effective
+// gravity to the water routine as a double; keep this placeholder double too.
 const WATER_GRAVITY: f64 = 0.02;
-const STEP_HEIGHT: f64 = 0.6;
-pub const PLAYER_HALF_WIDTH: f64 = 0.3;
-pub const PLAYER_HEIGHT: f64 = 1.8;
+// STEP_HEIGHT is a double attribute, but LivingEntity.maxUpStep casts it to
+// float.
+const STEP_HEIGHT: f32 = 0.6_f64 as f32;
 const SPRINT_JUMP_BOOST: f64 = 0.2;
 const FLYING_VERTICAL_FRICTION: f64 = 0.6;
-// Vanilla Player.getFlyingSpeed: sprinting while airborne (not flying).
-const SPRINT_AIR_ACCELERATION: f64 = 0.025_999_999_f32 as f64;
+// Vanilla Player.getFlyingSpeed values are floats.
+const SPRINT_AIR_ACCELERATION: f32 = 0.025_999_999;
 const SPRINT_HUNGER_THRESHOLD: u32 = 6;
 const JUMP_DELAY_TICKS: u32 = 10;
 // Vanilla `Entity.getFluidJumpThreshold`; always 0.4 for the player.
 const FLUID_JUMP_THRESHOLD: f64 = 0.4;
-// Vanilla `LivingEntity.jumpInLiquid` adds 0.04f.
-const LIQUID_JUMP_ACCELERATION: f64 = 0.04_f32 as f64;
+// Vanilla `LivingEntity.jumpInLiquid` / `goDownInWater` add/subtract 0.04f.
+const LIQUID_JUMP_ACCELERATION: f32 = 0.04;
 const DEFAULT_SPRINT_WINDOW: u32 = 7;
 const FLY_TOGGLE_WINDOW: u32 = 7;
-const MINOR_COLLISION_ANGLE: f64 = 0.13962634;
+// Mth.equal(double, double) widens the float EPSILON constant to double.
+const MTH_EQUAL_EPSILON: f64 = 1.0e-5_f32 as f64;
+const MINOR_COLLISION_ANGLE: f64 = 0.139_626_339_077_949_52;
+const DEG_TO_RAD: f32 = std::f32::consts::PI / 180.0_f32;
+const SIN_SCALE: f64 = 10_430.378_350_470_453;
 
 pub fn tick(
     player: &mut LocalPlayer,
     input: &InputState,
     chunk_store: &ChunkStore,
-    use_speed_multiplier: f64,
+    use_speed_multiplier: f32,
     slow_due_to_using_item: bool,
 ) {
     let jump_held = input.performing_action(input::Action::Jump);
@@ -66,16 +78,12 @@ pub fn tick(
     update_crouch_state(player, input, chunk_store);
     player.tick_eye_height();
 
-    // Vanilla `LocalPlayer.modifyInput`: an in-use item scales the movement
-    // input by its `UseEffects` speed multiplier (0.2 for food).
-    let (forward, strafe) = movement_input(input, player.crouching);
-    let (forward, strafe) = (
-        forward * use_speed_multiplier,
-        strafe * use_speed_multiplier,
-    );
+    // Vanilla `LocalPlayer.modifyInput` keeps the entire input pipeline in
+    // float: damping, item-use slowdown, sneaking slowdown, then square remap.
+    let (forward, strafe) = movement_input(input, player.crouching, use_speed_multiplier);
     let forward_pressed = input.key_pressed(KeyCode::KeyW)
         || input
-            .get_gamepad_left_analog()
+            .get_gamepad_movement_axes()
             .map(|vec| vec.y > input::STICK_MOVEMENT_THRESHOLD)
             .unwrap_or(false);
 
@@ -87,7 +95,7 @@ pub fn tick(
         slow_due_to_using_item,
     );
 
-    let (sin_y_rot, cos_y_rot) = (player.look_dir.y_rot_rad() as f64).sin_cos();
+    let (sin_y_rot, cos_y_rot) = vanilla_yaw_sin_cos(player.look_dir.y_rot_deg());
 
     update_fly_state(player, input, sin_y_rot, cos_y_rot);
 
@@ -110,7 +118,7 @@ pub fn tick(
     if jump_held {
         let in_water = player.in_water && player.fluid_height > 0.0;
         if in_water && (!player.on_ground || player.fluid_height > FLUID_JUMP_THRESHOLD) {
-            player.velocity.y += LIQUID_JUMP_ACCELERATION;
+            player.velocity.y += f64::from(LIQUID_JUMP_ACCELERATION);
         } else if (player.on_ground || (in_water && player.fluid_height <= FLUID_JUMP_THRESHOLD))
             && player.no_jump_delay == 0
         {
@@ -157,7 +165,7 @@ pub fn tick(
 
 // Vanilla `LocalPlayer.aiStep`: a fresh jump press arms the toggle window;
 // a second one inside it toggles flight.
-fn update_fly_state(player: &mut LocalPlayer, input: &InputState, sin_y_rot: f64, cos_y_rot: f64) {
+fn update_fly_state(player: &mut LocalPlayer, input: &InputState, sin_y_rot: f32, cos_y_rot: f32) {
     if player.may_fly {
         if player.game_mode == 3 {
             // Spectator flight is forced on. TODO: spectator noclip
@@ -184,12 +192,12 @@ fn update_fly_state(player: &mut LocalPlayer, input: &InputState, sin_y_rot: f64
     }
 }
 
-fn jump_from_ground(player: &mut LocalPlayer, sin_y_rot: f64, cos_y_rot: f64) {
-    player.velocity.y = JUMP_VELOCITY.max(player.velocity.y);
+fn jump_from_ground(player: &mut LocalPlayer, sin_y_rot: f32, cos_y_rot: f32) {
+    player.velocity.y = f64::from(JUMP_VELOCITY).max(player.velocity.y);
 
     if player.sprinting {
-        player.velocity.x -= sin_y_rot * SPRINT_JUMP_BOOST;
-        player.velocity.z += cos_y_rot * SPRINT_JUMP_BOOST;
+        player.velocity.x += f64::from(-sin_y_rot) * SPRINT_JUMP_BOOST;
+        player.velocity.z += f64::from(cos_y_rot) * SPRINT_JUMP_BOOST;
     }
 }
 
@@ -197,27 +205,21 @@ fn tick_land(
     player: &mut LocalPlayer,
     input: &InputState,
     chunk_store: &ChunkStore,
-    forward: f64,
-    strafe: f64,
-    sin_y_rot: f64,
-    cos_y_rot: f64,
+    forward: f32,
+    strafe: f32,
+    sin_y_rot: f32,
+    cos_y_rot: f32,
 ) {
     // Vanilla `travelInAir` samples on-ground once before the move and reuses
     // it for the end-of-tick drag, so a jump launches with ground friction.
     let on_ground_at_start = player.on_ground;
 
     let saved_vy = player.velocity.y;
-
-    let speed = if player.sprinting {
-        MOVEMENT_SPEED * (1.0 + SPRINT_SPEED_MODIFIER)
-    } else {
-        MOVEMENT_SPEED
-    };
-
+    let speed = movement_speed(player.sprinting);
     let accel = friction_influenced_speed(speed, player, BLOCK_FRICTION);
-    let (move_x, move_z) = world_movement(forward, strafe, sin_y_rot, cos_y_rot);
-    player.velocity.x += move_x * accel;
-    player.velocity.z += move_z * accel;
+    let (move_x, move_z) = movement_delta(forward, strafe, accel, sin_y_rot, cos_y_rot);
+    player.velocity.x += move_x;
+    player.velocity.z += move_z;
 
     apply_collision(
         player,
@@ -230,15 +232,15 @@ fn tick_land(
     );
 
     player.velocity.y -= GRAVITY;
-    player.velocity.y *= VERTICAL_DRAG as f64;
+    player.velocity.y *= f64::from(VERTICAL_DRAG);
 
     let h_friction = if on_ground_at_start {
         GROUND_FRICTION
     } else {
         HORIZONTAL_DRAG
     };
-    player.velocity.x *= h_friction;
-    player.velocity.z *= h_friction;
+    player.velocity.x *= f64::from(h_friction);
+    player.velocity.z *= f64::from(h_friction);
 
     overwrite_flying_vy(player, saved_vy);
 }
@@ -247,22 +249,22 @@ fn tick_water(
     player: &mut LocalPlayer,
     input: &InputState,
     chunk_store: &ChunkStore,
-    forward: f64,
-    strafe: f64,
-    sin_y_rot: f64,
-    cos_y_rot: f64,
+    forward: f32,
+    strafe: f32,
+    sin_y_rot: f32,
+    cos_y_rot: f32,
 ) {
     if input.performing_action(input::Action::Sneak) {
-        player.velocity.y -= 0.04;
+        player.velocity.y -= f64::from(LIQUID_JUMP_ACCELERATION);
     }
 
-    let (move_x, move_z) = world_movement(forward, strafe, sin_y_rot, cos_y_rot);
-    player.velocity.x += move_x * WATER_ACCELERATION;
-    player.velocity.z += move_z * WATER_ACCELERATION;
+    let (move_x, move_z) =
+        movement_delta(forward, strafe, WATER_ACCELERATION, sin_y_rot, cos_y_rot);
+    player.velocity.x += move_x;
+    player.velocity.z += move_z;
 
     if player.swimming {
-        let sin_x = player.look_dir.x_rot_rad().sin() as f64;
-        let target_vy = -sin_x;
+        let target_vy = vanilla_look_y(player.look_dir.x_rot_deg());
         let boost = if target_vy < -0.2 { 0.085 } else { 0.06 };
         player.velocity.y += (target_vy - player.velocity.y) * boost;
     }
@@ -284,8 +286,8 @@ fn tick_water(
     } else {
         WATER_HORIZONTAL_DRAG
     };
-    player.velocity.x *= h_drag;
-    player.velocity.z *= h_drag;
+    player.velocity.x *= f64::from(h_drag);
+    player.velocity.z *= f64::from(h_drag);
 
     let gravity = if player.velocity.y <= 0.0 && !player.swimming {
         GRAVITY * 0.25
@@ -293,7 +295,7 @@ fn tick_water(
         WATER_GRAVITY
     };
     player.velocity.y -= gravity;
-    player.velocity.y *= WATER_VERTICAL_DRAG;
+    player.velocity.y *= f64::from(WATER_VERTICAL_DRAG);
 
     overwrite_flying_vy(player, saved_vy);
 }
@@ -311,16 +313,12 @@ fn apply_collision(
     player: &mut LocalPlayer,
     input: &InputState,
     chunk_store: &ChunkStore,
-    forward: f64,
-    strafe: f64,
-    sin_y_rot: f64,
-    cos_y_rot: f64,
+    forward: f32,
+    strafe: f32,
+    sin_y_rot: f32,
+    cos_y_rot: f32,
 ) {
-    let aabb = Aabb::from_center(
-        player.position.into(),
-        PLAYER_HALF_WIDTH,
-        player.height() / 2.0,
-    );
+    let aabb = player.bounding_box();
     let delta = back_off_from_edge(
         chunk_store,
         &aabb,
@@ -329,14 +327,20 @@ fn apply_collision(
         player.on_ground,
         player.flying,
     );
-    let step_height = if player.on_ground { STEP_HEIGHT } else { 0.0 };
+    let step_height = if player.on_ground {
+        f64::from(STEP_HEIGHT)
+    } else {
+        0.0
+    };
     let (resolved, on_ground) = resolve_collision(chunk_store, aabb, delta.into(), step_height);
 
-    // Collisions compare against the edge-clamped delta so the clamp itself
-    // never zeroes velocity, letting the player keep creeping along the edge.
-    let collided_x = (resolved.x - delta.x).abs() > 1.0e-5;
-    let collided_y = (resolved.y - delta.y).abs() > 1.0e-5;
-    let collided_z = (resolved.z - delta.z).abs() > 1.0e-5;
+    // Vanilla horizontal collision flags use Mth.equal(double, double), whose
+    // epsilon is the widened float constant 1.0E-5f.
+    let collided_x = !mth_equal(delta.x, resolved.x);
+    // Vanilla only applies Mth.equal to the horizontal axes. Vertical
+    // collision is an exact double comparison.
+    let collided_y = delta.y != resolved.y;
+    let collided_z = !mth_equal(delta.z, resolved.z);
     let horizontal_collision = collided_x || collided_z;
 
     player.position += resolved;
@@ -369,7 +373,7 @@ fn apply_collision(
 fn update_sprint_state(
     player: &mut LocalPlayer,
     input: &InputState,
-    forward: f64,
+    forward: f32,
     forward_pressed: bool,
     slow_due_to_using_item: bool,
 ) {
@@ -439,7 +443,8 @@ fn back_off_from_edge(
     }
     // TODO: fall distance - falling less than the step height still counts
     // as above ground
-    let above_ground = on_ground || !can_fall_at_least(chunk_store, bb, 0.0, 0.0, STEP_HEIGHT);
+    let above_ground =
+        on_ground || !can_fall_at_least(chunk_store, bb, 0.0, 0.0, f64::from(STEP_HEIGHT));
     if !above_ground {
         return delta;
     }
@@ -449,21 +454,24 @@ fn back_off_from_edge(
     let step_x = dx.signum() * 0.05;
     let step_z = dz.signum() * 0.05;
 
-    while dx != 0.0 && can_fall_at_least(chunk_store, bb, dx, 0.0, STEP_HEIGHT) {
+    while dx != 0.0 && can_fall_at_least(chunk_store, bb, dx, 0.0, f64::from(STEP_HEIGHT)) {
         if dx.abs() <= 0.05 {
             dx = 0.0;
             break;
         }
         dx -= step_x;
     }
-    while dz != 0.0 && can_fall_at_least(chunk_store, bb, 0.0, dz, STEP_HEIGHT) {
+    while dz != 0.0 && can_fall_at_least(chunk_store, bb, 0.0, dz, f64::from(STEP_HEIGHT)) {
         if dz.abs() <= 0.05 {
             dz = 0.0;
             break;
         }
         dz -= step_z;
     }
-    while dx != 0.0 && dz != 0.0 && can_fall_at_least(chunk_store, bb, dx, dz, STEP_HEIGHT) {
+    while dx != 0.0
+        && dz != 0.0
+        && can_fall_at_least(chunk_store, bb, dx, dz, f64::from(STEP_HEIGHT))
+    {
         dx = if dx.abs() <= 0.05 { 0.0 } else { dx - step_x };
         if dz.abs() <= 0.05 {
             dz = 0.0;
@@ -495,27 +503,66 @@ fn can_fall_at_least(
     )
 }
 
-fn world_movement(forward: f64, strafe: f64, sin_y_rot: f64, cos_y_rot: f64) -> (f64, f64) {
-    (
-        forward * -sin_y_rot + strafe * -cos_y_rot,
-        forward * cos_y_rot + strafe * -sin_y_rot,
-    )
+fn movement_speed(sprinting: bool) -> f32 {
+    let mut speed = MOVEMENT_SPEED_ATTRIBUTE;
+    if sprinting {
+        speed *= 1.0 + SPRINT_SPEED_MODIFIER;
+    }
+    speed as f32
 }
 
-fn friction_influenced_speed(speed: f64, player: &LocalPlayer, block_friction: f64) -> f64 {
+fn movement_delta(
+    forward: f32,
+    strafe: f32,
+    speed: f32,
+    sin_y_rot: f32,
+    cos_y_rot: f32,
+) -> (f64, f64) {
+    // Vanilla constructs Vec3 from the float xxa/zza fields, then performs the
+    // normalization and speed scaling in double precision.
+    let mut x = f64::from(strafe);
+    let mut z = f64::from(forward);
+    let length_sq = x * x + z * z;
+    if length_sq < 1.0e-7 {
+        return (0.0, 0.0);
+    }
+    if length_sq > 1.0 {
+        let inv_len = length_sq.sqrt().recip();
+        x *= inv_len;
+        z *= inv_len;
+    }
+    let speed = f64::from(speed);
+    x *= speed;
+    z *= speed;
+
+    let sin = f64::from(sin_y_rot);
+    let cos = f64::from(cos_y_rot);
+    (x * cos - z * sin, z * cos + x * sin)
+}
+
+fn world_input_direction(forward: f32, strafe: f32, sin_y_rot: f32, cos_y_rot: f32) -> (f64, f64) {
+    let forward = f64::from(forward);
+    let strafe = f64::from(strafe);
+    let sin = f64::from(sin_y_rot);
+    let cos = f64::from(cos_y_rot);
+    (strafe * cos - forward * sin, forward * cos + strafe * sin)
+}
+
+fn friction_influenced_speed(speed: f32, player: &LocalPlayer, block_friction: f32) -> f32 {
     if player.on_ground {
-        if block_friction > BLOCK_FRICTION {
-            speed * (GROUND_ACCEL_FACTOR / block_friction.powi(3))
+        // Vanilla deliberately compares the widened float friction against the
+        // double literal 0.6. Normal-block 0.6f therefore enters this branch.
+        if f64::from(block_friction) > 0.6 {
+            speed * (GROUND_ACCEL_FACTOR / (block_friction * block_friction * block_friction))
         } else {
             speed
         }
     } else if player.flying {
         // Vanilla Player.getFlyingSpeed.
-        let fly_speed = f64::from(player.fly_speed);
         if player.sprinting {
-            fly_speed * 2.0
+            player.fly_speed * 2.0_f32
         } else {
-            fly_speed
+            player.fly_speed
         }
     } else if player.sprinting {
         SPRINT_AIR_ACCELERATION
@@ -525,16 +572,16 @@ fn friction_influenced_speed(speed: f64, player: &LocalPlayer, block_friction: f
 }
 
 fn is_minor_horizontal_collision(
-    forward: f64,
-    strafe: f64,
-    sin_y_rot: f64,
-    cos_y_rot: f64,
+    forward: f32,
+    strafe: f32,
+    sin_y_rot: f32,
+    cos_y_rot: f32,
     resolved: DVec3,
 ) -> bool {
-    let (intent_x, intent_z) = world_movement(forward, strafe, sin_y_rot, cos_y_rot);
+    let (intent_x, intent_z) = world_input_direction(forward, strafe, sin_y_rot, cos_y_rot);
     let intent_len_sq = intent_x * intent_x + intent_z * intent_z;
-    let resolved_len_sq = resolved.x.powi(2) + resolved.z.powi(2);
-    if intent_len_sq < 1.0e-5 || resolved_len_sq < 1.0e-5 {
+    let resolved_len_sq = resolved.x * resolved.x + resolved.z * resolved.z;
+    if intent_len_sq < f64::from(1.0e-5_f32) || resolved_len_sq < f64::from(1.0e-5_f32) {
         return false;
     }
     let dot = intent_x * resolved.x + intent_z * resolved.z;
@@ -542,14 +589,16 @@ fn is_minor_horizontal_collision(
     angle < MINOR_COLLISION_ANGLE
 }
 
-fn movement_input(input: &InputState, crouching: bool) -> (f64, f64) {
-    let mut forward = 0.0f64;
-    let mut strafe = 0.0f64;
-
-    if let Some(analog_input) = input.get_gamepad_left_analog() {
-        forward = analog_input.y as f64;
-        strafe = analog_input.x as f64;
+fn movement_input(input: &InputState, crouching: bool, use_speed_multiplier: f32) -> (f32, f32) {
+    // Keep the LocalPlayer input pipeline in float exactly like vanilla. Pomme's
+    // analog stick is already clamped to unit length; keyboard input is first
+    // normalized just like KeyboardInput.tick(). `strafe` follows vanilla xxa:
+    // positive is left, negative is right.
+    let (mut strafe, mut forward) = if let Some(analog) = input.get_gamepad_movement_axes() {
+        (analog.x, analog.y)
     } else {
+        let mut forward = 0.0_f32;
+        let mut strafe = 0.0_f32;
         if input.key_pressed(KeyCode::KeyW) {
             forward += 1.0;
         }
@@ -557,33 +606,205 @@ fn movement_input(input: &InputState, crouching: bool) -> (f64, f64) {
             forward -= 1.0;
         }
         if input.key_pressed(KeyCode::KeyA) {
-            strafe -= 1.0;
-        }
-        if input.key_pressed(KeyCode::KeyD) {
             strafe += 1.0;
         }
+        if input.key_pressed(KeyCode::KeyD) {
+            strafe -= 1.0;
+        }
+        normalize_vec2(strafe, forward)
+    };
+
+    if strafe == 0.0 && forward == 0.0 {
+        return (forward, strafe);
     }
 
-    forward *= INPUT_DAMPING;
     strafe *= INPUT_DAMPING;
+    forward *= INPUT_DAMPING;
+    strafe *= use_speed_multiplier;
+    forward *= use_speed_multiplier;
 
     if crouching {
-        forward *= SNEAKING_SPEED;
         strafe *= SNEAKING_SPEED;
+        forward *= SNEAKING_SPEED;
     }
 
-    square_movement(forward, strafe)
+    let (strafe, forward) = square_movement(strafe, forward);
+    (forward, strafe)
 }
 
-// Assumes cardinal keyboard input (-1/0/+1 axes); analog input would need a
-// normalize first.
-fn square_movement(forward: f64, strafe: f64) -> (f64, f64) {
-    let len = (forward * forward + strafe * strafe).sqrt();
-    if len < 1.0e-7 {
+fn normalize_vec2(x: f32, y: f32) -> (f32, f32) {
+    let length = mth_sqrt(x * x + y * y);
+    if length < 1.0e-4_f32 {
         return (0.0, 0.0);
     }
-    let max_axis = forward.abs().max(strafe.abs());
-    let modified = (len * len / max_axis).min(1.0);
-    let scale = modified / len;
-    (forward * scale, strafe * scale)
+    (x / length, y / length)
+}
+
+fn square_movement(x: f32, y: f32) -> (f32, f32) {
+    let length = mth_sqrt(x * x + y * y);
+    if length <= 0.0 {
+        return (x, y);
+    }
+    let inv_len = 1.0_f32 / length;
+    let dir_x = x * inv_len;
+    let dir_y = y * inv_len;
+    let abs_x = dir_x.abs();
+    let abs_y = dir_y.abs();
+    let tan = if abs_y > abs_x {
+        abs_x / abs_y
+    } else {
+        abs_y / abs_x
+    };
+    let distance_to_square = mth_sqrt(1.0_f32 + tan * tan);
+    let modified_length = (length * distance_to_square).min(1.0_f32);
+    (dir_x * modified_length, dir_y * modified_length)
+}
+
+fn mth_equal(a: f64, b: f64) -> bool {
+    (b - a).abs() < MTH_EQUAL_EPSILON
+}
+
+fn mth_sqrt(value: f32) -> f32 {
+    f64::from(value).sqrt() as f32
+}
+
+fn mth_sin(angle: f32) -> f32 {
+    let index = ((f64::from(angle) * SIN_SCALE) as i64 & 0xFFFF) as usize;
+    azalea_core::math::SIN[index]
+}
+
+fn mth_cos(angle: f32) -> f32 {
+    let index = ((f64::from(angle) * SIN_SCALE + 16_384.0) as i64 & 0xFFFF) as usize;
+    azalea_core::math::SIN[index]
+}
+
+fn vanilla_yaw_sin_cos(yaw_degrees: f32) -> (f32, f32) {
+    let angle = yaw_degrees * DEG_TO_RAD;
+    (mth_sin(angle), mth_cos(angle))
+}
+
+fn vanilla_look_y(pitch_degrees: f32) -> f64 {
+    let angle = pitch_degrees * DEG_TO_RAD;
+    -f64::from(mth_sin(angle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::player::{CROUCH_EYE_HEIGHT, STANDING_EYE_HEIGHT};
+
+    #[test]
+    fn player_width_stops_at_negative_two_block_face() {
+        let block = Aabb::block(0, 0, -2);
+        let player = Aabb::from_center(
+            dvec3(0.5, 0.0, block.min.z - PLAYER_HALF_WIDTH),
+            PLAYER_HALF_WIDTH,
+            STANDING_HEIGHT / 2.0,
+        );
+
+        assert_eq!(player.max.z, block.min.z);
+        assert_eq!(block.clip_z_collide(&player, 0.1), 0.0);
+    }
+
+    #[test]
+    fn float_derived_width_reconstructs_problem_block_faces_exactly() {
+        // These are the sparse integer boundaries where the old direct f64
+        // literal `0.3` could reconstruct one ULP inside the block face.
+        for block_coord in [-2, -32, -512, -8192, -131_072, -2_097_152] {
+            let face = f64::from(block_coord);
+            assert_eq!((face - PLAYER_HALF_WIDTH) + PLAYER_HALF_WIDTH, face);
+        }
+        for block_coord in [2, 32, 512, 8192, 131_072, 2_097_152] {
+            let face = f64::from(block_coord);
+            assert_eq!((face + PLAYER_HALF_WIDTH) - PLAYER_HALF_WIDTH, face);
+        }
+    }
+
+    #[test]
+    fn player_dimensions_match_vanilla_float_widening() {
+        assert_eq!(PLAYER_HALF_WIDTH.to_bits(), 0x3fd3333340000000);
+        assert_eq!(STANDING_HEIGHT.to_bits(), 0x3ffcccccc0000000);
+        assert_eq!(CROUCH_HEIGHT.to_bits(), 1.5_f64.to_bits());
+        assert_eq!(STANDING_EYE_HEIGHT.to_bits(), 0x3fcf5c29);
+        assert_eq!(CROUCH_EYE_HEIGHT.to_bits(), 0x3fa28f5c);
+    }
+
+    #[test]
+    fn movement_constants_match_vanilla_value_types() {
+        assert_eq!(JUMP_VELOCITY.to_bits(), 0x3ed70a3d);
+        assert_eq!(HORIZONTAL_DRAG.to_bits(), 0x3f68f5c3);
+        assert_eq!(BLOCK_FRICTION.to_bits(), 0x3f19999a);
+        assert_eq!(GROUND_FRICTION.to_bits(), 0x3f0bc6a9);
+        assert_eq!(GROUND_ACCEL_FACTOR.to_bits(), 0x3e5d2f1c);
+        assert_eq!(WATER_GRAVITY.to_bits(), 0x3f947ae147ae147b);
+        assert_eq!(MTH_EQUAL_EPSILON.to_bits(), 0x3ee4f8b580000000);
+        assert_eq!(MINOR_COLLISION_ANGLE.to_bits(), 0x3fc1df46a0000000);
+    }
+
+    #[test]
+    fn movement_speed_matches_vanilla_attribute_rounding() {
+        assert_eq!(movement_speed(false).to_bits(), 0x3dcccccd);
+        assert_eq!(movement_speed(true).to_bits(), 0x3e051eb9);
+
+        let mut player = LocalPlayer::new();
+        player.on_ground = true;
+        assert_eq!(
+            friction_influenced_speed(movement_speed(false), &player, BLOCK_FRICTION).to_bits(),
+            0x3dcccccd
+        );
+        assert_eq!(
+            friction_influenced_speed(movement_speed(true), &player, BLOCK_FRICTION).to_bits(),
+            0x3e051eb9
+        );
+    }
+
+    #[test]
+    fn keyboard_input_math_matches_vanilla_float_pipeline() {
+        let (left, forward) = normalize_vec2(1.0, 1.0);
+        let (left, forward) = square_movement(left * INPUT_DAMPING, forward * INPUT_DAMPING);
+        assert_eq!(left.to_bits(), 0x3f3504f2);
+        assert_eq!(forward.to_bits(), 0x3f3504f2);
+
+        let (left, forward) = normalize_vec2(0.0, 1.0);
+        let (left, forward) = square_movement(left * INPUT_DAMPING, forward * INPUT_DAMPING);
+        assert_eq!(left.to_bits(), 0x00000000);
+        assert_eq!(forward.to_bits(), 0x3f7ae148);
+    }
+
+    #[test]
+    fn gamepad_horizontal_axis_matches_vanilla_strafe_sign() {
+        let analog = input::gamepad_movement_axes(glam::vec2(-1.0, 0.0));
+        assert_eq!(analog, glam::vec2(1.0, 0.0));
+        let (sin, cos) = vanilla_yaw_sin_cos(0.0);
+        let (dx, dz) = movement_delta(analog.y, analog.x, 1.0, sin, cos);
+        assert_eq!((dx, dz), (1.0, 0.0));
+
+        let analog = input::gamepad_movement_axes(glam::vec2(1.0, 0.0));
+        assert_eq!(analog, glam::vec2(-1.0, 0.0));
+        let (dx, dz) = movement_delta(analog.y, analog.x, 1.0, sin, cos);
+        assert_eq!((dx, dz), (-1.0, 0.0));
+
+        assert_eq!(
+            input::gamepad_movement_axes(glam::vec2(-0.6, 0.8)),
+            glam::vec2(0.6, 0.8)
+        );
+    }
+
+    #[test]
+    fn vanilla_mth_trig_and_movement_rotation_match_java_bits() {
+        let (sin, cos) = vanilla_yaw_sin_cos(30.0);
+        assert_eq!(sin.to_bits(), 0x3efffc5f);
+        assert_eq!(cos.to_bits(), 0x3f5db4e3);
+
+        let (sin, cos) = vanilla_yaw_sin_cos(45.0);
+        assert_eq!(sin.to_bits(), 0x3f3504f3);
+        assert_eq!(cos.to_bits(), 0x3f3504f3);
+
+        let forward = f32::from_bits(0x3f3504f2);
+        let (dx, dz) = movement_delta(forward, 0.0, movement_speed(false), sin, cos);
+        assert_eq!(dx.to_bits(), 0xbfa999996d18578d);
+        assert_eq!(dz.to_bits(), 0x3fa999996d18578d);
+
+        assert_eq!(vanilla_look_y(30.0).to_bits(), 0xbfdfff8be0000000);
+    }
 }

--- a/pomme-client/src/player/interaction.rs
+++ b/pomme-client/src/player/interaction.rs
@@ -29,7 +29,6 @@ use crate::net::sender::PacketSender;
 use crate::particle::ParticleStore;
 use crate::physics::aabb::{self, Aabb, Axis, Face};
 use crate::physics::block_shape::{self, LocalBox};
-use crate::physics::movement::{PLAYER_HALF_WIDTH, PLAYER_HEIGHT};
 use crate::player::inventory::item_resource_name;
 use crate::renderer::pipelines::held_item::UseAnim;
 use crate::world::block::registry::BlockRegistry;
@@ -43,6 +42,7 @@ const CREATIVE_ENTITY_REACH_BONUS: f64 = 2.0;
 const DESTROY_COOLDOWN: u32 = 5;
 const MISS_COOLDOWN: u32 = 10;
 const USE_DELAY: u32 = 4;
+
 const SWING_DURATION: i32 = 6;
 /// Vanilla `Consumable`: no bite effects during the first ~22% of the use,
 /// then a burst every 4 ticks.
@@ -229,11 +229,10 @@ impl InteractionState {
         &mut self,
         seq: u32,
         chunks: &ChunkStore,
-        player_pos: DVec3,
+        player: Aabb,
         dirty_chunks: &mut Vec<BlockPos>,
     ) -> Option<DVec3> {
         let snap_allowed = self.last_teleport_seq < seq;
-        let player = Aabb::from_center(player_pos, PLAYER_HALF_WIDTH, PLAYER_HEIGHT / 2.0);
         // Keep the lowest block pos among overlapping reverts so the chosen snap
         // is deterministic (HashMap iteration order is not).
         let mut snap_to: Option<((i32, i32, i32), DVec3)> = None;
@@ -349,6 +348,7 @@ impl InteractionState {
         sender: &PacketSender,
         audio: &AudioEngine,
         player_pos: DVec3,
+        player_aabb: Aabb,
         eye_pos: DVec3,
         look: LookDirection,
         on_ground: bool,
@@ -438,6 +438,7 @@ impl InteractionState {
                 audio,
                 chunks,
                 player_pos,
+                player_aabb,
                 eye_pos,
                 look,
                 place_block,
@@ -626,6 +627,7 @@ impl InteractionState {
         audio: &AudioEngine,
         chunks: &ChunkStore,
         player_pos: DVec3,
+        player_aabb: Aabb,
         eye_pos: DVec3,
         look: LookDirection,
         place_block: Option<BlockState>,
@@ -685,7 +687,14 @@ impl InteractionState {
             }
             if place_block.is_some() {
                 self.swing(sender);
-                self.predict_place(hit, place_block, chunks, player_pos, dirty_chunks);
+                self.predict_place(
+                    hit,
+                    place_block,
+                    chunks,
+                    player_pos,
+                    player_aabb,
+                    dirty_chunks,
+                );
                 return true;
             }
             true
@@ -851,10 +860,10 @@ impl InteractionState {
 
     /// Vanilla `LocalPlayer.itemUseSpeedMultiplier`: the in-use item's
     /// `UseEffects` movement-input scale (1.0 when nothing is in use).
-    pub fn use_speed_multiplier(&self) -> f64 {
+    pub fn use_speed_multiplier(&self) -> f32 {
         self.using_item
             .as_ref()
-            .map_or(1.0, |a| a.use_effects.speed_multiplier as f64)
+            .map_or(1.0, |a| a.use_effects.speed_multiplier)
     }
 
     /// Vanilla `LocalPlayer.isSlowDueToUsingItem`, which gates sprinting.
@@ -891,6 +900,7 @@ impl InteractionState {
         place_block: Option<BlockState>,
         chunks: &ChunkStore,
         player_pos: DVec3,
+        player_aabb: Aabb,
         dirty_chunks: &mut Vec<BlockPos>,
     ) {
         let Some(state) = place_block else {
@@ -904,11 +914,8 @@ impl InteractionState {
         }
 
         // Don't predict a solid block overlapping the player; the server denies it.
-        if has_collision(state) {
-            let player = Aabb::from_center(player_pos, PLAYER_HALF_WIDTH, PLAYER_HEIGHT / 2.0);
-            if Aabb::block(pos.x, pos.y, pos.z).intersects(&player) {
-                return;
-            }
+        if has_collision(state) && Aabb::block(pos.x, pos.y, pos.z).intersects(&player_aabb) {
+            return;
         }
 
         self.retain_known_server_state(pos, BlockState::AIR, player_pos);

--- a/pomme-client/src/player/mod.rs
+++ b/pomme-client/src/player/mod.rs
@@ -8,13 +8,19 @@ use inventory::Inventory;
 
 use crate::entity::HURT_DURATION;
 use crate::entity::components::{LookDirection, Position, Velocity};
+use crate::physics::aabb::Aabb;
 use crate::world::block::{FluidKind, fluid};
 
 pub const MAX_AIR_SUPPLY: i32 = 300;
-pub const STANDING_HEIGHT: f64 = 1.8;
-pub const CROUCH_HEIGHT: f64 = 1.5;
-pub const STANDING_EYE_HEIGHT: f64 = 1.62;
-pub const CROUCH_EYE_HEIGHT: f64 = 1.27;
+// Vanilla stores player dimensions/eye heights as floats and only widens them
+// when combining them with double-precision positions and AABBs.
+pub const PLAYER_HALF_WIDTH: f64 = (0.6_f32 / 2.0_f32) as f64;
+pub const STANDING_HEIGHT: f64 = 1.8_f32 as f64;
+pub const CROUCH_HEIGHT: f64 = 1.5_f32 as f64;
+pub const STANDING_EYE_HEIGHT: f32 = 1.62;
+pub const CROUCH_EYE_HEIGHT: f32 = 1.27;
+// Entity.checkInsideBlocks passes the float literal through AABB's double API.
+const INSIDE_BLOCK_MARGIN: f64 = 1.0e-5_f32 as f64;
 const DROWN_DAMAGE_THRESHOLD: i32 = -20;
 const DROWN_DAMAGE: f32 = 2.0;
 const AIR_RECOVERY_RATE: i32 = 4;
@@ -75,8 +81,8 @@ pub struct LocalPlayer {
     /// Vanilla `onUpdateAbilities`: a locally toggled `flying` still has to be
     /// reported to the server via `ServerboundPlayerAbilities`.
     pub abilities_dirty: bool,
-    pub eye_height: f64,
-    pub prev_eye_height: f64,
+    pub eye_height: f32,
+    pub prev_eye_height: f32,
     pub walk_dist: f32,
     pub prev_walk_dist: f32,
     pub bob: f32,
@@ -203,7 +209,11 @@ impl LocalPlayer {
         }
     }
 
-    pub fn target_eye_height(&self) -> f64 {
+    pub fn bounding_box(&self) -> Aabb {
+        Aabb::from_center(self.position.into(), PLAYER_HALF_WIDTH, self.height() / 2.0)
+    }
+
+    pub fn target_eye_height(&self) -> f32 {
         if self.crouching {
             CROUCH_EYE_HEIGHT
         } else {
@@ -234,11 +244,11 @@ impl LocalPlayer {
     }
 
     pub fn prev_eye_pos(&self) -> Position {
-        self.prev_position + dvec3(0.0, self.prev_eye_height, 0.0)
+        self.prev_position + dvec3(0.0, f64::from(self.prev_eye_height), 0.0)
     }
 
     pub fn eye_pos(&self) -> Position {
-        self.position + dvec3(0.0, self.eye_height, 0.0)
+        self.position + dvec3(0.0, f64::from(self.eye_height), 0.0)
     }
 
     // TODO: OXYGEN_BONUS attribute - chance to skip air loss per tick
@@ -255,9 +265,9 @@ impl LocalPlayer {
     }
 
     pub fn update_water_state(&mut self, chunks: &crate::world::chunk::ChunkStore) {
-        let half_w = 0.3;
+        let half_w = PLAYER_HALF_WIDTH;
         let height = self.height();
-        let eye_height = self.target_eye_height();
+        let eye_height = f64::from(self.target_eye_height());
 
         // Vanilla `EntityFluidInteraction.update`: scan the bounding box
         // deflated by 0.001; a block's fluid column is `amount / 9` of a
@@ -305,16 +315,16 @@ impl LocalPlayer {
     }
 
     /// Vanilla Entity.checkInsideBlocks: a nether portal counts as entered when
-    /// the bounding box deflated by 1.0E-5 overlaps its (full) block cell.
+    /// the bounding box deflated by the widened float `1.0E-5f` overlaps its
+    /// (full) block cell.
     pub fn is_inside_nether_portal(&self, chunks: &crate::world::chunk::ChunkStore) -> bool {
-        const MARGIN: f64 = 1.0e-5;
-        let half_w = 0.3;
-        let x0 = (self.position.x - half_w + MARGIN).floor() as i32;
-        let x1 = (self.position.x + half_w - MARGIN).ceil() as i32 - 1;
-        let y0 = (self.position.y + MARGIN).floor() as i32;
-        let y1 = (self.position.y + self.height() - MARGIN).ceil() as i32 - 1;
-        let z0 = (self.position.z - half_w + MARGIN).floor() as i32;
-        let z1 = (self.position.z + half_w - MARGIN).ceil() as i32 - 1;
+        let half_w = PLAYER_HALF_WIDTH;
+        let x0 = (self.position.x - half_w + INSIDE_BLOCK_MARGIN).floor() as i32;
+        let x1 = (self.position.x + half_w - INSIDE_BLOCK_MARGIN).ceil() as i32 - 1;
+        let y0 = (self.position.y + INSIDE_BLOCK_MARGIN).floor() as i32;
+        let y1 = (self.position.y + self.height() - INSIDE_BLOCK_MARGIN).ceil() as i32 - 1;
+        let z0 = (self.position.z - half_w + INSIDE_BLOCK_MARGIN).floor() as i32;
+        let z1 = (self.position.z + half_w - INSIDE_BLOCK_MARGIN).ceil() as i32 - 1;
 
         for bx in x0..=x1 {
             for by in y0..=y1 {
@@ -377,6 +387,20 @@ impl LocalPlayer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bounding_box_tracks_current_crouching_pose() {
+        let mut player = LocalPlayer::new();
+        player.position = Position::new(0.5, 0.0, 0.5);
+        let ceiling = Aabb::new(dvec3(0.0, 1.6, 0.0), dvec3(1.0, 2.0, 1.0));
+
+        player.crouching = false;
+        assert!(player.bounding_box().intersects(&ceiling));
+
+        player.crouching = true;
+        assert!(!player.bounding_box().intersects(&ceiling));
+        assert_eq!(player.bounding_box().max.y, CROUCH_HEIGHT);
+    }
 
     #[test]
     fn hurt_state_matches_vanilla_duration_direction_and_expiry() {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling
- [ ] Documentation

## Summary

- Match vanilla 26.2 float/double conversion boundaries in implemented local-player movement and collision, fixing negative-coordinate block-face penetration caused by direct `f64` player dimensions.
- Keep controller movement/server input direction and current-pose interaction collision boxes on shared production paths so they cannot drift from local physics.

## Reference

`EntityDimensions`, `Entity`, `LivingEntity`, `Player`, `LocalPlayer`, `ClientInput`, `KeyboardInput`, `Mth`, and `ClientLevel` under `reference/26.2/decompiled/net/minecraft`.

## Testing

- `just client-pre-pr` — 39 protocol tests and 276 client tests passed.
- Manual Z=-2 repro and general movement/water/flight sanity passed; controller hardware is unavailable, so controller direction is covered by gilrs source tracing, production-path regressions, and independent audits.

Closes #563 